### PR TITLE
feat/UDT-20-회원가입_설문조사

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/entity/enums/GenreType.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/enums/GenreType.java
@@ -3,6 +3,7 @@ package com.example.udtbe.domain.content.entity.enums;
 import com.example.udtbe.global.exception.RestApiException;
 import com.example.udtbe.global.exception.code.EnumErrorCode;
 import java.util.Arrays;
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -43,5 +44,17 @@ public enum GenreType {
                 .filter(g -> g.name().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new RestApiException(EnumErrorCode.GENRE_TYPE_NOT_FOUND));
+    }
+
+    public static List<String> toGenreTypes(List<String> types) {
+        return types.stream()
+                .map(type -> Arrays.stream(values())
+                        .filter(g -> g.getType().equals(type))
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new RestApiException(EnumErrorCode.GENRE_TYPE_NOT_FOUND)
+                        )
+                        .name()
+                ).toList();
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/entity/enums/PlatformType.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/enums/PlatformType.java
@@ -3,6 +3,7 @@ package com.example.udtbe.domain.content.entity.enums;
 import com.example.udtbe.global.exception.RestApiException;
 import com.example.udtbe.global.exception.code.EnumErrorCode;
 import java.util.Arrays;
+import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -26,5 +27,17 @@ public enum PlatformType {
                 .filter(p -> p.name().equals(value))
                 .findFirst()
                 .orElseThrow(() -> new RestApiException(EnumErrorCode.PLATFORM_TYPE_NOT_FOUND));
+    }
+
+    public static List<String> toPlatformTypes(List<String> types) {
+        return types.stream()
+                .map(type -> Arrays.stream(values())
+                        .filter(p -> p.getType().equals(type))
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new RestApiException(EnumErrorCode.PLATFORM_TYPE_NOT_FOUND)
+                        )
+                        .name()
+                ).toList();
     }
 }

