### PR TITLE
feat/UDT-19-회원가입

### DIFF
--- a/src/main/java/com/example/udtbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/udtbe/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.example.udtbe.domain.auth.controller;
 
+import com.example.udtbe.domain.auth.dto.request.TempAuthRequest;
 import com.example.udtbe.domain.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,6 +23,18 @@ public class AuthController implements AuthControllerApiSpec {
     @Override
     public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
         authService.reissue(request, response);
-        return null;
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> tempSignUp(TempAuthRequest request) {
+        authService.tempSignUp(request);
+        return ResponseEntity.status(201).build();
+    }
+
+    @Override
+    public ResponseEntity<Void> tempSignIn(TempAuthRequest request, HttpServletResponse response) {
+        authService.tempSignIn(request, response);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/udtbe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/udtbe/domain/auth/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.example.udtbe.domain.auth.controller;
 
 import com.example.udtbe.domain.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,4 +12,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthControllerApiSpec {
 
     private final AuthService authService;
+
+    @Override
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        authService.logout(request, response);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+        authService.reissue(request, response);
+        return null;
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/auth/controller/AuthControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/auth/controller/AuthControllerApiSpec.java
@@ -1,8 +1,23 @@
 package com.example.udtbe.domain.auth.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "Auth API", description = "인증/인가 관련 API")
 public interface AuthControllerApiSpec {
 
+    @Operation(summary = "로그아웃 API", description = "로그아웃한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/api/auth/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response);
+
+    @Operation(summary = "토큰 재발급 API", description = "토큰을 재발급한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/api/auth/reissue/token")
+    public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/com/example/udtbe/domain/auth/controller/AuthControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/auth/controller/AuthControllerApiSpec.java
@@ -1,12 +1,15 @@
 package com.example.udtbe.domain.auth.controller;
 
+import com.example.udtbe.domain.auth.dto.request.TempAuthRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Auth API", description = "인증/인가 관련 API")
 public interface AuthControllerApiSpec {
@@ -20,4 +23,16 @@ public interface AuthControllerApiSpec {
     @ApiResponse(useReturnTypeSchema = true)
     @PostMapping("/api/auth/reissue/token")
     public ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response);
+
+    @Operation(summary = "임시 회원가입(토큰 발급) API", description = "임시 회원가입 후 토큰을 발급한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/api/auth/temp-signup")
+    public ResponseEntity<Void> tempSignUp(@RequestBody @Valid TempAuthRequest request);
+
+    @Operation(summary = "임시 로그인(토큰 발급) API", description = "임시 로그인 후 토큰을 발급한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/api/auth/temp-signin")
+    public ResponseEntity<Void> tempSignIn(
+            @RequestBody @Valid TempAuthRequest request,
+            HttpServletResponse response);
 }

--- a/src/main/java/com/example/udtbe/domain/auth/dto/request/TempAuthRequest.java
+++ b/src/main/java/com/example/udtbe/domain/auth/dto/request/TempAuthRequest.java
@@ -1,0 +1,10 @@
+package com.example.udtbe.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+
+public record TempAuthRequest(
+        @Email
+        String email
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/auth/exception/AuthErrorCode.java
@@ -9,6 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
+    UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다."),
+    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그아웃에 실패했습니다."),
+    FAIL_REISSUE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 재발급에 실패했습니다."),
+    MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AT가 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/udtbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/auth/exception/AuthErrorCode.java
@@ -13,6 +13,7 @@ public enum AuthErrorCode implements ErrorCode {
     LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "로그아웃에 실패했습니다."),
     FAIL_REISSUE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 재발급에 실패했습니다."),
     MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AT가 존재하지 않습니다."),
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/udtbe/domain/auth/service/AuthQuery.java
+++ b/src/main/java/com/example/udtbe/domain/auth/service/AuthQuery.java
@@ -36,4 +36,7 @@ public class AuthQuery {
         memberRepository.deleteAll();
     }
 
+    public boolean existsByEmail(String email) {
+        return memberRepository.existsByEmail(email);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/auth/service/AuthQuery.java
+++ b/src/main/java/com/example/udtbe/domain/auth/service/AuthQuery.java
@@ -31,4 +31,9 @@ public class AuthQuery {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
+
+    public void deleteAll() {
+        memberRepository.deleteAll();
+    }
+
 }

--- a/src/main/java/com/example/udtbe/domain/auth/service/AuthQuery.java
+++ b/src/main/java/com/example/udtbe/domain/auth/service/AuthQuery.java
@@ -1,6 +1,10 @@
 package com.example.udtbe.domain.auth.service;
 
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.exception.MemberErrorCode;
 import com.example.udtbe.domain.member.repository.MemberRepository;
+import com.example.udtbe.global.exception.RestApiException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -9,4 +13,22 @@ import org.springframework.stereotype.Component;
 public class AuthQuery {
 
     private final MemberRepository memberRepository;
+
+    public Optional<Member> getOptionalMemberByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public Member save(Member member) {
+        return memberRepository.save(member);
+    }
+
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/udtbe/domain/auth/service/AuthService.java
@@ -1,22 +1,41 @@
 package com.example.udtbe.domain.auth.service;
 
+import com.example.udtbe.domain.auth.exception.AuthErrorCode;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.entity.enums.Gender;
 import com.example.udtbe.domain.member.entity.enums.Role;
+import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.security.dto.AuthInfo;
+import com.example.udtbe.global.security.dto.CustomOauth2User;
 import com.example.udtbe.global.security.dto.Oauth2Response;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import com.example.udtbe.global.token.service.TokenProvider;
 import com.example.udtbe.global.token.service.TokenStore;
+import com.example.udtbe.global.util.RedisUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
+    private static final String DELETE = "delete";
+    private static final String REFRESH_TOKEN_PREFIX = "RT:";
     private final AuthQuery authQuery;
     @Qualifier("redisTokenStore")
     private final TokenStore tokenStore;
+    private final TokenProvider tokenProvider;
+    private final CookieUtil cookieUtil;
+    private final RedisUtil redisUtil;
 
     public Member saveOrUpdate(Oauth2Response oauth2Response) {
         Member member = authQuery.getOptionalMemberByEmail(oauth2Response.getEmail())
@@ -34,5 +53,92 @@ public class AuthService {
     private Member createMemberFromOauth2Response(Oauth2Response oauth2Response) {
         return Member.of(oauth2Response.getEmail(), oauth2Response.getName(), Role.ROLE_GUEST,
                 oauth2Response.getProfileImageUrl(), Gender.MAN, LocalDateTime.now(), false);
+    }
+
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = cookieUtil.getCookieValue(request);
+
+        if (!tokenProvider.validateToken(accessToken, new Date())) {
+            throw new RestApiException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+        }
+
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        Member member = (Member) authentication.getPrincipal();
+
+        deleteRefreshTokenIfExists(member.getEmail());
+        addToBlacklist(accessToken);
+        cookieUtil.deleteCookie(response);
+    }
+
+    private void deleteRefreshTokenIfExists(String email) {
+        String refreshKey = getRefreshTokenPrefix(email);
+        String value = redisUtil.getValues(refreshKey);
+        if (StringUtils.hasText(value)) {
+            redisUtil.deleteValues(refreshKey);
+        }
+    }
+
+    private void addToBlacklist(String accessToken) {
+        Long expiration = tokenProvider.getExpiration(accessToken, new Date());
+        redisUtil.setValues(accessToken, DELETE, Duration.ofMillis(expiration));
+
+        if (!DELETE.equals(redisUtil.getValues(accessToken))) {
+            throw new RestApiException(AuthErrorCode.LOGOUT_FAILED);
+        }
+    }
+
+    public void reissue(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = cookieUtil.getCookieValue(request);
+
+        if (Objects.isNull(accessToken)) {
+            throw new RestApiException(AuthErrorCode.MISSING_ACCESS_TOKEN);
+        }
+
+        validateReissueAbleAccessToken(accessToken);
+
+        Member findMember = tokenProvider.getMemberAllowExpired(accessToken);
+        String refreshKey = getRefreshTokenPrefix(findMember.getEmail());
+
+        validateRefreshToken(refreshKey);
+        redisUtil.deleteValues(refreshKey);
+        reissueTokens(response, findMember);
+    }
+
+    private void validateReissueAbleAccessToken(String accessToken) {
+        if ("logout".equals(redisUtil.getValues(accessToken))) {
+            throw new RestApiException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+        }
+    }
+
+    private void validateRefreshToken(String refreshKey) {
+        try {
+            redisUtil.validateExpiredFromKey(refreshKey);
+            String refreshToken = redisUtil.getValues(refreshKey);
+
+            // 로그아웃 또는 토큰 만료 경우 처리
+            if ("false".equals(refreshToken)) {
+                throw new RestApiException(AuthErrorCode.UNAUTHORIZED_TOKEN);
+            }
+        } catch (Exception e) {
+            // 재로그인 요청 처리
+            throw new RestApiException(AuthErrorCode.FAIL_REISSUE_TOKEN);
+        }
+    }
+
+    private void reissueTokens(HttpServletResponse response, Member findMember) {
+        CustomOauth2User customUser = new CustomOauth2User(
+                AuthInfo.of(findMember.getName(), findMember.getEmail(),
+                        findMember.getRole().getRole()));
+
+        String reissuedAccessToken = tokenProvider.generateAccessToken(findMember, customUser,
+                new Date());
+        tokenProvider.generateRefreshToken(findMember, customUser, new Date());
+
+        cookieUtil.deleteCookie(response);
+        response.addCookie(cookieUtil.createCookie(reissuedAccessToken));
+    }
+
+    private String getRefreshTokenPrefix(String email) {
+        return REFRESH_TOKEN_PREFIX + email;
     }
 }

--- a/src/main/java/com/example/udtbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/udtbe/domain/auth/service/AuthService.java
@@ -1,6 +1,13 @@
 package com.example.udtbe.domain.auth.service;
 
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Gender;
+import com.example.udtbe.domain.member.entity.enums.Role;
+import com.example.udtbe.global.security.dto.Oauth2Response;
+import com.example.udtbe.global.token.service.TokenStore;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -8,4 +15,24 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final AuthQuery authQuery;
+    @Qualifier("redisTokenStore")
+    private final TokenStore tokenStore;
+
+    public Member saveOrUpdate(Oauth2Response oauth2Response) {
+        Member member = authQuery.getOptionalMemberByEmail(oauth2Response.getEmail())
+                .map(m -> {
+                    tokenStore.deleteRefreshTokenIfExists(m);
+                    tokenStore.deleteOauthAccessTokenIfExists(m);
+                    tokenStore.saveOauth2AccessToken(oauth2Response, m);
+                    return m;
+                })
+                .orElseGet(() -> createMemberFromOauth2Response(oauth2Response));
+
+        return authQuery.save(member);
+    }
+
+    private Member createMemberFromOauth2Response(Oauth2Response oauth2Response) {
+        return Member.of(oauth2Response.getEmail(), oauth2Response.getName(), Role.ROLE_GUEST,
+                oauth2Response.getProfileImageUrl(), Gender.MAN, LocalDateTime.now(), false);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/udtbe/domain/auth/service/AuthService.java
@@ -130,8 +130,8 @@ public class AuthService {
 
     private void reissueTokens(HttpServletResponse response, Member findMember) {
         CustomOauth2User customUser = new CustomOauth2User(
-                AuthInfo.of(findMember.getName(), findMember.getEmail(),
-                        findMember.getRole().getRole()));
+                AuthInfo.of(findMember.getName(), findMember.getEmail(), findMember.getRole())
+        );
 
         String reissuedAccessToken = tokenProvider.generateAccessToken(findMember, customUser,
                 new Date());
@@ -162,7 +162,7 @@ public class AuthService {
         Member findMember = authQuery.getMemberByEmail(request.email());
 
         AuthInfo authInfo = AuthInfo.of(
-                findMember.getName(), findMember.getEmail(), findMember.getRole().getRole()
+                findMember.getName(), findMember.getEmail(), findMember.getRole()
         );
         CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
 

--- a/src/main/java/com/example/udtbe/domain/content/entity/Platform.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/Platform.java
@@ -33,7 +33,7 @@ public class Platform extends TimeBaseEntity {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
-    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "platform", cascade = CascadeType.ALL)
     private List<ContentPlatform> contentPlatforms = new ArrayList<>();
 
     private Platform(String platformName, boolean isDeleted,

--- a/src/main/java/com/example/udtbe/domain/content/entity/enums/CategoryType.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/enums/CategoryType.java
@@ -20,7 +20,7 @@ public enum CategoryType {
 
     public static CategoryType from(String value) {
         return Arrays.stream(values())
-                .filter(r -> r.getType().equals(value))
+                .filter(c -> c.name().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new RestApiException(EnumErrorCode.CATEGORY_TYPE_NOT_FOUND));
     }

--- a/src/main/java/com/example/udtbe/domain/content/entity/enums/FeedbackType.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/enums/FeedbackType.java
@@ -19,7 +19,7 @@ public enum FeedbackType {
 
     public static FeedbackType from(String value) {
         return Arrays.stream(values())
-                .filter(r -> r.getType().equals(value))
+                .filter(f -> f.name().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new RestApiException(EnumErrorCode.FEEDBACK_TYPE_NOT_FOUND));
     }

--- a/src/main/java/com/example/udtbe/domain/content/entity/enums/GenreType.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/enums/GenreType.java
@@ -40,7 +40,7 @@ public enum GenreType {
 
     public static GenreType from(String value) {
         return Arrays.stream(values())
-                .filter(r -> r.getType().equals(value))
+                .filter(g -> g.name().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new RestApiException(EnumErrorCode.GENRE_TYPE_NOT_FOUND));
     }

--- a/src/main/java/com/example/udtbe/domain/member/entity/enums/Gender.java
+++ b/src/main/java/com/example/udtbe/domain/member/entity/enums/Gender.java
@@ -18,7 +18,7 @@ public enum Gender {
 
     public static Gender from(String value) {
         return Arrays.stream(values())
-                .filter(r -> r.getGender().equals(value))
+                .filter(g -> g.name().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new RestApiException(EnumErrorCode.GENDER_NOT_FOUND));
     }

--- a/src/main/java/com/example/udtbe/domain/member/entity/enums/Role.java
+++ b/src/main/java/com/example/udtbe/domain/member/entity/enums/Role.java
@@ -18,7 +18,7 @@ public enum Role {
 
     public static Role from(String value) {
         return Arrays.stream(values())
-                .filter(r -> r.getRole().equals(value))
+                .filter(r -> r.name().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new RestApiException(EnumErrorCode.ROLE_NOT_FOUND));
     }

--- a/src/main/java/com/example/udtbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/udtbe/domain/member/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/udtbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/udtbe/domain/member/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.example.udtbe.domain.member.repository;
 
 import com.example.udtbe.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(
                         (auth) -> auth
-                                .requestMatchers("/").permitAll()
+                                .requestMatchers("/**").permitAll()
                 )
                 .oauth2Login(
                         (oauth2) -> oauth2
@@ -72,7 +72,8 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
                 .requestMatchers(
-                        "/error", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**",
+                        "/error", "/favicon.ico", "/api/auth/temp-signup",
+                        "/api/auth/temp-signin", "/swagger-ui/**", "/v3/api-docs/**",
                         "/swagger-ui.html"
                 );
     }

--- a/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.example.udtbe.global.security.handler.CustomOauth2SuccessHandler;
 import com.example.udtbe.global.security.service.CustomOauth2UserService;
 import com.example.udtbe.global.token.filter.TokenAuthenticationFilter;
 import com.example.udtbe.global.token.filter.TokenExceptionFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final CustomOauth2FailureHandler customOauth2FailureHandler;
     private final TokenAuthenticationFilter tokenAuthenticationFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -58,10 +60,11 @@ public class SecurityConfig {
 
                 .addFilterBefore(tokenAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(new TokenExceptionFilter(), tokenAuthenticationFilter.getClass())
+                .addFilterBefore(new TokenExceptionFilter(objectMapper),
+                        tokenAuthenticationFilter.getClass())
 
                 .exceptionHandling((exception) -> exception
-                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint(objectMapper))
                         .accessDeniedHandler(customAccessDeniedHandler)
                 );
 

--- a/src/main/java/com/example/udtbe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/udtbe/global/config/SwaggerConfig.java
@@ -2,13 +2,9 @@ package com.example.udtbe.global.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.servers.Server;
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 
 @OpenAPIDefinition(
         info = @io.swagger.v3.oas.annotations.info.Info(
@@ -22,33 +18,10 @@ import org.springframework.http.HttpHeaders;
 @Configuration
 public class SwaggerConfig {
 
-    private static final String ACCESS_TOKEN_KEY = "Access Token (Bearer)";
-
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(createComponents())
-                .addSecurityItem(createSecurityRequirement())
                 .info(createApiInfo());
-    }
-
-    private Components createComponents() {
-        return new Components()
-                .addSecuritySchemes(ACCESS_TOKEN_KEY, createAccessTokenSecurityScheme());
-    }
-
-    private SecurityRequirement createSecurityRequirement() {
-        return new SecurityRequirement()
-                .addList(ACCESS_TOKEN_KEY);
-    }
-
-    private SecurityScheme createAccessTokenSecurityScheme() {
-        return new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("Authorization")
-                .in(SecurityScheme.In.HEADER)
-                .name(HttpHeaders.AUTHORIZATION);
     }
 
     private io.swagger.v3.oas.models.info.Info createApiInfo() {

--- a/src/main/java/com/example/udtbe/global/exception/code/RedisErrorCode.java
+++ b/src/main/java/com/example/udtbe/global/exception/code/RedisErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.udtbe.global.exception.code;
+
+import com.example.udtbe.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisErrorCode implements ErrorCode {
+
+    REDIS_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "저장하지 못했습니다."),
+    REDIS_FIND_ERROR(HttpStatus.NOT_FOUND, "값을 찾는 도중 오류가 발생했습니다."),
+    REDIS_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "삭제하지 못했습니다."),
+    REDIS_EXPIRE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "만료시키지하지 못했습니다."),
+    REDIS_EXPIRED_ERROR(HttpStatus.GONE, "만료된 키 입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/udtbe/global/security/dto/AuthInfo.java
+++ b/src/main/java/com/example/udtbe/global/security/dto/AuthInfo.java
@@ -1,5 +1,6 @@
 package com.example.udtbe.global.security.dto;
 
+import com.example.udtbe.domain.member.entity.enums.Role;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +11,10 @@ public class AuthInfo {
 
     private String socialName;
     private String socialEmail;
-    private String role;
+    private Role role;
 
     @Builder
-    private AuthInfo(String socialName, String socialEmail, String role) {
+    private AuthInfo(String socialName, String socialEmail, Role role) {
         this.socialName = socialName;
         this.socialEmail = socialEmail;
         this.role = role;
@@ -32,7 +33,7 @@ public class AuthInfo {
                 .build();
     }
 
-    public static AuthInfo of(String socialName, String socialEmail, String role) {
+    public static AuthInfo of(String socialName, String socialEmail, Role role) {
         return AuthInfo.builder()
                 .socialName(socialName)
                 .socialEmail(socialEmail)

--- a/src/main/java/com/example/udtbe/global/security/dto/AuthInfo.java
+++ b/src/main/java/com/example/udtbe/global/security/dto/AuthInfo.java
@@ -1,0 +1,43 @@
+package com.example.udtbe.global.security.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AuthInfo {
+
+    private String socialName;
+    private String socialEmail;
+    private String role;
+
+    @Builder
+    private AuthInfo(String socialName, String socialEmail, String role) {
+        this.socialName = socialName;
+        this.socialEmail = socialEmail;
+        this.role = role;
+    }
+
+    public static AuthInfo fromSocialEmail(String socialEmail) {
+        return AuthInfo.builder()
+                .socialEmail(socialEmail)
+                .build();
+    }
+
+    public static AuthInfo of(String socialName, String socialEmail) {
+        return AuthInfo.builder()
+                .socialName(socialName)
+                .socialEmail(socialEmail)
+                .build();
+    }
+
+    public static AuthInfo of(String socialName, String socialEmail, String role) {
+        return AuthInfo.builder()
+                .socialName(socialName)
+                .socialEmail(socialEmail)
+                .role(role)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/udtbe/global/security/dto/CustomOauth2User.java
+++ b/src/main/java/com/example/udtbe/global/security/dto/CustomOauth2User.java
@@ -23,8 +23,7 @@ public class CustomOauth2User implements OAuth2User {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        String role = authInfo.getRole();
-        return Collections.singletonList(new SimpleGrantedAuthority(role));
+        return Collections.singletonList(new SimpleGrantedAuthority(authInfo.getRole().name()));
     }
 
     @Override

--- a/src/main/java/com/example/udtbe/global/security/dto/CustomOauth2User.java
+++ b/src/main/java/com/example/udtbe/global/security/dto/CustomOauth2User.java
@@ -1,0 +1,38 @@
+package com.example.udtbe.global.security.dto;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class CustomOauth2User implements OAuth2User {
+
+    private final AuthInfo authInfo;
+    private Map<String, Object> attributes;
+
+    public CustomOauth2User(AuthInfo authInfo) {
+        this.authInfo = authInfo;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        String role = authInfo.getRole();
+        return Collections.singletonList(new SimpleGrantedAuthority(role));
+    }
+
+    @Override
+    public String getName() {
+        return authInfo.getSocialName();
+    }
+
+    public String getEmail() {
+        return authInfo.getSocialEmail();
+    }
+}

--- a/src/main/java/com/example/udtbe/global/security/dto/KakaoResponse.java
+++ b/src/main/java/com/example/udtbe/global/security/dto/KakaoResponse.java
@@ -1,0 +1,41 @@
+package com.example.udtbe.global.security.dto;
+
+import java.util.Map;
+
+public class KakaoResponse implements Oauth2Response {
+
+    private final Map<String, Object> attribute;
+    private final Long id;
+    private final String oauth2AccessToken;
+
+    public KakaoResponse(Map<String, Object> attribute, String oauth2AccessToken) {
+        this.attribute = (Map<String, Object>) attribute.get("kakao_account");
+        this.id = (Long) attribute.get("id");
+        this.oauth2AccessToken = oauth2AccessToken;
+    }
+
+    @Override
+    public String getProviderId() {
+        return this.id.toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return ((Map<String, Object>) attribute.get("profile")).get("nickname").toString();
+    }
+
+    @Override
+    public String getOauth2AccessToken() {
+        return this.oauth2AccessToken;
+    }
+
+    public String getProfileImageUrl() {
+        return ((Map<String, Object>) attribute.get("profile")).get("profile_image_url").toString();
+    }
+
+}

--- a/src/main/java/com/example/udtbe/global/security/dto/Oauth2Response.java
+++ b/src/main/java/com/example/udtbe/global/security/dto/Oauth2Response.java
@@ -1,0 +1,15 @@
+package com.example.udtbe.global.security.dto;
+
+public interface Oauth2Response {
+
+
+    String getProviderId();
+
+    String getEmail();
+
+    String getName();
+
+    String getOauth2AccessToken();
+
+    String getProfileImageUrl();
+}

--- a/src/main/java/com/example/udtbe/global/security/exception/SecurityErrorCode.java
+++ b/src/main/java/com/example/udtbe/global/security/exception/SecurityErrorCode.java
@@ -9,11 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SecurityErrorCode implements ErrorCode {
 
-    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "비인가 사용자 요청입니다."),
-    FORBIDDEN_USER(HttpStatus.UNAUTHORIZED, "USER 권한이 필요합니다."),
-    FORBIDDEN_GUEST(HttpStatus.UNAUTHORIZED, "GUEST 권한이 필요합니다."),
-    FORBIDDEN_ADMIN(HttpStatus.UNAUTHORIZED, "ADMIN 권한이 필요합니다."),
-    FORBIDDEN_MISMATCH(HttpStatus.UNAUTHORIZED, "어떤 권한도 매치되지 않습니다.");
+    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "비인가 사용자 요청입니다."),
+    FORBIDDEN_USER(HttpStatus.FORBIDDEN, "USER 권한이 필요합니다."),
+    FORBIDDEN_GUEST(HttpStatus.FORBIDDEN, "GUEST 권한이 필요합니다."),
+    FORBIDDEN_ADMIN(HttpStatus.FORBIDDEN, "ADMIN 권한이 필요합니다."),
+    FORBIDDEN_MISMATCH(HttpStatus.FORBIDDEN, "어떤 권한도 매치되지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/udtbe/global/security/exception/SecurityErrorCode.java
+++ b/src/main/java/com/example/udtbe/global/security/exception/SecurityErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.udtbe.global.security.exception;
+
+import com.example.udtbe.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SecurityErrorCode implements ErrorCode {
+
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "비인가 사용자 요청입니다."),
+    FORBIDDEN_USER(HttpStatus.UNAUTHORIZED, "USER 권한이 필요합니다."),
+    FORBIDDEN_GUEST(HttpStatus.UNAUTHORIZED, "GUEST 권한이 필요합니다."),
+    FORBIDDEN_ADMIN(HttpStatus.UNAUTHORIZED, "ADMIN 권한이 필요합니다."),
+    FORBIDDEN_MISMATCH(HttpStatus.UNAUTHORIZED, "어떤 권한도 매치되지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,84 @@
+package com.example.udtbe.global.security.handler;
+
+import com.example.udtbe.global.exception.ErrorResponse;
+import com.example.udtbe.global.security.exception.SecurityErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final String ROLE_GUEST = "ROLE_GUEST";
+    private static final String ROLE_USER = "ROLE_USER";
+    private static final String ROLE_ADMIN = "ROLE_ADMIN";
+
+    private static boolean matchAuthenticationFromRole(Authentication authentication, String role) {
+        String authRole = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining());
+
+        return Objects.equals(authRole, role);
+    }
+
+    private static void setUpResponse(
+            HttpServletResponse response,
+            SecurityErrorCode securityErrorCode
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                securityErrorCode.getMessage(),
+                securityErrorCode.getHttpStatus().name()
+        );
+
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonResponse = mapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(jsonResponse);
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException {
+        // 현재 인증된 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        log.error(authentication.getName());
+        // 사용자 권한에 따라 다른 응답 제공
+        if (!Objects.isNull(accessDeniedException)) {
+            if (!matchAuthenticationFromRole(authentication, ROLE_USER)) {
+                // ROLE_USER 권한이 없는 경우
+                log.info(SecurityErrorCode.FORBIDDEN_USER.getMessage());
+                setUpResponse(response, SecurityErrorCode.FORBIDDEN_USER);
+            } else if (!matchAuthenticationFromRole(authentication, ROLE_GUEST)) {
+                // ROLE_GUEST 권한이 없는 경우
+                log.info(SecurityErrorCode.FORBIDDEN_GUEST.getMessage());
+                setUpResponse(response, SecurityErrorCode.FORBIDDEN_GUEST);
+            } else if (!matchAuthenticationFromRole(authentication, ROLE_ADMIN)) {
+                // ROLE_GUEST 권한이 없는 경우
+                log.info(SecurityErrorCode.FORBIDDEN_GUEST.getMessage());
+                setUpResponse(response, SecurityErrorCode.FORBIDDEN_GUEST);
+            } else {
+                // 기타 권한이 없는 경우
+                log.info(SecurityErrorCode.FORBIDDEN_MISMATCH.getMessage());
+                setUpResponse(response, SecurityErrorCode.FORBIDDEN_MISMATCH);
+            }
+        } else {
+            log.info(SecurityErrorCode.FORBIDDEN_MISMATCH.getMessage());
+            setUpResponse(response, SecurityErrorCode.FORBIDDEN_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomAccessDeniedHandler.java
@@ -70,7 +70,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             } else if (!matchAuthenticationFromRole(authentication, ROLE_ADMIN)) {
                 // ROLE_GUEST 권한이 없는 경우
                 log.info(SecurityErrorCode.FORBIDDEN_GUEST.getMessage());
-                setUpResponse(response, SecurityErrorCode.FORBIDDEN_GUEST);
+                setUpResponse(response, SecurityErrorCode.FORBIDDEN_ADMIN);
             } else {
                 // 기타 권한이 없는 경우
                 log.info(SecurityErrorCode.FORBIDDEN_MISMATCH.getMessage());

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -6,12 +6,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
 @Slf4j
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
@@ -27,8 +31,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                 SecurityErrorCode.UNAUTHORIZED_USER.getMessage(),
                 SecurityErrorCode.UNAUTHORIZED_USER.getHttpStatus().name());
 
-        ObjectMapper mapper = new ObjectMapper();
-        String jsonResponse = mapper.writeValueAsString(errorResponse);
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
 
         response.getWriter().write(jsonResponse);
     }

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.example.udtbe.global.security.handler;
+
+import com.example.udtbe.global.exception.ErrorResponse;
+import com.example.udtbe.global.security.exception.SecurityErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException {
+
+        log.error("비인가 사용자 요청 -> 예외 발생 : {}", authException.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                SecurityErrorCode.UNAUTHORIZED_USER.getMessage(),
+                SecurityErrorCode.UNAUTHORIZED_USER.getHttpStatus().name());
+
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonResponse = mapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomOauth2FailureHandler.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomOauth2FailureHandler.java
@@ -1,0 +1,21 @@
+package com.example.udtbe.global.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CustomOauth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception) throws IOException {
+        log.error("소셜 로그인 실패", exception);
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST, "소셜 로그인에 실패하였습니다.");
+    }
+}

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomOauth2SuccessHandler.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomOauth2SuccessHandler.java
@@ -1,0 +1,55 @@
+package com.example.udtbe.global.security.handler;
+
+import com.example.udtbe.domain.auth.service.AuthQuery;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
+import com.example.udtbe.global.security.dto.CustomOauth2User;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import com.example.udtbe.global.token.service.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOauth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final AuthQuery authQuery;
+    private final TokenProvider tokenProvider;
+    private final CookieUtil cookieUtil;
+    @Value("${direct.sign-up}")
+    private String REDIRECTION_SIGNUP;
+    @Value("${direct.home}")
+    private String REDIRECTION_HOME;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws IOException {
+
+        CustomOauth2User customOauth2User = (CustomOauth2User) authentication.getPrincipal();
+
+        String email = customOauth2User.getEmail();
+        Member findmember = authQuery.getMemberByEmail(email);
+
+        String token = tokenProvider.generateAccessToken(findmember, customOauth2User, new Date());
+        tokenProvider.generateRefreshToken(findmember, customOauth2User, new Date());
+
+        response.addCookie(cookieUtil.createCookie(token));
+
+        if (isRoleGuest(findmember.getRole())) {
+            response.sendRedirect(REDIRECTION_SIGNUP);
+        } else {
+            response.sendRedirect(REDIRECTION_HOME);
+        }
+    }
+
+    private boolean isRoleGuest(Role role) {
+        return Role.ROLE_GUEST.equals(role);
+    }
+}

--- a/src/main/java/com/example/udtbe/global/security/service/CustomOauth2UserService.java
+++ b/src/main/java/com/example/udtbe/global/security/service/CustomOauth2UserService.java
@@ -1,0 +1,56 @@
+package com.example.udtbe.global.security.service;
+
+import com.example.udtbe.domain.auth.service.AuthService;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.global.security.dto.AuthInfo;
+import com.example.udtbe.global.security.dto.CustomOauth2User;
+import com.example.udtbe.global.security.dto.KakaoResponse;
+import com.example.udtbe.global.security.dto.Oauth2Response;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOauth2UserService extends DefaultOAuth2UserService {
+
+    private final AuthService authService;
+    private static final String KAKAO = "kakao";
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String oauth2AccessToken = userRequest.getAccessToken().getTokenValue();
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        Oauth2Response oauth2Response = null;
+
+        if (Objects.equals(registrationId, KAKAO)) {
+            oauth2Response = new KakaoResponse(oAuth2User.getAttributes(), oauth2AccessToken);
+        } else {
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("ERROR"),
+                    "UNSUPPORTED SOCIAL LOGIN"
+            );
+        }
+
+        Member savedMember = authService.saveOrUpdate(oauth2Response);
+
+        AuthInfo authInfo = AuthInfo.of(
+                savedMember.getName(),
+                savedMember.getEmail(),
+                savedMember.getRole().getRole()
+        );
+        return new CustomOauth2User(authInfo);
+    }
+
+}
+

--- a/src/main/java/com/example/udtbe/global/security/service/CustomOauth2UserService.java
+++ b/src/main/java/com/example/udtbe/global/security/service/CustomOauth2UserService.java
@@ -47,7 +47,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         AuthInfo authInfo = AuthInfo.of(
                 savedMember.getName(),
                 savedMember.getEmail(),
-                savedMember.getRole().getRole()
+                savedMember.getRole()
         );
         return new CustomOauth2User(authInfo);
     }

--- a/src/main/java/com/example/udtbe/global/token/cookie/CookieConfig.java
+++ b/src/main/java/com/example/udtbe/global/token/cookie/CookieConfig.java
@@ -1,0 +1,11 @@
+package com.example.udtbe.global.token.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface CookieConfig {
+
+    public Cookie createCookie(String token);
+
+    public void deleteCookie(HttpServletResponse response);
+}

--- a/src/main/java/com/example/udtbe/global/token/cookie/CookieUtil.java
+++ b/src/main/java/com/example/udtbe/global/token/cookie/CookieUtil.java
@@ -1,0 +1,36 @@
+package com.example.udtbe.global.token.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CookieUtil {
+
+    private final CookieConfig cookieConfig;
+
+    public Cookie createCookie(String token) {
+        return cookieConfig.createCookie(token);
+    }
+
+    public void deleteCookie(HttpServletResponse response) {
+        cookieConfig.deleteCookie(response);
+    }
+
+    public String getCookieValue(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("Authorization".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/udtbe/global/token/cookie/DevCookie.java
+++ b/src/main/java/com/example/udtbe/global/token/cookie/DevCookie.java
@@ -1,0 +1,37 @@
+package com.example.udtbe.global.token.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("dev")
+public class DevCookie implements CookieConfig {
+
+    @Override
+    public Cookie createCookie(String token) {
+        Cookie cookie = new Cookie("Authorization", token);
+        cookie.setPath("/");
+        cookie.setDomain("yourstie.com");
+        cookie.setMaxAge(60 * 180);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
+        return cookie;
+    }
+
+    @Override
+    public void deleteCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("Authorization", null);
+        cookie.setPath("/");
+        cookie.setDomain("yourstie.com");
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
+
+        response.addCookie(cookie);
+    }
+
+}

--- a/src/main/java/com/example/udtbe/global/token/cookie/LocalCookie.java
+++ b/src/main/java/com/example/udtbe/global/token/cookie/LocalCookie.java
@@ -1,0 +1,34 @@
+package com.example.udtbe.global.token.cookie;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("local")
+public class LocalCookie implements CookieConfig {
+
+    @Override
+    public Cookie createCookie(String token) {
+        Cookie cookie = new Cookie("Authorization", token);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 180);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
+        return cookie;
+    }
+
+    @Override
+    public void deleteCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("Authorization", null);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
+
+        response.addCookie(cookie);
+    }
+}

--- a/src/main/java/com/example/udtbe/global/token/exception/TokenErrorCode.java
+++ b/src/main/java/com/example/udtbe/global/token/exception/TokenErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.udtbe.global.token.exception;
+
+import com.example.udtbe.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TokenErrorCode implements ErrorCode {
+
+    MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "알맞지 않은 형식의 토큰입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
@@ -46,7 +46,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             }
         }
 
-        String accessToken = resolveToken(request);
+        String accessToken = cookieUtil.getCookieValue(request);
 
         if (tokenProvider.validateToken(accessToken, new Date())) {
             // accessToken logout 여부 확인

--- a/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.example.udtbe.global.token.filter;
+
+import static com.example.udtbe.global.token.exception.TokenErrorCode.INVALID_TOKEN;
+
+import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import com.example.udtbe.global.token.service.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final List<String> SKIP_URLS = Arrays.asList(
+            "/error", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html"
+    );
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final TokenProvider tokenProvider;
+    private final CookieUtil cookieUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        for (String pattern : SKIP_URLS) {
+            if (pathMatcher.match(pattern, request.getRequestURI())) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
+
+        String accessToken = resolveToken(request);
+
+        if (tokenProvider.validateToken(accessToken, new Date())) {
+            // accessToken logout 여부 확인
+            if (tokenProvider.verifyBlackList(accessToken)) {
+                saveAuthentication(accessToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void saveAuthentication(String accessToken) {
+        Authentication authentication = tokenProvider.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String accessToken = cookieUtil.getCookieValue(request);
+
+        if (ObjectUtils.isEmpty(accessToken) || !accessToken.startsWith(TOKEN_PREFIX)) {
+            throw new RestApiException(INVALID_TOKEN);
+        }
+        return accessToken.substring(TOKEN_PREFIX.length());
+    }
+
+}

--- a/src/main/java/com/example/udtbe/global/token/filter/TokenExceptionFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenExceptionFilter.java
@@ -1,18 +1,22 @@
 package com.example.udtbe.global.token.filter;
 
+import com.example.udtbe.global.exception.ErrorResponse;
+import com.example.udtbe.global.token.exception.TokenErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
+@RequiredArgsConstructor
 public class TokenExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -27,12 +31,11 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
             response.setContentType("application/json");
             response.setCharacterEncoding("UTF-8");
 
-            Map<String, Object> errorResponse = new HashMap<>();
-            errorResponse.put("message", e.getMessage());
-            errorResponse.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+            ErrorResponse errorResponse = new ErrorResponse(
+                    TokenErrorCode.INVALID_TOKEN.getMessage(),
+                    TokenErrorCode.INVALID_TOKEN.getHttpStatus().name());
 
-            ObjectMapper mapper = new ObjectMapper();
-            String jsonResponse = mapper.writeValueAsString(errorResponse);
+            String jsonResponse = objectMapper.writeValueAsString(errorResponse);
 
             response.getWriter().write(jsonResponse);
         }

--- a/src/main/java/com/example/udtbe/global/token/filter/TokenExceptionFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenExceptionFilter.java
@@ -1,0 +1,40 @@
+package com.example.udtbe.global.token.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+public class TokenExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+
+            log.error("JWT 검증 실패로 인한 예외 발생 : {}", e.getMessage());
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
+            response.setContentType("application/json");
+            response.setCharacterEncoding("UTF-8");
+
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("message", e.getMessage());
+            errorResponse.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+
+            ObjectMapper mapper = new ObjectMapper();
+            String jsonResponse = mapper.writeValueAsString(errorResponse);
+
+            response.getWriter().write(jsonResponse);
+        }
+    }
+}

--- a/src/main/java/com/example/udtbe/global/token/service/RedisTokenStore.java
+++ b/src/main/java/com/example/udtbe/global/token/service/RedisTokenStore.java
@@ -1,0 +1,54 @@
+package com.example.udtbe.global.token.service;
+
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.global.security.dto.Oauth2Response;
+import com.example.udtbe.global.util.RedisUtil;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisTokenStore implements TokenStore {
+
+    private final RedisUtil redisUtil;
+
+    @Override
+    public void deleteRefreshTokenIfExists(Member m) {
+        if (redisUtil.getValues("RT:" + m.getEmail()) != null) {
+            redisUtil.deleteValues("RT:" + m.getEmail());
+        }
+    }
+
+    @Override
+    public void deleteOauthAccessTokenIfExists(Member m) {
+        if (redisUtil.getValues("AT(oauth):" + m.getEmail()) != null) {
+            redisUtil.deleteValues("AT(oauth):" + m.getEmail());
+        }
+    }
+
+    @Override
+    public void saveOauth2AccessToken(Oauth2Response oauth2Response, Member m) {
+        redisUtil.setValues(
+                "AT(oauth):" + m.getEmail(),
+                oauth2Response.getOauth2AccessToken(),
+                Duration.ofMillis(ACCESS_TOKEN_EXPIRATION)
+        );
+    }
+
+    @Override
+    public void save(String key, String value, Duration ttl) {
+        redisUtil.setValues(key, value, ttl);
+    }
+
+    @Override
+    public Optional<String> find(String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void delete(String key) {
+
+    }
+}

--- a/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
+++ b/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
@@ -36,7 +36,6 @@ import org.springframework.util.StringUtils;
 public class TokenProvider {
 
     private static final String ROLE_KEY = "ROLE";
-    private static final String TOKEN_PREFIX = "Bearer ";
     private static final String[] BLACKLIST = new String[]{"false", "delete"};
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 90L;
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L;
@@ -72,7 +71,7 @@ public class TokenProvider {
         Date expiredTime = createExpiredDateWithTokenType(now, tokenExpireTime);
         String authorities = getAuthorities(authentication);
 
-        return TOKEN_PREFIX + Jwts.builder()
+        return Jwts.builder()
                 .subject(String.valueOf(findMember.getId()))
                 .claim(ROLE_KEY, authorities)
                 .issuedAt(now)

--- a/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
+++ b/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
@@ -1,0 +1,154 @@
+package com.example.udtbe.global.token.service;
+
+import static com.example.udtbe.global.token.exception.TokenErrorCode.INVALID_TOKEN;
+import static com.example.udtbe.global.token.exception.TokenErrorCode.MALFORMED_TOKEN;
+
+import com.example.udtbe.domain.auth.service.AuthQuery;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.security.dto.CustomOauth2User;
+import com.example.udtbe.global.token.exception.TokenErrorCode;
+import com.example.udtbe.global.util.RedisUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    private static final String ROLE_KEY = "ROLE";
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private static final String[] BLACKLIST = new String[]{"false", "delete"};
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 90L;
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L;
+
+    private final AuthQuery authQuery;
+    private final RedisUtil redisUtil;
+
+    @Value("${spring.jwt.key}")
+    private String key;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    private void initSecretKey() {
+        this.secretKey = Keys.hmacShaKeyFor(key.getBytes());
+    }
+
+    public String generateAccessToken(Member findMember, CustomOauth2User authentication,
+            Date now) {
+        return generateToken(findMember, authentication, ACCESS_TOKEN_EXPIRE_TIME, now);
+    }
+
+    public void generateRefreshToken(Member findMember, CustomOauth2User authentication, Date now) {
+        String refreshToken = generateToken(findMember, authentication, REFRESH_TOKEN_EXPIRE_TIME,
+                now);
+
+        // redis Refresh 저장
+        redisUtil.setValues("RT:" + authentication.getEmail(), refreshToken,
+                Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
+    }
+
+    private String generateToken(Member findMember, CustomOauth2User authentication,
+            long tokenExpireTime, Date now) {
+        Date expiredTime = createExpiredDateWithTokenType(now, tokenExpireTime);
+        String authorities = getAuthorities(authentication);
+
+        return TOKEN_PREFIX + Jwts.builder()
+                .subject(String.valueOf(findMember.getId()))
+                .claim(ROLE_KEY, authorities)
+                .issuedAt(now)
+                .expiration(expiredTime)
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    private String getAuthorities(CustomOauth2User authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining());
+    }
+
+    private Date createExpiredDateWithTokenType(Date date, long tokenExpireTime) {
+        return new Date(date.getTime() + tokenExpireTime);
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseToken(token);
+        List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
+
+        String subject = claims.getSubject();
+        Member principal = authQuery.getMemberById(Long.valueOf(subject));
+
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+    public boolean validateToken(String token, Date date) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        Claims claims = parseToken(token);
+        if (!claims.getExpiration().after(date)) {
+            throw new RestApiException(TokenErrorCode.EXPIRED_TOKEN);
+        }
+
+        return true;
+    }
+
+    private Claims parseToken(String token) {
+        try {
+            return Jwts.parser().verifyWith(secretKey).build()
+                    .parseSignedClaims(token).getPayload();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        } catch (MalformedJwtException e) {
+            throw new RestApiException(MALFORMED_TOKEN);
+        } catch (Exception e) {
+            throw new RestApiException(INVALID_TOKEN);
+        }
+    }
+
+    private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+        return Collections.singletonList(new SimpleGrantedAuthority(
+                claims.get(ROLE_KEY).toString()
+        ));
+    }
+
+    public Long getExpiration(String token, Date date) {
+        Claims claims = parseToken(token);
+        Date expiration = claims.getExpiration();
+        return (expiration.getTime() - date.getTime());
+    }
+
+    public boolean verifyBlackList(String accessToken) {
+        String value = redisUtil.getValues(accessToken);
+        return Arrays.asList(BLACKLIST).contains(value);
+    }
+
+    public Member getMemberAllowExpired(String token) {
+        Claims claims = parseToken(token);
+
+        String subject = claims.getSubject();
+        return authQuery.getMemberById(Long.valueOf(subject));
+    }
+
+}

--- a/src/main/java/com/example/udtbe/global/token/service/TokenStore.java
+++ b/src/main/java/com/example/udtbe/global/token/service/TokenStore.java
@@ -1,0 +1,23 @@
+package com.example.udtbe.global.token.service;
+
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.global.security.dto.Oauth2Response;
+import java.time.Duration;
+import java.util.Optional;
+
+public interface TokenStore {
+
+    static final long ACCESS_TOKEN_EXPIRATION = 3600 * 1000;
+
+    void deleteRefreshTokenIfExists(Member m);
+
+    void deleteOauthAccessTokenIfExists(Member m);
+
+    void saveOauth2AccessToken(Oauth2Response oauth2Response, Member m);
+
+    void save(String key, String value, Duration ttl);
+
+    Optional<String> find(String key);
+
+    void delete(String key);
+}

--- a/src/main/java/com/example/udtbe/global/util/RedisUtil.java
+++ b/src/main/java/com/example/udtbe/global/util/RedisUtil.java
@@ -1,0 +1,90 @@
+package com.example.udtbe.global.util;
+
+import static com.example.udtbe.global.exception.code.RedisErrorCode.REDIS_DELETE_ERROR;
+import static com.example.udtbe.global.exception.code.RedisErrorCode.REDIS_EXPIRED_ERROR;
+import static com.example.udtbe.global.exception.code.RedisErrorCode.REDIS_EXPIRE_ERROR;
+import static com.example.udtbe.global.exception.code.RedisErrorCode.REDIS_FIND_ERROR;
+import static com.example.udtbe.global.exception.code.RedisErrorCode.REDIS_SAVE_ERROR;
+
+import com.example.udtbe.global.exception.RestApiException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValues(String key, String data) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            values.set(key, data);
+        } catch (Exception e) {
+            throw new RestApiException(REDIS_SAVE_ERROR);
+        }
+
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            values.set(key, data, duration);
+        } catch (Exception e) {
+            throw new RestApiException(REDIS_SAVE_ERROR);
+        }
+    }
+
+    public String getValues(String key) {
+        try {
+            ValueOperations<String, Object> values = redisTemplate.opsForValue();
+            if (values.get(key) == null) {
+                return "false";
+            }
+            return (String) values.get(key);
+        } catch (Exception e) {
+            throw new RestApiException(REDIS_FIND_ERROR);
+        }
+    }
+
+    public void deleteValues(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            throw new RestApiException(REDIS_DELETE_ERROR);
+        }
+    }
+
+    public void expireValues(String key, int timeout) {
+        try {
+            redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+
+        } catch (Exception e) {
+            throw new RestApiException(REDIS_EXPIRE_ERROR);
+        }
+    }
+
+    public boolean validateData(String key, String data) {
+        String findValues = this.getValues(key);
+        if (Objects.equals(findValues, "false")) {
+            throw new RestApiException(REDIS_FIND_ERROR);
+        }
+
+        return Objects.equals(findValues, data);
+    }
+
+    public void validateExpiredFromKey(String key) {
+        Long ttl = redisTemplate.getExpire(key, TimeUnit.MILLISECONDS);
+        if (ttl == null || ttl <= 0) {
+            throw new RestApiException(REDIS_EXPIRED_ERROR);
+        }
+    }
+
+}

--- a/src/test/java/com/example/udtbe/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/udtbe/auth/service/AuthServiceTest.java
@@ -1,0 +1,130 @@
+package com.example.udtbe.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.domain.auth.service.AuthService;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
+import com.example.udtbe.global.security.dto.CustomOauth2User;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import com.example.udtbe.global.token.service.TokenProvider;
+import com.example.udtbe.global.token.service.TokenStore;
+import com.example.udtbe.global.util.RedisUtil;
+import jakarta.servlet.http.Cookie;
+import java.time.Duration;
+import java.util.Date;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private TokenStore tokenStore;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Mock
+    private CookieUtil cookieUtil;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @DisplayName("로그인 회원은 로그아웃 할 수 있다.")
+    @Test
+    void logout() {
+        // given
+        final Long fiveMinutes = 300_000L;
+        final String email = "test@naver.com";
+        final String token = "testtesttesttest";
+
+        Member principal = MemberFixture.member(email, Role.ROLE_USER);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "test");
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        mockRequest.setCookies(new Cookie("Authorization", token));
+
+        given(cookieUtil.getCookieValue(mockRequest)).willReturn(token);
+        given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
+        given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
+        given(tokenProvider.getExpiration(anyString(), any(Date.class))).willReturn(fiveMinutes);
+        given(redisUtil.getValues(anyString())).willReturn("refresh");
+        given(redisUtil.getValues(anyString())).willReturn("delete");
+
+        willDoNothing().given(redisUtil).setValues(anyString(), anyString(), any(Duration.class));
+
+        // when
+        authService.logout(mockRequest, mockResponse);
+
+        // then
+        Assertions.assertAll(
+                () -> verify(cookieUtil, times(1)).getCookieValue(mockRequest),
+                () -> verify(tokenProvider, times(1)).getAuthentication(token),
+                () -> verify(cookieUtil, times(1)).deleteCookie(mockResponse)
+        );
+    }
+
+    @DisplayName("refresh 토큰이 만료되지 않았다면 재발급 할 수 있다.")
+    @Test
+    void reissue() {
+        // given
+        final String email = "test@naver.com";
+        final String token = "testtesttesttest";
+        final String reissueToken = "reissueToken";
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+        mockRequest.setCookies(new Cookie("Authorization", token));
+
+        Member principal = MemberFixture.member(email, Role.ROLE_USER);
+
+        given(cookieUtil.getCookieValue(mockRequest)).willReturn("testtesttesttest");
+        given(cookieUtil.createCookie(anyString())).willReturn(
+                new Cookie("Authorization", reissueToken));
+        given(tokenProvider.getMemberAllowExpired(anyString())).willReturn(principal);
+        given(redisUtil.getValues(anyString())).willReturn(reissueToken);
+        given(tokenProvider.generateAccessToken(
+                any(Member.class),
+                any(CustomOauth2User.class),
+                any(Date.class)))
+                .willReturn("reissueToken");
+        doNothing().when(tokenProvider)
+                .generateRefreshToken(any(Member.class), any(CustomOauth2User.class),
+                        any(Date.class));
+
+        // when
+        authService.reissue(mockRequest, mockResponse);
+        Cookie[] cookies = mockResponse.getCookies();
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(cookies)
+                        .hasSize(1)
+                        .extracting(Cookie::getName, Cookie::getValue)
+                        .containsExactly(tuple("Authorization", reissueToken))
+        );
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/MemberFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/MemberFixture.java
@@ -4,14 +4,13 @@ import static com.example.udtbe.domain.member.entity.enums.Gender.MAN;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.example.udtbe.domain.member.entity.Member;
-import com.example.udtbe.domain.member.entity.enums.Role;
 import java.time.LocalDateTime;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public class MemberFixture {
 
-    public static Member member(String email, Role role) {
+    public static Member member(String email, String role) {
         return Member.of(
                 email,
                 "홍길동",

--- a/src/test/java/com/example/udtbe/common/fixture/MemberFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/MemberFixture.java
@@ -4,18 +4,19 @@ import static com.example.udtbe.domain.member.entity.enums.Gender.MAN;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
 import java.time.LocalDateTime;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public class MemberFixture {
 
-    public static Member member(String email, String role) {
+    public static Member member(String email, Role role) {
         return Member.of(
                 email,
                 "홍길동",
-                null,
                 role,
+                null,
                 MAN,
                 LocalDateTime.of(2025, 7, 6, 1, 20),
                 false

--- a/src/test/java/com/example/udtbe/common/support/ApiSupport.java
+++ b/src/test/java/com/example/udtbe/common/support/ApiSupport.java
@@ -3,6 +3,7 @@ package com.example.udtbe.common.support;
 import com.example.udtbe.common.fixture.MemberFixture;
 import com.example.udtbe.domain.auth.service.AuthQuery;
 import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
 import com.example.udtbe.global.security.dto.AuthInfo;
 import com.example.udtbe.global.security.dto.CustomOauth2User;
 import com.example.udtbe.global.token.cookie.CookieUtil;
@@ -52,8 +53,8 @@ public abstract class ApiSupport extends TestContainerSupport {
             return;
         }
 
-        this.loginAdmin = authQuery.save(MemberFixture.member("admin@naver.com", "관리자"));
-        this.loginUser = authQuery.save(MemberFixture.member("user@naver.com", "일반회원"));
+        this.loginAdmin = authQuery.save(MemberFixture.member("admin@naver.com", Role.ROLE_ADMIN));
+        this.loginUser = authQuery.save(MemberFixture.member("user@naver.com", Role.ROLE_USER));
 
         AuthInfo authInfoOfAdmin = getAuthInfo(loginAdmin);
         AuthInfo authInfoOfUser = getAuthInfo(loginUser);

--- a/src/test/java/com/example/udtbe/common/support/ApiSupport.java
+++ b/src/test/java/com/example/udtbe/common/support/ApiSupport.java
@@ -3,7 +3,6 @@ package com.example.udtbe.common.support;
 import com.example.udtbe.common.fixture.MemberFixture;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.repository.MemberRepository;
-import com.example.udtbe.domain.member.entity.enums.Role;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,9 +37,9 @@ public abstract class ApiSupport extends TestContainerSupport {
         }
 
         this.loginAdmin = memberRepository.save(
-                MemberFixture.member("admin@naver.com", Role.ROLE_ADMIN));
+                MemberFixture.member("admin@naver.com", "관리자"));
         this.loginUser = memberRepository.save(
-                MemberFixture.member("user@naver.com", Role.ROLE_USER));
+                MemberFixture.member("user@naver.com", "일반회원"));
 
         this.accessTokenOfAdmin = BEARER + "tmpToken";
         this.accessTokenOfUser = BEARER + "tmpToken";

--- a/src/test/java/com/example/udtbe/common/support/ApiSupport.java
+++ b/src/test/java/com/example/udtbe/common/support/ApiSupport.java
@@ -1,10 +1,17 @@
 package com.example.udtbe.common.support;
 
 import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.domain.auth.service.AuthQuery;
 import com.example.udtbe.domain.member.entity.Member;
-import com.example.udtbe.domain.member.repository.MemberRepository;
+import com.example.udtbe.global.security.dto.AuthInfo;
+import com.example.udtbe.global.security.dto.CustomOauth2User;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import com.example.udtbe.global.token.service.TokenProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import java.util.Date;
+import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -15,39 +22,65 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 public abstract class ApiSupport extends TestContainerSupport {
 
-    private static final String BEARER = "Bearer ";
     protected Member loginAdmin;
     protected Member loginUser;
-    protected String accessTokenOfUser;
-    protected String accessTokenOfAdmin;
-    @Autowired
-    protected MemberRepository memberRepository;
+    protected Cookie accessTokenOfUser;
+    protected Cookie accessTokenOfAdmin;
     @Autowired
     protected MockMvc mockMvc;
     @Autowired
     protected ObjectMapper objectMapper;
+    @Autowired
+    protected AuthQuery authQuery;
+    @Autowired
+    protected CookieUtil cookieUtil;
+    @Autowired
+    protected TokenProvider tokenProvider;
 
     protected String toJson(Object object) throws JsonProcessingException {
         return objectMapper.writeValueAsString(object);
     }
 
+    @BeforeEach
+    void setUp() {
+        authQuery.deleteAll();
+        setUpMembers();
+    }
+
     public void setUpMembers() {
-        if (loginAdmin != null && loginUser != null) {
+        if (Objects.isNull(loginAdmin) && Objects.isNull(loginUser)) {
             return;
         }
 
-        this.loginAdmin = memberRepository.save(
-                MemberFixture.member("admin@naver.com", "관리자"));
-        this.loginUser = memberRepository.save(
-                MemberFixture.member("user@naver.com", "일반회원"));
+        this.loginAdmin = authQuery.save(MemberFixture.member("admin@naver.com", "관리자"));
+        this.loginUser = authQuery.save(MemberFixture.member("user@naver.com", "일반회원"));
 
-        this.accessTokenOfAdmin = BEARER + "tmpToken";
-        this.accessTokenOfUser = BEARER + "tmpToken";
+        AuthInfo authInfoOfAdmin = getAuthInfo(loginAdmin);
+        AuthInfo authInfoOfUser = getAuthInfo(loginUser);
+
+        this.accessTokenOfAdmin = cookieUtil.createCookie(
+                generateTokens(loginAdmin, authInfoOfAdmin)
+        );
+        this.accessTokenOfUser = cookieUtil.createCookie(
+                generateTokens(loginUser, authInfoOfUser)
+        );
     }
 
-    @BeforeEach
-    void setUp() {
-        memberRepository.deleteAll();
-        setUpMembers();
+    private String generateTokens(Member member, AuthInfo authInfo) {
+        tokenProvider.generateRefreshToken(member, new CustomOauth2User(authInfo),
+                new Date());
+
+        return tokenProvider.generateAccessToken(member, new CustomOauth2User(authInfo),
+                new Date());
     }
+
+    private AuthInfo getAuthInfo(Member member) {
+        return AuthInfo.of(
+                member.getName(),
+                member.getEmail(),
+                member.getRole().getRole()
+        );
+    }
+
+
 }


### PR DESCRIPTION
## 📝 요약(Summary)

- OAuth2 Social Login
  - Kakao Social Login 구현  * 추후 타 소셜 로그인 확장성 고려
  - 회원가입/로그인 분기 처리
- JWT
  - AccessToken + Cookie 방식 도입
  - RefreshToken, OAuth2AccessToken => Redis 저장
- Token Reissue API
  - API 구현
  - Unit Test
- OAuth2 Logout API
  - API 구현
  - Unit Test
- Swagger Authentication
  - 임시 회원가입/로그인 API 구현

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

### 중복 이메일
- 현재 Email 이 Unique 하지 않다고 생가각하는데, Unique 제약 조건을 두고 ** 다른 Provider + 같은 Email  ** 인 경우 이미 회원가입 되어 있다고 분기처리 하는건 어떤가요??  * 한다면 2차 || 3차 MVP로 생각하고 있습니다!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 30분
