### PR TITLE
feat/UDT-61-회원-정보-조회

### DIFF
--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
@@ -1,7 +1,10 @@
 package com.example.udtbe.domain.member.controller;
 
+import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -10,5 +13,10 @@ public class MemberController implements MemberControllerApiSpec {
 
     private final MemberService memberService;
 
+    @Override
+    public ResponseEntity<MemberInfoResponse> getMemberInfo(Member member) {
+        MemberInfoResponse response = memberService.getMemberInfo(member.getId());
+        return ResponseEntity.ok(response);
+    }
 
 }

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
@@ -1,8 +1,23 @@
 package com.example.udtbe.domain.member.controller;
 
+import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "Member API", description = "회원 관련 API")
+@RequestMapping("/api")
 public interface MemberControllerApiSpec {
 
+    @Operation(summary = "마이페이지에서 유저 정보 조회 API")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/users/me")
+    ResponseEntity<MemberInfoResponse> getMemberInfo(
+            @AuthenticationPrincipal Member member
+    );
 }

--- a/src/main/java/com/example/udtbe/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/example/udtbe/domain/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,13 @@
+package com.example.udtbe.domain.member.dto.response;
+
+import java.util.List;
+
+public record MemberInfoResponse(
+        String name,
+        String email,
+        List<String> platforms,
+        List<String> genres,
+        String profileImageUrl
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/udtbe/domain/member/repository/MemberRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findMemberById(Long id);
+
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/example/udtbe/domain/member/service/MemberQuery.java
+++ b/src/main/java/com/example/udtbe/domain/member/service/MemberQuery.java
@@ -1,6 +1,9 @@
 package com.example.udtbe.domain.member.service;
 
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.exception.MemberErrorCode;
 import com.example.udtbe.domain.member.repository.MemberRepository;
+import com.example.udtbe.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -9,4 +12,10 @@ import org.springframework.stereotype.Component;
 public class MemberQuery {
 
     private final MemberRepository memberRepository;
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findMemberById(memberId)
+                .orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
@@ -1,11 +1,32 @@
 package com.example.udtbe.domain.member.service;
 
+import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.entity.Survey;
+import com.example.udtbe.domain.survey.service.SurveyQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberQuery memberQuery;
+    private final SurveyQuery surveyQuery;
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMemberInfo(Long memberId) {
+
+        Member member = memberQuery.findMemberById(memberId);
+        Survey survey = surveyQuery.findSurveyByMemberId(memberId);
+
+        return new MemberInfoResponse(
+                member.getName(),
+                member.getEmail(),
+                survey.getGenreTag(),
+                survey.getPlatformTag(),
+                member.getProfileImageUrl());
+
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
@@ -24,8 +24,8 @@ public class MemberService {
         return new MemberInfoResponse(
                 member.getName(),
                 member.getEmail(),
-                survey.getGenreTag(),
                 survey.getPlatformTag(),
+                survey.getGenreTag(),
                 member.getProfileImageUrl());
 
     }

--- a/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
@@ -2,11 +2,14 @@ package com.example.udtbe.domain.survey.repository;
 
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.entity.Survey;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+    Optional<Survey> findSurveyByMemberId(Long Long);
 
     boolean existsByMember(Member member);
 }

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
@@ -2,7 +2,9 @@ package com.example.udtbe.domain.survey.service;
 
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.entity.Survey;
+import com.example.udtbe.domain.survey.exception.SurveyErrorCode;
 import com.example.udtbe.domain.survey.repository.SurveyRepository;
+import com.example.udtbe.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,5 +20,10 @@ public class SurveyQuery {
 
     public Survey save(Survey survey) {
         return surveyRepository.save(survey);
+    }
+
+    public Survey findSurveyByMemberId(Long memberId) {
+        return surveyRepository.findSurveyByMemberId(memberId)
+                .orElseThrow(() -> new RestApiException(SurveyErrorCode.SURVEY_NOT_FOUND));
     }
 }

--- a/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
@@ -1,7 +1,21 @@
 package com.example.udtbe.member.service;
 
+import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.common.fixture.SurveyFixture;
+import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.service.MemberQuery;
 import com.example.udtbe.domain.member.service.MemberService;
+import com.example.udtbe.domain.survey.entity.Survey;
+import com.example.udtbe.domain.survey.service.SurveyQuery;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -13,6 +27,38 @@ class MemberServiceTest {
     @Mock
     private MemberQuery memberQuery;
 
+    @Mock
+    private SurveyQuery surveyQuery;
+
     @InjectMocks
     private MemberService memberService;
+
+    @DisplayName("마이페이지에서 회원 정보를 조회한다.")
+    @Test
+    void getMemberInfo() {
+        // given
+        final String email = "test@email.com";
+
+        Member member = MemberFixture.member(email, ROLE_USER);
+        Survey survey = SurveyFixture.survey(null, member);
+
+        given(memberQuery.findMemberById(member.getId())).willReturn(member);
+        given(surveyQuery.findSurveyByMemberId(member.getId())).willReturn(survey);
+
+        // when
+        MemberInfoResponse response = memberService.getMemberInfo(member.getId());
+
+        // then
+        then(memberQuery).should().findMemberById(member.getId());
+        then(surveyQuery).should().findSurveyByMemberId(survey.getId());
+
+        assertAll(
+                () -> assertThat(response.name()).isEqualTo(member.getName()),
+                () -> assertThat(response.email()).isEqualTo(member.getEmail()),
+                () -> assertThat(response.platforms()).isEqualTo(survey.getPlatformTag()),
+                () -> assertThat(response.genres()).isEqualTo(survey.getGenreTag()),
+                () -> assertThat(response.profileImageUrl()).isEqualTo(member.getProfileImageUrl())
+        );
+
+    }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
**마이페이지에서 회원 정보를 조회** API를 개발했습니다.
조회하는 정보
- 이름
- 이메일
- 프로필 사진
- 구독 플랫폼
- 선호 장르

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
