### PR TITLE
feat/UDT-63-회원-선호-장르-수정

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/entity/enums/GenreType.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/enums/GenreType.java
@@ -50,7 +50,7 @@ public enum GenreType {
         return Arrays.stream(values())
                 .filter(g -> g.getType().equals(value))
                 .findFirst()
-                .orElseThrow(() -> new RestApiException(EnumErrorCode.CATEGORY_TYPE_BAD_REQUEST));
+                .orElseThrow(() -> new RestApiException(EnumErrorCode.GENRE_TYPE_BAD_REQUEST));
     }
 
     public static List<String> toGenreTypes(List<String> types) {

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.example.udtbe.domain.member.controller;
 
+import com.example.udtbe.domain.member.dto.request.MemberUpdateGenreRequest;
 import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.dto.response.MemberUpdateGenreResponse;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,15 @@ public class MemberController implements MemberControllerApiSpec {
     public ResponseEntity<MemberInfoResponse> getMemberInfo(Member member) {
         MemberInfoResponse response = memberService.getMemberInfo(member.getId());
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<MemberUpdateGenreResponse> updateSurveyGenres(Member member,
+            MemberUpdateGenreRequest memberUpdateGenreRequest) {
+
+        MemberUpdateGenreResponse memberUpdateGenreResponse = memberService.updateMemberGenres(
+                member.getId(), memberUpdateGenreRequest);
+        return ResponseEntity.ok(memberUpdateGenreResponse);
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
@@ -7,6 +7,7 @@ import com.example.udtbe.domain.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,6 +31,6 @@ public interface MemberControllerApiSpec {
     @PatchMapping("/users/survey/genre")
     ResponseEntity<MemberUpdateGenreResponse> updateSurveyGenres(
             @AuthenticationPrincipal Member member,
-            @RequestBody MemberUpdateGenreRequest memberUpdateGenreRequest
+            @Valid @RequestBody MemberUpdateGenreRequest memberUpdateGenreRequest
     );
 }

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
@@ -1,6 +1,8 @@
 package com.example.udtbe.domain.member.controller;
 
+import com.example.udtbe.domain.member.dto.request.MemberUpdateGenreRequest;
 import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.dto.response.MemberUpdateGenreResponse;
 import com.example.udtbe.domain.member.entity.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,6 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Tag(name = "Member API", description = "회원 관련 API")
@@ -19,5 +23,13 @@ public interface MemberControllerApiSpec {
     @GetMapping("/users/me")
     ResponseEntity<MemberInfoResponse> getMemberInfo(
             @AuthenticationPrincipal Member member
+    );
+
+    @Operation(summary = "마이페이지에서 유저 선호 장르 수정")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PatchMapping("/users/survey/genre")
+    ResponseEntity<MemberUpdateGenreResponse> updateSurveyGenres(
+            @AuthenticationPrincipal Member member,
+            @RequestBody MemberUpdateGenreRequest memberUpdateGenreRequest
     );
 }

--- a/src/main/java/com/example/udtbe/domain/member/dto/request/MemberUpdateGenreRequest.java
+++ b/src/main/java/com/example/udtbe/domain/member/dto/request/MemberUpdateGenreRequest.java
@@ -1,0 +1,9 @@
+package com.example.udtbe.domain.member.dto.request;
+
+import java.util.List;
+
+public record MemberUpdateGenreRequest(
+        List<String> genres
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/member/dto/request/MemberUpdateGenreRequest.java
+++ b/src/main/java/com/example/udtbe/domain/member/dto/request/MemberUpdateGenreRequest.java
@@ -1,8 +1,13 @@
 package com.example.udtbe.domain.member.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record MemberUpdateGenreRequest(
+
+        @NotNull(message = "장르 선택은 필수 입니다.")
+        @Size(min = 1, max = 3, message = "장르 수정은 최소 1개 이상 최대 3개 이하입니다.")
         List<String> genres
 ) {
 

--- a/src/main/java/com/example/udtbe/domain/member/dto/response/MemberUpdateGenreResponse.java
+++ b/src/main/java/com/example/udtbe/domain/member/dto/response/MemberUpdateGenreResponse.java
@@ -1,0 +1,9 @@
+package com.example.udtbe.domain.member.dto.response;
+
+import java.util.List;
+
+public record MemberUpdateGenreResponse(
+        List<String> genres
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
@@ -1,9 +1,13 @@
 package com.example.udtbe.domain.member.service;
 
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.domain.member.dto.request.MemberUpdateGenreRequest;
 import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.dto.response.MemberUpdateGenreResponse;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.domain.survey.service.SurveyQuery;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,4 +33,20 @@ public class MemberService {
                 member.getProfileImageUrl());
 
     }
+
+    @Transactional
+    public MemberUpdateGenreResponse updateMemberGenres(Long memberId,
+            MemberUpdateGenreRequest memberUpdateGenreRequest) {
+        Survey survey = surveyQuery.findSurveyByMemberId(memberId);
+
+        List<String> genres = memberUpdateGenreRequest.genres().stream().map(genreType ->
+                GenreType.fromByType(genreType).name()
+        ).toList();
+
+        survey.updateGenreTag(genres);
+
+        return new MemberUpdateGenreResponse(memberUpdateGenreRequest.genres());
+    }
+
+
 }

--- a/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
+++ b/src/main/java/com/example/udtbe/domain/survey/entity/Survey.java
@@ -78,4 +78,8 @@ public class Survey extends TimeBaseEntity {
                 .member(member)
                 .build();
     }
+
+    public void updateGenreTag(List<String> genreTag) {
+        this.genreTag = genreTag;
+    }
 }

--- a/src/test/java/com/example/udtbe/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/udtbe/member/controller/MemberControllerTest.java
@@ -1,9 +1,22 @@
 package com.example.udtbe.member.controller;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.example.udtbe.common.support.ApiSupport;
+import com.example.udtbe.domain.member.dto.request.MemberUpdateGenreRequest;
 import com.example.udtbe.domain.member.repository.MemberRepository;
+import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
+import com.example.udtbe.domain.survey.repository.SurveyRepository;
+import com.example.udtbe.global.exception.code.EnumErrorCode;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("[MemberController] 통합테스트")
@@ -11,9 +24,78 @@ class MemberControllerTest extends ApiSupport {
 
     @Autowired
     MemberRepository memberRepository;
+    @Autowired
+    SurveyRepository surveyRepository;
+
+    @BeforeEach
+    void setup() throws Exception {
+
+    }
 
     @AfterEach
     void tearDown() {
+        surveyRepository.deleteAll();
         memberRepository.deleteAll();
     }
+
+    @DisplayName("마이페이지에서 회원 선호 장르를 수정한다.")
+    @Test
+    void updateGenre() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디");
+
+        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(platforms, genres);
+
+        mockMvc.perform(post("/api/survey")
+                .content(toJson(surveyCreateRequest))
+                .contentType(APPLICATION_JSON)
+                .cookie(accessTokenOfTempMember)
+        );
+
+        MemberUpdateGenreRequest memberUpdateGenreRequest = new MemberUpdateGenreRequest(
+                List.of("서사/드라마", "키즈")
+        );
+
+        mockMvc.perform(patch("/api/users/survey/genre")
+                        .content(toJson(memberUpdateGenreRequest))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                ).andExpect(status().isOk())
+                .andExpect(jsonPath("$.genres.size()").value(
+                        memberUpdateGenreRequest.genres().size()));
+    }
+
+    @DisplayName("마이페이지에서 올바르지 않은 장르타입으로 수정 시 400에러가 나온다.")
+    @Test
+    void updateInvalidGenre() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디");
+
+        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(platforms, genres);
+
+        mockMvc.perform(post("/api/survey")
+                .content(toJson(surveyCreateRequest))
+                .contentType(APPLICATION_JSON)
+                .cookie(accessTokenOfTempMember)
+        );
+
+        MemberUpdateGenreRequest memberUpdateGenreRequest = new MemberUpdateGenreRequest(
+                List.of("할래말래", "키즈")
+        );
+
+        // when & then
+        mockMvc.perform(patch("/api/users/survey/genre")
+                        .content(toJson(memberUpdateGenreRequest))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                ).andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(
+                        EnumErrorCode.GENRE_TYPE_BAD_REQUEST.name()))
+                .andExpect(jsonPath("$.message").value(
+                        EnumErrorCode.GENRE_TYPE_BAD_REQUEST.getMessage()));
+    }
+
+
 }

--- a/src/test/java/com/example/udtbe/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/udtbe/member/controller/MemberControllerTest.java
@@ -14,7 +14,6 @@ import com.example.udtbe.domain.survey.repository.SurveyRepository;
 import com.example.udtbe.global.exception.code.EnumErrorCode;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,11 +25,6 @@ class MemberControllerTest extends ApiSupport {
     MemberRepository memberRepository;
     @Autowired
     SurveyRepository surveyRepository;
-
-    @BeforeEach
-    void setup() throws Exception {
-
-    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/com/example/udtbe/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/example/udtbe/member/repository/MemberRepositoryTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("[MemberRepository 테스트]")
-class MemberRepository extends DataJpaSupport {
+class MemberRepositoryTest extends DataJpaSupport {
 
     @Autowired
     MemberQuery memberQuery;

--- a/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
@@ -2,18 +2,26 @@ package com.example.udtbe.member.service;
 
 import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_USER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import com.example.udtbe.common.fixture.MemberFixture;
 import com.example.udtbe.common.fixture.SurveyFixture;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.domain.member.dto.request.MemberUpdateGenreRequest;
 import com.example.udtbe.domain.member.dto.response.MemberInfoResponse;
+import com.example.udtbe.domain.member.dto.response.MemberUpdateGenreResponse;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.service.MemberQuery;
 import com.example.udtbe.domain.member.service.MemberService;
 import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.domain.survey.service.SurveyQuery;
+import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.exception.code.EnumErrorCode;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,5 +68,58 @@ class MemberServiceTest {
                 () -> assertThat(response.profileImageUrl()).isEqualTo(member.getProfileImageUrl())
         );
 
+    }
+
+    @DisplayName("마이페이지에서 회원 선호 장르를 수정한다.")
+    @Test
+    void updateGenre() {
+        // given
+        final MemberUpdateGenreRequest request = new MemberUpdateGenreRequest(
+                List.of("키즈", "액션")
+        );
+
+        final String email = "test@email.com";
+
+        Member member = MemberFixture.member(email, ROLE_USER);
+        Survey survey = SurveyFixture.survey(List.of("NETFLIX"), List.of("SF", "ROMANCE"), member);
+
+        given(surveyQuery.findSurveyByMemberId(member.getId())).willReturn(survey);
+        // when
+        MemberUpdateGenreResponse response =
+                memberService.updateMemberGenres(member.getId(), request);
+
+        // then
+        then(surveyQuery).should().findSurveyByMemberId(member.getId());
+        assertAll(
+                () -> assertEquals(
+                        request.genres().stream()
+                                .map(e -> GenreType.fromByType(e).name()).toList(),
+                        response.genres()),
+                () -> assertEquals(
+                        request.genres().stream()
+                                .map(e -> GenreType.fromByType(e).name()).toList(),
+                        survey.getGenreTag())
+        );
+    }
+
+    @DisplayName("마이페이지에서 올바르지 않은 장르타입으로 수정 시 400에러가 나온다.")
+    @Test
+    public void updateInvalidGenre() {
+        // given
+        final MemberUpdateGenreRequest request = new MemberUpdateGenreRequest(
+                List.of("엥?", "액션")
+        );
+
+        final String email = "test@email.com";
+
+        Member member = MemberFixture.member(email, ROLE_USER);
+        Survey survey = SurveyFixture.survey(List.of("NETFLIX"), List.of("SF", "ROMANCE"), member);
+
+        given(surveyQuery.findSurveyByMemberId(member.getId())).willReturn(survey);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateMemberGenres(member.getId(), request))
+                .isInstanceOf(RestApiException.class)
+                .hasMessage(EnumErrorCode.GENRE_TYPE_BAD_REQUEST.getMessage());
     }
 }

--- a/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
@@ -91,10 +91,7 @@ class MemberServiceTest {
         // then
         then(surveyQuery).should().findSurveyByMemberId(member.getId());
         assertAll(
-                () -> assertEquals(
-                        request.genres().stream()
-                                .map(e -> GenreType.fromByType(e).name()).toList(),
-                        response.genres()),
+                () -> assertEquals(request.genres(), response.genres()),
                 () -> assertEquals(
                         request.genres().stream()
                                 .map(e -> GenreType.fromByType(e).name()).toList(),

--- a/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
@@ -41,7 +41,7 @@ class MemberServiceTest {
     @InjectMocks
     private MemberService memberService;
 
-    @DisplayName("마이페이지에서 회원 정보를 조회한다.")
+    @DisplayName("마이페이지에서 회원 정보를 조회할 수 있다..")
     @Test
     void getMemberInfo() {
         // given
@@ -70,7 +70,7 @@ class MemberServiceTest {
 
     }
 
-    @DisplayName("마이페이지에서 회원 선호 장르를 수정한다.")
+    @DisplayName("마이페이지에서 회원 선호 장르를 수정할 수 있다.")
     @Test
     void updateGenre() {
         // given
@@ -99,7 +99,7 @@ class MemberServiceTest {
         );
     }
 
-    @DisplayName("마이페이지에서 올바르지 않은 장르타입으로 수정 시 400에러가 나온다.")
+    @DisplayName("마이페이지에서 올바르지 않은 장르타입으로 수정할 수 없다.")
     @Test
     public void updateInvalidGenre() {
         // given


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
**회원 선호 장르 수정 API 개발**
- 회원가입 시 설문조사로 받은 선호 장르를 마이페이지를 통해 수정할 수 있습니다.
- 변경된 선호 장르를 바탕으로 콘텐츠 추천 알고리즘이 반영이 될 것입니다.

**테스트**
- service, controller테스트 진행

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [v] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [v] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