--- a/src/main/java/com/example/udtbe/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/example/udtbe/domain/survey/controller/SurveyController.java
@@ -1,7 +1,10 @@
 package com.example.udtbe.domain.survey.controller;
 
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
 import com.example.udtbe.domain.survey.service.SurveyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,4 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class SurveyController implements SurveyControllerApiSpec {
 
     private final SurveyService surveyService;
+
+    @Override
+    public ResponseEntity<Void> survey(SurveyCreateRequest request, Member member) {
+        surveyService.createSurvey(request, member);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/survey/controller/SurveyControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/survey/controller/SurveyControllerApiSpec.java
@@ -5,6 +5,7 @@ import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,7 +18,7 @@ public interface SurveyControllerApiSpec {
     @ApiResponse(useReturnTypeSchema = true)
     @PostMapping("/api/survey")
     public ResponseEntity<Void> survey(
-            @RequestBody SurveyCreateRequest request,
+            @RequestBody @Valid SurveyCreateRequest request,
             @AuthenticationPrincipal Member member
     );
 }

--- a/src/main/java/com/example/udtbe/domain/survey/controller/SurveyControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/survey/controller/SurveyControllerApiSpec.java
@@ -1,8 +1,23 @@
 package com.example.udtbe.domain.survey.controller;
 
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "설문조사 API", description = "설문조사 관련 API")
 public interface SurveyControllerApiSpec {
 
+    @Operation(summary = "설문조사 API", description = "콘텐츠 추천 기반 설문조사를 한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/api/survey")
+    public ResponseEntity<Void> survey(
+            @RequestBody SurveyCreateRequest request,
+            @AuthenticationPrincipal Member member
+    );
 }

--- a/src/main/java/com/example/udtbe/domain/survey/dto/SurveyMapper.java
+++ b/src/main/java/com/example/udtbe/domain/survey/dto/SurveyMapper.java
@@ -1,0 +1,27 @@
+package com.example.udtbe.domain.survey.dto;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.domain.content.entity.enums.PlatformType;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
+import com.example.udtbe.domain.survey.entity.Survey;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+
+public class SurveyMapper {
+
+    public static Survey toEntity(SurveyCreateRequest request, Member member) {
+        // TODO : 2차 MVP Contents 변경
+        return Survey.of(
+                PlatformType.toPlatformTypes(request.platforms()),
+                GenreType.toGenreTypes(request.genres()),
+                List.of(""),
+                false,
+                member
+        );
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/survey/dto/request/SurveyCreateRequest.java
+++ b/src/main/java/com/example/udtbe/domain/survey/dto/request/SurveyCreateRequest.java
@@ -5,12 +5,12 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record SurveyCreateRequest(
-        @NotNull
-        @Size(min = 1, max = 7)
+        @NotNull(message = "플랫폼 리스트는 필수 값입니다.")
+        @Size(min = 1, max = 7, message = "OTT 플랫폼은 최소 1개 이상 최대 7개 이하입니다.")
         List<String> platforms,
 
-        @NotNull
-        @Size(min = 1, max = 3)
+        @NotNull(message = "선호 장르는 필수 값입니다.")
+        @Size(min = 1, max = 3, message = "선호 장르는 최소 1개 이상 최대 3개 이하입니다.")
         List<String> genres
 ) {
 

--- a/src/main/java/com/example/udtbe/domain/survey/dto/request/SurveyCreateRequest.java
+++ b/src/main/java/com/example/udtbe/domain/survey/dto/request/SurveyCreateRequest.java
@@ -1,0 +1,17 @@
+package com.example.udtbe.domain.survey.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record SurveyCreateRequest(
+        @NotNull
+        @Size(min = 1, max = 7)
+        List<String> platforms,
+
+        @NotNull
+        @Size(min = 1, max = 3)
+        List<String> genres
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
+++ b/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
@@ -6,8 +6,10 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.entity.TimeBaseEntity;
+import com.example.udtbe.global.util.TagConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -16,6 +18,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,14 +34,17 @@ public class Survey extends TimeBaseEntity {
     @Column(name = "survey_id")
     private Long id;
 
+    @Convert(converter = TagConverter.class)
     @Column(name = "platform_tag", nullable = false)
-    private String platformTag;
+    private List<String> platformTag;
 
+    @Convert(converter = TagConverter.class)
     @Column(name = "genre_tag", nullable = false)
-    private String genreTag;
+    private List<String> genreTag;
 
+    @Convert(converter = TagConverter.class)
     @Column(name = "content_tag")
-    private String contentTag;
+    private List<String> contentTag;
 
     @Column(name = "is_age_rating_limit", nullable = false)
     private boolean isAgeRatingLimit;
@@ -55,7 +61,7 @@ public class Survey extends TimeBaseEntity {
     private Member member;
 
     @Builder(access = PRIVATE)
-    private Survey(String platformTag, String genreTag, String contentTag,
+    private Survey(List<String> platformTag, List<String> genreTag, List<String> contentTag,
             boolean isAgeRatingLimit, boolean isDeleted, Member member) {
         this.platformTag = platformTag;
         this.genreTag = genreTag;
@@ -65,7 +71,8 @@ public class Survey extends TimeBaseEntity {
         this.member = member;
     }
 
-    public static Survey of(String platformTag, String genreTag, String contentTag,
+    public static Survey of(List<String> platformTag, List<String> genreTag,
+            List<String> contentTag,
             boolean isAgeRatingLimit, boolean isDeleted, Member member) {
         return Survey.builder()
                 .platformTag(platformTag)

--- a/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
+++ b/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
@@ -46,9 +46,6 @@ public class Survey extends TimeBaseEntity {
     @Column(name = "content_tag")
     private List<String> contentTag;
 
-    @Column(name = "is_age_rating_limit", nullable = false)
-    private boolean isAgeRatingLimit;
-
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
@@ -62,23 +59,20 @@ public class Survey extends TimeBaseEntity {
 
     @Builder(access = PRIVATE)
     private Survey(List<String> platformTag, List<String> genreTag, List<String> contentTag,
-            boolean isAgeRatingLimit, boolean isDeleted, Member member) {
+            boolean isDeleted, Member member) {
         this.platformTag = platformTag;
         this.genreTag = genreTag;
         this.contentTag = contentTag;
-        this.isAgeRatingLimit = isAgeRatingLimit;
         this.isDeleted = isDeleted;
         this.member = member;
     }
 
     public static Survey of(List<String> platformTag, List<String> genreTag,
-            List<String> contentTag,
-            boolean isAgeRatingLimit, boolean isDeleted, Member member) {
+            List<String> contentTag, boolean isDeleted, Member member) {
         return Survey.builder()
                 .platformTag(platformTag)
                 .genreTag(genreTag)
                 .contentTag(contentTag)
-                .isAgeRatingLimit(isAgeRatingLimit)
                 .isDeleted(isDeleted)
                 .member(member)
                 .build();

--- a/src/main/java/com/example/udtbe/domain/survey/exception/SurveyErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/survey/exception/SurveyErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum SurveyErrorCode implements ErrorCode {
 
     SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, "설문조사를 찾을 수 없습니다."),
-    ;
+    SURVEY_ALREADY_EXISTS_FOR_MEMBER(HttpStatus.CONFLICT, "이미 설문조사를 완료한 회원입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
@@ -1,8 +1,12 @@
 package com.example.udtbe.domain.survey.repository;
 
+import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.entity.Survey;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
+    boolean existsByMember(Member member);
 }

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
@@ -1,5 +1,7 @@
 package com.example.udtbe.domain.survey.service;
 
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.domain.survey.repository.SurveyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -9,4 +11,12 @@ import org.springframework.stereotype.Component;
 public class SurveyQuery {
 
     private final SurveyRepository surveyRepository;
+
+    public boolean existsByMember(Member member) {
+        return surveyRepository.existsByMember(member);
+    }
+
+    public Survey save(Survey survey) {
+        return surveyRepository.save(survey);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
@@ -1,5 +1,11 @@
 package com.example.udtbe.domain.survey.service;
 
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.dto.SurveyMapper;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
+import com.example.udtbe.domain.survey.entity.Survey;
+import com.example.udtbe.domain.survey.exception.SurveyErrorCode;
+import com.example.udtbe.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,4 +14,14 @@ import org.springframework.stereotype.Service;
 public class SurveyService {
 
     private final SurveyQuery surveyQuery;
+
+    public void createSurvey(SurveyCreateRequest request, Member member) {
+        if (surveyQuery.existsByMember(member)) {
+            throw new RestApiException(SurveyErrorCode.SURVEY_ALREADY_EXISTS_FOR_MEMBER);
+        }
+
+        Survey survey = SurveyMapper.toEntity(request, member);
+        surveyQuery.save(survey);
+
+    }
 }

--- a/src/main/java/com/example/udtbe/global/util/CommonConverter.java
+++ b/src/main/java/com/example/udtbe/global/util/CommonConverter.java
@@ -3,12 +3,19 @@ package com.example.udtbe.global.util;
 import static com.example.udtbe.global.exception.CommonErrorCode.INVALID_PARAMETER;
 
 import com.example.udtbe.global.exception.RestApiException;
+import java.util.List;
 import java.util.Objects;
 
 public abstract class CommonConverter {
 
     protected void validateNotNull(Object arg) {
         if (Objects.isNull(arg)) {
+            throw new RestApiException(INVALID_PARAMETER);
+        }
+    }
+
+    protected void validateList(List<String> args) {
+        if (Objects.isNull(args) || args.isEmpty()) {
             throw new RestApiException(INVALID_PARAMETER);
         }
     }

--- a/src/main/java/com/example/udtbe/global/util/TagConverter.java
+++ b/src/main/java/com/example/udtbe/global/util/TagConverter.java
@@ -1,0 +1,25 @@
+package com.example.udtbe.global.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class TagConverter extends CommonConverter implements
+        AttributeConverter<List<String>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public List<String> convertToEntityAttribute(String databaseValue) {
+        validateNotNull(databaseValue);
+        return Arrays.asList(databaseValue.split(DELIMITER));
+    }
+
+    @Override
+    public String convertToDatabaseColumn(List<String> tagList) {
+        validateList(tagList);
+        return String.join(DELIMITER, tagList);
+    }
+}

--- a/src/test/java/com/example/udtbe/common/support/ApiSupport.java
+++ b/src/test/java/com/example/udtbe/common/support/ApiSupport.java
@@ -24,9 +24,11 @@ import org.springframework.test.web.servlet.MockMvc;
 public abstract class ApiSupport extends TestContainerSupport {
 
     protected Member loginAdmin;
-    protected Member loginUser;
-    protected Cookie accessTokenOfUser;
+    protected Member loginMember;
+    protected Member loginTempMember;
     protected Cookie accessTokenOfAdmin;
+    protected Cookie accessTokenOfMember;
+    protected Cookie accessTokenOfTempMember;
     @Autowired
     protected MockMvc mockMvc;
     @Autowired
@@ -49,21 +51,28 @@ public abstract class ApiSupport extends TestContainerSupport {
     }
 
     public void setUpMembers() {
-        if (Objects.isNull(loginAdmin) && Objects.isNull(loginUser)) {
+        if (!Objects.isNull(loginAdmin) && !Objects.isNull(loginMember) && Objects.isNull(
+                loginTempMember)) {
             return;
         }
 
         this.loginAdmin = authQuery.save(MemberFixture.member("admin@naver.com", Role.ROLE_ADMIN));
-        this.loginUser = authQuery.save(MemberFixture.member("user@naver.com", Role.ROLE_USER));
+        this.loginMember = authQuery.save(MemberFixture.member("user@naver.com", Role.ROLE_USER));
+        this.loginTempMember = authQuery.save(
+                MemberFixture.member("tempuser@naver.com", Role.ROLE_GUEST));
 
         AuthInfo authInfoOfAdmin = getAuthInfo(loginAdmin);
-        AuthInfo authInfoOfUser = getAuthInfo(loginUser);
+        AuthInfo authInfoOfMember = getAuthInfo(loginMember);
+        AuthInfo authInfoOfTempMember = getAuthInfo(loginTempMember);
 
         this.accessTokenOfAdmin = cookieUtil.createCookie(
                 generateTokens(loginAdmin, authInfoOfAdmin)
         );
-        this.accessTokenOfUser = cookieUtil.createCookie(
-                generateTokens(loginUser, authInfoOfUser)
+        this.accessTokenOfMember = cookieUtil.createCookie(
+                generateTokens(loginMember, authInfoOfMember)
+        );
+        this.accessTokenOfTempMember = cookieUtil.createCookie(
+                generateTokens(loginTempMember, authInfoOfTempMember)
         );
     }
 

--- a/src/test/java/com/example/udtbe/common/support/DataJpaSupport.java
+++ b/src/test/java/com/example/udtbe/common/support/DataJpaSupport.java
@@ -6,11 +6,9 @@ import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.repository.Repository;
 
-@DataJpaTest(includeFilters = @ComponentScan.Filter(Repository.class))
+@DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({TestJpaAuditingConfig.class, QueryDslConfig.class})
 public abstract class DataJpaSupport extends TestContainerSupport {

--- a/src/test/java/com/example/udtbe/survey/controller/SurveyControllerTest.java
+++ b/src/test/java/com/example/udtbe/survey/controller/SurveyControllerTest.java
@@ -1,0 +1,199 @@
+package com.example.udtbe.survey.controller;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.udtbe.common.support.ApiSupport;
+import com.example.udtbe.domain.member.repository.MemberRepository;
+import com.example.udtbe.domain.survey.controller.SurveyController;
+import com.example.udtbe.domain.survey.dto.SurveyMapper;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
+import com.example.udtbe.domain.survey.repository.SurveyRepository;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SurveyControllerTest extends ApiSupport {
+
+    @Autowired
+    SurveyController surveyController;
+
+    @Autowired
+    SurveyRepository surveyRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        surveyRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @DisplayName("설문조사를 저장한다.")
+    @Test
+    void createSurvey() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디", "범죄");
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isNoContent());
+    }
+
+    @DisplayName("설문조사는 2회 이상 할 수 없다.")
+    @Test
+    void throwExceptionIfSurveyAlreadyExistsForMember() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디", "범죄");
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        surveyRepository.save(SurveyMapper.toEntity(request, loginTempMember));
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("SURVEY_ALREADY_EXISTS_FOR_MEMBER"))
+                .andExpect(jsonPath("$.message").value("이미 설문조사를 완료한 회원입니다."));
+    }
+
+    @DisplayName("설문조사 시 OTT 플랫폼은 필수 값이다.")
+    @Test
+    void throwExceptionIfSurveyPlatformIsNull() throws Exception {
+        // given
+        List<String> platforms = null;
+        List<String> genres = List.of("코미디", "범죄");
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.message").value("플랫폼 리스트는 필수 값입니다."));
+    }
+
+    @DisplayName("설문조사 시 OTT 플랫폼의 최소 선택 갯수는 1개다.")
+    @Test
+    void throwExceptionIfSurveyPlatformCountIsLessThanOne() throws Exception {
+        // given
+        List<String> platforms = Collections.emptyList();
+        List<String> genres = List.of("코미디", "범죄");
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.message").value("OTT 플랫폼은 최소 1개 이상 최대 7개 이하입니다."));
+    }
+
+    @DisplayName("설문조사 시 OTT 플랫폼의 최대 선택 갯수는 7개다.")
+    @Test
+    void throwExceptionIfSurveyPlatformCountExceedsSeven() throws Exception {
+        // given
+        List<String> platforms = List.of(
+                "넷플릭스", "디즈니+", "티빙", "쿠팡플레이", "웨이브", "왓챠", "Apple TV", "유튜브"
+        );
+        List<String> genres = List.of("코미디", "범죄");
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.message").value("OTT 플랫폼은 최소 1개 이상 최대 7개 이하입니다."));
+    }
+
+    @DisplayName("설문조사 시 선호 장르는 필수 값이다.")
+    @Test
+    void throwExceptionIfSurveyGenreIsNull() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = null;
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.message").value("선호 장르는 필수 값입니다."));
+    }
+
+    @DisplayName("설문조사 시 선호 장르는 최소 1개 이상이다.")
+    @Test
+    void throwExceptionIfSurveyGenreCountIsLessThanOne() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = Collections.emptyList();
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.message").value("선호 장르는 최소 1개 이상 최대 3개 이하입니다."));
+    }
+
+    @DisplayName("설문조사 시 선호 장르는 최대 3개다.")
+    @Test
+    void throwExceptionIfSurveyGenreCountExceedsThree() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디", "범죄", "액션", "뮤지컬");
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.message").value("선호 장르는 최소 1개 이상 최대 3개 이하입니다."));
+    }
+}

--- a/src/test/java/com/example/udtbe/survey/repository/SurveyRepositoryTest.java
+++ b/src/test/java/com/example/udtbe/survey/repository/SurveyRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.example.udtbe.survey.repository;
+
+import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_GUEST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.common.support.DataJpaSupport;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.domain.content.entity.enums.PlatformType;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.repository.MemberRepository;
+import com.example.udtbe.domain.survey.dto.SurveyMapper;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
+import com.example.udtbe.domain.survey.entity.Survey;
+import com.example.udtbe.domain.survey.repository.SurveyRepository;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SurveyRepositoryTest extends DataJpaSupport {
+
+    @Autowired
+    SurveyRepository surveyRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @DisplayName("설문조사를 저장한다.")
+    @Test
+    void saveSurvey() {
+        // given
+        final String email = "test@naver.com";
+
+        Member member = MemberFixture.member(email, ROLE_GUEST);
+        Member savedMember = memberRepository.save(member);
+
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디", "범죄");
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        List<String> platformTypes = PlatformType.toPlatformTypes(platforms);
+        List<String> genreTypes = GenreType.toGenreTypes(genres);
+
+        Survey survey = SurveyMapper.toEntity(request, savedMember);
+
+        // when
+        Survey savedSurvey = surveyRepository.save(survey);
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(savedSurvey.getPlatformTag()).containsExactly(
+                        platformTypes.get(0),
+                        platformTypes.get(1)
+                ),
+                () -> assertThat(savedSurvey.getGenreTag()).containsExactly(
+                        genreTypes.get(0),
+                        genreTypes.get(1)
+                )
+        );
+
+    }
+}

--- a/src/test/java/com/example/udtbe/survey/service/SurveyServiceTest.java
+++ b/src/test/java/com/example/udtbe/survey/service/SurveyServiceTest.java
@@ -1,0 +1,78 @@
+package com.example.udtbe.survey.service;
+
+import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_GUEST;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
+import com.example.udtbe.domain.survey.entity.Survey;
+import com.example.udtbe.domain.survey.exception.SurveyErrorCode;
+import com.example.udtbe.domain.survey.service.SurveyQuery;
+import com.example.udtbe.domain.survey.service.SurveyService;
+import com.example.udtbe.global.exception.RestApiException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SurveyServiceTest {
+
+    @Mock
+    SurveyQuery surveyQuery;
+
+    @InjectMocks
+    SurveyService surveyService;
+
+    @DisplayName("설문조사를 저장한다.")
+    @Test
+    void createSurvey() {
+        // given
+        final String email = "test@naver.com";
+
+        Member member = MemberFixture.member(email, ROLE_GUEST);
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디", "범죄");
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        BDDMockito.given(surveyQuery.existsByMember(member)).willReturn(Boolean.FALSE);
+        BDDMockito.given(surveyQuery.save(any(Survey.class))).willReturn(any(Survey.class));
+
+        // when
+        surveyService.createSurvey(request, member);
+
+        // then
+        assertAll(
+                () -> verify(surveyQuery, times(1)).existsByMember(member),
+                () -> verify(surveyQuery, times(1)).save(any(Survey.class))
+        );
+    }
+
+    @DisplayName("설문조사는 2회 이상 할 수 없다.")
+    @Test
+    void throwExceptionIfSurveyAlreadyExists() {
+        // given
+        final String email = "test@naver.com";
+
+        Member member = MemberFixture.member(email, ROLE_GUEST);
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디", "범죄");
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+
+        BDDMockito.given(surveyQuery.existsByMember(member)).willReturn(Boolean.TRUE);
+
+        // when  // then
+        assertThatThrownBy(() -> surveyService.createSurvey(request, member))
+                .isInstanceOf(RestApiException.class)
+                .hasMessage(SurveyErrorCode.SURVEY_ALREADY_EXISTS_FOR_MEMBER.getMessage());
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- Survay Save API  * 1차 MVP(OTT 플랫폼, 장르)
  - OTT Platform, Genre, Content Tag 형식 저장을 위한 `TagConverter.Class` 추가
  - OTT Platform, Genre, Content 각 Enum 상수명 저장을 위한 `toXXXTypes()` 추가

- Test
  - Repository 단위 테스트
  - Service 단위 테스트
  - Controller 통합 테스트 및 Request 경계값 테스트
  - ApiSupport
    - 설문조사 로직 통합 테스트를 위한 LoginTempMember 및 관련 JWT Setup() 추가
  - DataJpaSupport
    - `@DataJpaTest(ComponentScan)` 관련 문제 해결을 위해 ComponentScan 제거

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- Repository 단위 테스트 시 XXXQuery.Class도 단위 테스트를 따로 해야할지 고민입니다..

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분
