### PR TITLE
fix/UDT-54-설문조사-Content-Validtaion-수정

### DIFF
--- a/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
+++ b/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
@@ -6,6 +6,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.entity.TimeBaseEntity;
+import com.example.udtbe.global.util.OptionalTagConverter;
 import com.example.udtbe.global.util.TagConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -42,7 +43,7 @@ public class Survey extends TimeBaseEntity {
     @Column(name = "genre_tag", nullable = false)
     private List<String> genreTag;
 
-    @Convert(converter = TagConverter.class)
+    @Convert(converter = OptionalTagConverter.class)
     @Column(name = "content_tag")
     private List<String> contentTag;
 

--- a/src/main/java/com/example/udtbe/global/util/OptionalTagConverter.java
+++ b/src/main/java/com/example/udtbe/global/util/OptionalTagConverter.java
@@ -1,0 +1,32 @@
+package com.example.udtbe.global.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.springframework.util.StringUtils;
+
+@Converter
+public class OptionalTagConverter extends CommonConverter implements
+        AttributeConverter<List<String>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public List<String> convertToEntityAttribute(String databaseValue) {
+        if (!StringUtils.hasText(databaseValue)) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(databaseValue.split(DELIMITER));
+    }
+
+    @Override
+    public String convertToDatabaseColumn(List<String> tagList) {
+        if (Objects.isNull(tagList) || tagList.isEmpty()) {
+            return null;
+        }
+        return String.join(DELIMITER, tagList);
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/SurveyFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/SurveyFixture.java
@@ -1,0 +1,33 @@
+package com.example.udtbe.common.fixture;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.entity.Survey;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class SurveyFixture {
+
+    public static Survey survey(List<String> platformTypes, List<String> genreTypes,
+            Member member) {
+        return Survey.of(
+                platformTypes,
+                genreTypes,
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey survey(List<String> contents, Member member) {
+        return Survey.of(
+                List.of("TVING", "WAVVE"),
+                List.of("CRIME", "THRILLER"),
+                contents,
+                false,
+                member
+        );
+    }
+}

--- a/src/test/java/com/example/udtbe/survey/repository/SurveyRepositoryTest.java
+++ b/src/test/java/com/example/udtbe/survey/repository/SurveyRepositoryTest.java
@@ -4,12 +4,12 @@ import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_GUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.common.fixture.SurveyFixture;
 import com.example.udtbe.common.support.DataJpaSupport;
 import com.example.udtbe.domain.content.entity.enums.GenreType;
 import com.example.udtbe.domain.content.entity.enums.PlatformType;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.repository.MemberRepository;
-import com.example.udtbe.domain.survey.dto.SurveyMapper;
 import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
 import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.domain.survey.repository.SurveyRepository;
@@ -43,7 +43,7 @@ class SurveyRepositoryTest extends DataJpaSupport {
         List<String> platformTypes = PlatformType.toPlatformTypes(platforms);
         List<String> genreTypes = GenreType.toGenreTypes(genres);
 
-        Survey survey = SurveyMapper.toEntity(request, savedMember);
+        Survey survey = SurveyFixture.survey(platformTypes, genreTypes, member);
 
         // when
         Survey savedSurvey = surveyRepository.save(survey);
@@ -54,11 +54,28 @@ class SurveyRepositoryTest extends DataJpaSupport {
                         platformTypes.get(0),
                         platformTypes.get(1)
                 ),
+                // given
                 () -> assertThat(savedSurvey.getGenreTag()).containsExactly(
                         genreTypes.get(0),
                         genreTypes.get(1)
                 )
         );
+    }
 
+    @DisplayName("선택된 콘텐츠가 없어도 설문조사를 저장한다.")
+    @Test
+    void saveSurveyWhenContentsIsNull() {
+        final String email = "test@naver.com";
+
+        Member member = MemberFixture.member(email, ROLE_GUEST);
+        Member savedMember = memberRepository.save(member);
+
+        Survey survey = SurveyFixture.survey(null, member);
+
+        // when
+        Survey savedSurvey = surveyRepository.save(survey);
+
+        // then
+        assertThat(savedSurvey.getContentTag()).isNull();
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

- Survey Content가 Null일 경우를 고려해 Converter 변경 및 단위 테스트 작성

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- AttributeConverte 내부 로직 중 DB에서 Value 조회 시 Value가 NULL일 경우 AttributeConverter 구현체를 지나지 않고 바로 Null을 반환하는 로직을 알게 되었습니다! 관련 내용 노션 문서화 하겠습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
