### PR TITLE
feat/UDT-71-JWT-Cookie-Domain-지정

### DIFF
--- a/src/main/java/com/example/udtbe/global/token/cookie/DevCookie.java
+++ b/src/main/java/com/example/udtbe/global/token/cookie/DevCookie.java
@@ -13,7 +13,7 @@ public class DevCookie implements CookieConfig {
     public Cookie createCookie(String token) {
         Cookie cookie = new Cookie("Authorization", token);
         cookie.setPath("/");
-        cookie.setDomain("yourstie.com");
+        cookie.setDomain("banditbool.com");
         cookie.setMaxAge(60 * 180);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
@@ -25,7 +25,7 @@ public class DevCookie implements CookieConfig {
     public void deleteCookie(HttpServletResponse response) {
         Cookie cookie = new Cookie("Authorization", null);
         cookie.setPath("/");
-        cookie.setDomain("yourstie.com");
+        cookie.setDomain("banditbool.com");
         cookie.setMaxAge(0);
         cookie.setHttpOnly(true);
         cookie.setSecure(true);


### PR DESCRIPTION
## 📝 요약(Summary)

- 개발 서버 Swagger JWT Cookie 저장 실패하는 문제 해결
  - 개발 서버용 Cookie 세부 설정 변경
    - setDomain("banditbool.com")

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 1분
