### PR TITLE
Feat/udt 22 추천 콘텐츠 알고리즘

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,14 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    /* 추천 Lucene 라이브러리 */
+    implementation 'org.apache.lucene:lucene-core:9.12.2'
+    implementation 'org.apache.lucene:lucene-analysis-common:9.12.2'
+    implementation 'org.apache.lucene:lucene-queryparser:9.12.2'
+
+    /* 한국어 분석기 (Nori) */
+    implementation 'org.apache.lucene:lucene-analysis-nori:9.12.2'
+
     /* test */
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
@@ -1,12 +1,29 @@
 package com.example.udtbe.domain.content.controller;
 
-import com.example.udtbe.domain.content.service.RecommendContentService;
+import com.example.udtbe.domain.content.dto.ContentRecommendationResponse;
+import com.example.udtbe.domain.content.service.ContentRecommendationService;
+import com.example.udtbe.domain.member.entity.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class RecommendContentController implements RecommendContentControllerApiSpec {
 
-    private final RecommendContentService recommendContentService;
+    private final ContentRecommendationService contentRecommendationService;
+
+    @Override
+    public ResponseEntity<List<ContentRecommendationResponse>> getRecommendations(
+            @AuthenticationPrincipal Member member,
+            @RequestParam(defaultValue = "10") int limit) {
+        List<ContentRecommendationResponse> recommendations = contentRecommendationService.recommendContents(
+                member,
+                limit);
+
+        return ResponseEntity.ok(recommendations);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
@@ -1,8 +1,41 @@
 package com.example.udtbe.domain.content.controller;
 
+import com.example.udtbe.domain.content.dto.ContentRecommendationResponse;
+import com.example.udtbe.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name = "콘텐츠 추천 API", description = "콘텐츠 추천 관련 API")
+@Tag(name = "Content Recommendation API", description = "콘텐츠 추천 관련 API")
+@RequestMapping("/api/v1/contents")
 public interface RecommendContentControllerApiSpec {
 
+    @Operation(
+            summary = "개인화 콘텐츠 추천 API",
+            description = "사용자의 설문조사 결과 기반으로 개인화된 콘텐츠를 추천합니다. " +
+                    "개인화 추천이 불가능한 경우 인기 콘텐츠를 제공합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "추천 콘텐츠 목록 조회 성공",
+            useReturnTypeSchema = true
+    )
+    @GetMapping("/recommendations")
+    ResponseEntity<List<ContentRecommendationResponse>> getRecommendations(
+            @Parameter(description = "인증된 사용자 정보", required = true)
+            @AuthenticationPrincipal Member member,
+
+            @Parameter(
+                    description = "추천 콘텐츠 개수 (기본값: 10, 최소값: 5)",
+                    example = "10"
+            )
+            @RequestParam(defaultValue = "10") int limit
+    );
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/ContentRecommendation.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/ContentRecommendation.java
@@ -1,0 +1,5 @@
+package com.example.udtbe.domain.content.dto;
+
+public record ContentRecommendation(Long contentId, float score) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/content/dto/ContentRecommendationResponse.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/ContentRecommendationResponse.java
@@ -1,0 +1,138 @@
+package com.example.udtbe.domain.content.dto;
+
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.enums.CategoryType;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.domain.content.entity.enums.PlatformType;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public record ContentRecommendationResponse(
+        Long contentId,
+        String title,
+        String description,
+        String posterUrl,
+        String backdropUrl,
+        String openDate,
+        int runningTime,
+        String episode,
+        String rating,
+        String category,
+        List<String> genres,
+        List<String> directors,
+        List<String> platforms
+) {
+
+    public static ContentRecommendationResponse of(Content content, ContentMetadata metadata) {
+        return new ContentRecommendationResponse(
+                content.getId(),
+                content.getTitle(),
+                content.getDescription(),
+                content.getPosterUrl(),
+                content.getBackdropUrl(),
+                content.getOpenDate() != null ? content.getOpenDate().toLocalDate().toString()
+                        : null,
+                content.getRunningTime(),
+                content.getEpisode() != 0 ? content.getEpisode() + "회차" : "에피소드 없음",
+                content.getRating(),
+//                metadata.getCategoryTag() != null && !metadata.getCategoryTag().isEmpty()
+//                        ? metadata.getCategoryTag().get(0) : null,
+                convertCategoryToKorean(metadata.getCategoryTag()),
+//                metadata.getGenreTag() != null ? metadata.getGenreTag() : List.of(),
+                convertGenresToKorean(metadata.getGenreTag()),
+                metadata.getDirectorTag() != null ? metadata.getDirectorTag() : List.of(),
+//                metadata.getPlatformTag() != null ? metadata.getPlatformTag() : List.of()
+                convertPlatformsToKorean(metadata.getPlatformTag())
+        );
+    }
+
+
+    public static List<ContentRecommendationResponse> of(
+            List<Content> contents,
+            List<ContentMetadata> metadataList) {
+
+        // ContentMetadata를 contentId 기준으로 맵으로 변환
+        Map<Long, ContentMetadata> metadataMap = metadataList.stream()
+                .collect(Collectors.toMap(
+                        metadata -> metadata.getContent().getId(),
+                        metadata -> metadata
+                ));
+
+        // Content와 해당하는 ContentMetadata를 매핑하여 Response 생성
+        return contents.stream()
+                .map(content -> {
+                    ContentMetadata metadata = metadataMap.get(content.getId());
+                    if (metadata != null) {
+                        return of(content, metadata);
+                    }
+                    // metadata가 없는 경우 기본값으로 처리 (또는 예외 처리)
+                    return createDefaultResponse(content);
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private static ContentRecommendationResponse createDefaultResponse(Content content) {
+        return new ContentRecommendationResponse(
+                content.getId(),
+                content.getTitle(),
+                content.getDescription(),
+                content.getPosterUrl(),
+                content.getBackdropUrl(),
+                content.getOpenDate() != null ? content.getOpenDate().toLocalDate().toString()
+                        : null,
+                content.getRunningTime(),
+                content.getEpisode() != 0 ? content.getEpisode() + "회차" : "에피소드 없음",
+                content.getRating(),
+                null, // category
+                List.of(), // genres
+                List.of(), // directors
+                List.of()  // platforms
+        );
+
+    }
+
+    private static String convertCategoryToKorean(List<String> categoryTags) {
+        if (categoryTags == null || categoryTags.isEmpty()) {
+            return null;
+        }
+        try {
+            return CategoryType.valueOf(categoryTags.get(0)).getType();
+        } catch (IllegalArgumentException e) {
+            return categoryTags.get(0);
+        }
+    }
+
+    private static List<String> convertGenresToKorean(List<String> genreTags) {
+        if (genreTags == null) {
+            return List.of();
+        }
+        return genreTags.stream()
+                .map(genre -> {
+                    try {
+                        return GenreType.valueOf(genre).getType();
+                    } catch (IllegalArgumentException e) {
+                        return genre;
+                    }
+                })
+                .toList();
+    }
+
+    private static List<String> convertPlatformsToKorean(List<String> platformTags) {
+        if (platformTags == null) {
+            return List.of();
+        }
+        return platformTags.stream()
+                .map(platform -> {
+                    try {
+                        return PlatformType.valueOf(platform).getType();
+                    } catch (IllegalArgumentException e) {
+                        return platform;
+                    }
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/entity/ContentMetadata.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/ContentMetadata.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PRIVATE;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.example.udtbe.global.entity.TimeBaseEntity;
+import com.example.udtbe.global.util.OptionalTagConverter;
 import com.example.udtbe.global.util.TagConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
@@ -53,11 +54,11 @@ public class ContentMetadata extends TimeBaseEntity {
     @Column(name = "platform_tag")
     private List<String> platformTag;
 
-    @Convert(converter = TagConverter.class)
+    @Convert(converter = OptionalTagConverter.class)
     @Column(name = "director_tag")
     private List<String> directorTag;
 
-    @Convert(converter = TagConverter.class)
+    @Convert(converter = OptionalTagConverter.class)
     private List<String> castTag;
 
 

--- a/src/main/java/com/example/udtbe/domain/content/exception/RecommendContentErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/content/exception/RecommendContentErrorCode.java
@@ -10,6 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum RecommendContentErrorCode implements ErrorCode {
 
     RECOMMEND_CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "추천 콘텐츠를 찾을 수 없습니다."),
+    SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, "설문조사를 찾을 수 없습니다."),
+    CONTENT_METADATA_CACHE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "콘텐츠 메타데이터 캐시 생성에 실패했습니다."),
+    FEEDBACK_RETRIEVAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "피드백 조회에 실패했습니다."),
+    CONTENT_BATCH_RETRIEVAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "콘텐츠 일괄 조회에 실패했습니다."),
+    POPULAR_CONTENT_RETRIEVAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "인기 콘텐츠 조회에 실패했습니다."),
+    INVALID_LIMIT_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 limit 파라미터입니다."),
+    RECOMMENDATION_GENERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "추천 생성에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentMetadataRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentMetadataRepository.java
@@ -1,10 +1,13 @@
 package com.example.udtbe.domain.content.repository;
 
 import com.example.udtbe.domain.content.entity.ContentMetadata;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContentMetadataRepository extends JpaRepository<ContentMetadata, Long> {
 
     Optional<ContentMetadata> findByContent_Id(Long contentId);
+
+    List<ContentMetadata> findByIsDeletedFalse();
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepository.java
@@ -1,8 +1,10 @@
 package com.example.udtbe.domain.content.repository;
 
 import com.example.udtbe.domain.content.entity.Content;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContentRepository extends JpaRepository<Content, Long>, ContentRepositoryCustom {
 
+    List<Content> findAllById(Iterable<Long> contentIds);
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
@@ -1,10 +1,13 @@
 package com.example.udtbe.domain.content.repository;
 
 import com.example.udtbe.domain.content.entity.Feedback;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long>, FeedbackQueryDSL {
 
     Optional<Feedback> findFeedbackById(Long feedbackId);
+
+    List<Feedback> findByMemberIdAndIsDeletedFalse(Long memberId);
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationQuery.java
@@ -1,0 +1,119 @@
+package com.example.udtbe.domain.content.service;
+
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.exception.RecommendContentErrorCode;
+import com.example.udtbe.domain.content.repository.ContentMetadataRepository;
+import com.example.udtbe.domain.content.repository.ContentRepository;
+import com.example.udtbe.domain.content.repository.FeedbackRepository;
+import com.example.udtbe.domain.survey.entity.Survey;
+import com.example.udtbe.domain.survey.repository.SurveyRepository;
+import com.example.udtbe.global.exception.RestApiException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ContentRecommendationQuery {
+
+    private final ContentMetadataRepository contentMetadataRepository;
+    private final SurveyRepository surveyRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final ContentRepository contentRepository;
+
+    /**
+     * 회원별 설문 조회
+     */
+    public Optional<Survey> findSurveyByMemberId(Long memberId) {
+        if (memberId == null) {
+            throw new RestApiException(RecommendContentErrorCode.INVALID_LIMIT_PARAMETER);
+        }
+        return surveyRepository.findByMemberId(memberId);
+    }
+
+    /**
+     * 모든 ContentMetadata 캐시 생성
+     */
+    public Map<Long, ContentMetadata> findContentMetadataCache() {
+        try {
+            return contentMetadataRepository.findByIsDeletedFalse()
+                    .stream()
+                    .filter(metadata -> metadata.getContent() != null)
+                    .collect(Collectors.toMap(
+                            metadata -> metadata.getContent().getId(),
+                            metadata -> metadata
+                    ));
+        } catch (Exception e) {
+            log.error("ContentMetadata 캐시 생성 실패: {}", e.getMessage(), e);
+            throw new RestApiException(RecommendContentErrorCode.CONTENT_METADATA_CACHE_ERROR);
+        }
+    }
+
+    /**
+     * 회원별 피드백 조회
+     */
+    public List<Feedback> findFeedbacksByMemberId(Long memberId) {
+        if (memberId == null) {
+            throw new RestApiException(RecommendContentErrorCode.INVALID_LIMIT_PARAMETER);
+        }
+        try {
+            return feedbackRepository.findByMemberIdAndIsDeletedFalse(memberId);
+        } catch (Exception e) {
+            log.error("피드백 조회 실패: memberId={}, error={}", memberId, e.getMessage(), e);
+            throw new RestApiException(RecommendContentErrorCode.FEEDBACK_RETRIEVAL_ERROR);
+        }
+    }
+
+    /**
+     * ID 목록으로 컨텐츠 조회
+     */
+    public List<Content> findContentsByIds(List<Long> contentIds) {
+        if (contentIds == null || contentIds.isEmpty()) {
+            return List.of();
+        }
+        try {
+            return contentRepository.findAllById(contentIds);
+        } catch (Exception e) {
+            log.error("컨텐츠 조회 실패: error={}", e.getMessage(), e);
+            throw new RestApiException(RecommendContentErrorCode.CONTENT_BATCH_RETRIEVAL_ERROR);
+        }
+    }
+
+    /**
+     * 인기 컨텐츠 메타데이터 조회 (최신순)
+     */
+    public List<ContentMetadata> findPopularContentMetadata(int limit) {
+        if (limit <= 0) {
+            throw new RestApiException(RecommendContentErrorCode.INVALID_LIMIT_PARAMETER);
+        }
+        try {
+            return contentMetadataRepository.findByIsDeletedFalse()
+                    .stream()
+                    .sorted((m1, m2) -> m2.getCreatedAt().compareTo(m1.getCreatedAt()))
+                    .limit(limit)
+                    .toList();
+        } catch (Exception e) {
+            log.error("인기 컨텐츠 메타데이터 조회 실패: error={}", e.getMessage(), e);
+            throw new RestApiException(RecommendContentErrorCode.POPULAR_CONTENT_RETRIEVAL_ERROR);
+        }
+    }
+
+    /**
+     * 삭제되지 않은 모든 ContentMetadata 조회
+     */
+    public List<ContentMetadata> findAllContentMetadata() {
+        try {
+            return contentMetadataRepository.findByIsDeletedFalse();
+        } catch (Exception e) {
+            log.error("모든 ContentMetadata 조회 실패: error={}", e.getMessage(), e);
+            throw new RestApiException(RecommendContentErrorCode.CONTENT_METADATA_CACHE_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -72,8 +72,7 @@ public class ContentRecommendationService {
         log.info("--- 개인화 추천 검색 시작 ---");
         long startTime = System.currentTimeMillis();
 
-        // 1. 모든 ContentMetadata를 한 번에 조회하여 캐시 생성
-        log.debug("ContentMetadata 캐시 생성 중...");
+        // 1. 모든 ContentMetadata를 한 번에 조회하여 캐시 생성 , 추후 메모리 분석 및 성능 개선의 여지가 농후
         Map<Long, ContentMetadata> metadataCache = contentRecommendationQuery.findContentMetadataCache();
         log.info("ContentMetadata 캐시 생성 완료: 총 {}개 콘텐츠", metadataCache.size());
 

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -1,0 +1,333 @@
+package com.example.udtbe.domain.content.service;
+
+import com.example.udtbe.domain.content.dto.ContentRecommendation;
+import com.example.udtbe.domain.content.dto.ContentRecommendationResponse;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.survey.entity.Survey;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TopDocs;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ContentRecommendationService {
+
+    private final ContentRecommendationQuery contentRecommendationQuery;
+
+    private final LuceneIndexService luceneIndexService;
+
+    @Transactional(readOnly = true)
+    public List<ContentRecommendationResponse> recommendContents(Member member, int limit) {
+        log.info("===== 추천 시스템 시작 =====");
+        log.info("요청 사용자: memberId={}, limit={}", member.getId(), limit);
+
+        try {
+            Optional<Survey> userSurvey = contentRecommendationQuery.findSurveyByMemberId(
+                    member.getId());
+            if (userSurvey.isEmpty()) {
+                log.warn("사용자 설문 데이터 없음 - 인기 콘텐츠 반환: memberId={}", member.getId());
+                return getPopularContents(limit);
+            }
+
+            log.info("사용자 설문 발견: platformTags={}, genreTags={}",
+                    userSurvey.get().getPlatformTag(), userSurvey.get().getGenreTag());
+
+            return searchRecommendations(userSurvey.get(), member, limit);
+
+        } catch (Exception e) {
+            log.error("추천 시스템 오류 발생: memberId={}, error={}", member.getId(), e.getMessage(), e);
+            return getPopularContents(limit);
+        }
+    }
+
+    public List<ContentRecommendationResponse> searchRecommendations(Survey userSurvey,
+            Member member, int limit)
+            throws Exception {
+        log.info("--- 개인화 추천 검색 시작 ---");
+        long startTime = System.currentTimeMillis();
+
+        // 1. 모든 ContentMetadata를 한 번에 조회하여 캐시 생성
+        log.debug("ContentMetadata 캐시 생성 중...");
+        Map<Long, ContentMetadata> metadataCache = contentRecommendationQuery.findContentMetadataCache();
+        log.info("ContentMetadata 캐시 생성 완료: 총 {}개 콘텐츠", metadataCache.size());
+
+        // 2. 캐시를 활용하여 플랫폼 필터링
+        log.debug("플랫폼 필터링 시작: platforms={}", userSurvey.getPlatformTag());
+        List<Long> platformFilteredContentIds = getPlatformFilteredContentIds(
+                userSurvey.getPlatformTag(), metadataCache);
+        log.info("플랫폼 필터링 완료: {}개 → {}개 콘텐츠",
+                metadataCache.size(), platformFilteredContentIds.size());
+
+        log.debug("Lucene 인덱스 리더 및 검색기 초기화");
+        DirectoryReader reader = luceneIndexService.getIndexReader();
+        IndexSearcher searcher = new IndexSearcher(reader);
+        Analyzer analyzer = luceneIndexService.getAnalyzer();
+
+        // 플랫폼 필터링된 컨텐츠 ID들로 제한하는 쿼리
+        log.debug("Lucene 쿼리 빌드 시작");
+        BooleanQuery.Builder mainQueryBuilder = new BooleanQuery.Builder();
+
+        // 플랫폼 필터링된 ID들을 OR 조건으로 연결
+        BooleanQuery.Builder idFilterBuilder = new BooleanQuery.Builder();
+        for (Long contentId : platformFilteredContentIds) {
+            idFilterBuilder.add(new TermQuery(new Term("contentId", contentId.toString())),
+                    BooleanClause.Occur.SHOULD);
+        }
+        mainQueryBuilder.add(idFilterBuilder.build(), BooleanClause.Occur.MUST);
+        log.debug("플랫폼 필터 쿼리 추가: {}개 ID", platformFilteredContentIds.size());
+
+        // 장르 유사도 쿼리 추가 (List<String>으로 변경)
+        List<String> userGenres = userSurvey.getGenreTag();
+        int genreQueryCount = 0;
+        if (userGenres != null && !userGenres.isEmpty()) {
+            for (String userGenre : userGenres) {
+                if (userGenre != null && !userGenre.trim().isEmpty()) {
+                    QueryParser genreParser = new QueryParser("genreTag", analyzer);
+                    Query genreQuery = genreParser.parse(userGenre);
+                    mainQueryBuilder.add(genreQuery, BooleanClause.Occur.SHOULD);
+                    genreQueryCount++;
+                }
+            }
+        }
+        log.debug("장르 유사도 쿼리 추가: {}개 장르", genreQueryCount);
+
+        BooleanQuery query = mainQueryBuilder.build();
+        log.debug("최종 Lucene 쿼리: {}", query.toString());
+
+        TopDocs topDocs = searcher.search(query, limit * 3);
+        log.info("Lucene 검색 완료: {}개 결과 (요청 {}개)", topDocs.scoreDocs.length, limit * 3);
+
+        List<ContentRecommendation> recommendations = new ArrayList<>();
+
+        // 3. 캐시를 활용하여 피드백 점수 계산
+        log.debug("사용자 피드백 점수 계산 시작");
+        Map<String, Float> feedbackScores = calculateGenreFeedbackScores(member, metadataCache);
+        log.info("피드백 점수 계산 완료: {}개 장르에 대한 점수", feedbackScores.size());
+        log.debug("장르별 피드백 점수: {}", feedbackScores);
+
+        log.debug("점수 계산 및 추천 목록 생성 시작");
+        for (int i = 0; i < topDocs.scoreDocs.length; i++) {
+            ScoreDoc scoreDoc = topDocs.scoreDocs[i];
+            Document doc = searcher.storedFields().document(scoreDoc.doc);
+            Long contentId = Long.valueOf(doc.get("contentId"));
+            // TF-IDF 점수
+            float luceneScore = scoreDoc.score;
+            //설문 기반 선호도
+            float genreBoost = calculateGenreBoost(doc, userGenres);
+            //실제 행동 기반 선호도
+            float feedbackScore = calculateGenreFeedbackBoost(doc, feedbackScores);
+
+            float finalScore = luceneScore + genreBoost * 2.0f + feedbackScore;
+
+            log.debug("콘텐츠 점수 계산 [{}]: contentId={}, lucene={}, genre={}, feedback={}, final={}",
+                    i + 1, contentId, String.format("%.3f", luceneScore),
+                    String.format("%.3f", genreBoost), String.format("%.3f", feedbackScore),
+                    String.format("%.3f", finalScore));
+
+            recommendations.add(new ContentRecommendation(contentId, finalScore));
+        }
+        log.info("점수 계산 완료: {}개 콘텐츠 점수 계산", recommendations.size());
+
+        reader.close();
+
+        log.debug("최종 추천 목록 정렬 및 제한");
+        List<ContentRecommendation> sortedRecommendations = recommendations.stream()
+                .sorted((r1, r2) -> Float.compare(r2.score(), r1.score()))
+                .limit(limit)
+                .toList();
+
+        // 상위 추천 콘텐츠 점수 로깅
+        log.info("=== 최종 추천 결과 TOP {} ===", Math.min(limit, sortedRecommendations.size()));
+        for (int i = 0; i < Math.min(5, sortedRecommendations.size()); i++) {
+            ContentRecommendation rec = sortedRecommendations.get(i);
+            log.info("순위 {}: contentId={}, 최종점수={}",
+                    i + 1, rec.contentId(), String.format("%.3f", rec.score()));
+        }
+
+        List<Long> sortedContentIds = sortedRecommendations.stream()
+                .map(ContentRecommendation::contentId)
+                .toList();
+
+        log.debug("Content 엔티티 조회: {}개 ID", sortedContentIds.size());
+        List<Content> contents = contentRecommendationQuery.findContentsByIds(sortedContentIds);
+
+        // 4. 캐시에서 해당하는 ContentMetadata 들을 추출
+        log.debug("캐시에서 ContentMetadata 추출");
+        List<ContentMetadata> metadataList = contents.stream()
+                .map(content -> metadataCache.get(content.getId()))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        long endTime = System.currentTimeMillis();
+        log.info("--- 개인화 추천 검색 완료 ---");
+        log.info("총 처리 시간: {}ms, 최종 반환: {}개 콘텐츠",
+                endTime - startTime, contents.size());
+
+        return ContentRecommendationResponse.of(contents, metadataList);
+    }
+
+    private List<Long> getPlatformFilteredContentIds(List<String> platformTags,
+            Map<Long, ContentMetadata> metadataCache) {
+        log.debug("플랫폼 필터링 상세 로직 시작");
+
+        if (platformTags == null || platformTags.isEmpty()) {
+            log.debug("플랫폼 태그 없음 - 모든 콘텐츠 반환");
+            return new ArrayList<>(metadataCache.keySet());
+        }
+
+        // 여러 플랫폼 태그 중 하나라도 포함된 컨텐츠 필터링 (캐시 활용)
+        Set<Long> contentIds = new HashSet<>();
+        for (String platformTag : platformTags) {
+            if (platformTag != null && !platformTag.trim().isEmpty()) {
+                int matchCount = 0;
+                for (Map.Entry<Long, ContentMetadata> entry : metadataCache.entrySet()) {
+                    ContentMetadata metadata = entry.getValue();
+                    if (metadata.getPlatformTag() != null &&
+                            metadata.getPlatformTag().contains(platformTag)) {
+                        contentIds.add(entry.getKey());
+                        matchCount++;
+                    }
+                }
+                log.debug("플랫폼 '{}' 매칭: {}개 콘텐츠", platformTag, matchCount);
+            }
+        }
+
+        log.debug("플랫폼 필터링 결과: {}개 콘텐츠 선택", contentIds.size());
+        return new ArrayList<>(contentIds);
+    }
+
+    private float calculateGenreBoost(Document doc, List<String> userGenres) {
+        if (userGenres == null || userGenres.isEmpty()) {
+            return 0.0f;
+        }
+
+        String genreTag = doc.get("genreTag");
+        if (genreTag == null) {
+            return 0.0f;
+        }
+        float boost = 0.0f;
+        String[] docGenres = genreTag.split(",");
+        for (String userGenre : userGenres) {
+            if (userGenre != null && !userGenre.trim().isEmpty()) {
+                for (String docGenre : docGenres) {
+                    if (docGenre.trim().equals(userGenre.trim())) {
+                        boost += 1.0f;
+                        break; // 중복 매칭 방지
+                    }
+                }
+            }
+        }
+        return boost;
+    }
+
+    private float calculateGenreFeedbackBoost(Document doc, Map<String, Float> genreScores) {
+        String docGenreTag = doc.get("genreTag");
+        if (docGenreTag == null) {
+            return 0.0f;
+        }
+
+        float boost = 0.0f;
+        String[] docGenres = docGenreTag.split(",");
+        for (String genre : docGenres) {
+            genre = genre.trim();
+            boost += genreScores.getOrDefault(genre, 0.0f);
+        }
+        return boost;
+    }
+
+    //좋아하는 콘텐츠의 장르에 점수부여 (캐시 활용)
+    private Map<String, Float> calculateGenreFeedbackScores(Member member,
+            Map<Long, ContentMetadata> metadataCache) {
+        log.debug("사용자 피드백 점수 계산 상세 로직 시작: memberId={}", member.getId());
+        Map<String, Float> genreScores = new HashMap<>();
+
+        List<Feedback> feedbacks = contentRecommendationQuery.findFeedbacksByMemberId(
+                member.getId());
+        if (feedbacks == null || feedbacks.isEmpty()) {
+            log.debug("사용자 피드백 없음");
+            return genreScores;
+        }
+
+        log.debug("사용자 피드백 발견: {}개", feedbacks.size());
+
+        // 피드백 처리 (캐시 활용)
+        int processedCount = 0;
+        for (Feedback feedback : feedbacks) {
+            if (!feedback.isDeleted()) {
+                Long contentId = feedback.getContent().getId();
+                ContentMetadata metadata = metadataCache.get(contentId);
+
+                if (metadata != null && metadata.getGenreTag() != null) {
+                    float score = switch (feedback.getFeedbackType()) {
+                        case LIKE -> 1.0f;
+                        case DISLIKE -> -1.0f;
+                        case UNINTERESTED -> -0.5f;
+                    };
+
+                    log.debug("피드백 처리: contentId={}, type={}, score={}",
+                            contentId, feedback.getFeedbackType(), score);
+
+                    // genreTag는 이제 List<String> 타입이므로 직접 사용
+                    for (String genre : metadata.getGenreTag()) {
+                        if (genre != null && !genre.trim().isEmpty()) {
+                            genre = genre.trim();
+                            float oldScore = genreScores.getOrDefault(genre, 0.0f);
+                            float newScore = oldScore + score;
+                            genreScores.put(genre, newScore);
+                            log.trace("장르 점수 업데이트: {} {} → {}",
+                                    genre, String.format("%.2f", oldScore),
+                                    String.format("%.2f", newScore));
+                        }
+                    }
+                    processedCount++;
+                } else {
+                    log.trace("메타데이터 없음: contentId={}", contentId);
+                }
+            }
+        }
+
+        log.debug("피드백 점수 계산 완료: {}개 피드백 처리, {}개 장르 점수 생성",
+                processedCount, genreScores.size());
+        return genreScores;
+    }
+
+    private List<ContentRecommendationResponse> getPopularContents(int limit) {
+        log.info("인기 콘텐츠 조회 시작: limit={}", limit);
+
+        List<ContentMetadata> metadataList = contentRecommendationQuery.findPopularContentMetadata(
+                limit);
+
+        List<Content> contents = metadataList.stream()
+                .map(ContentMetadata::getContent)
+                .toList();
+
+        log.info("인기 콘텐츠 조회 완료: {}개 반환", contents.size());
+        return ContentRecommendationResponse.of(contents, metadataList);
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
@@ -54,7 +54,6 @@ public class LuceneIndexService {
         log.debug("IndexWriter 설정 생성 완료: analyzer={}", analyzer.getClass().getSimpleName());
 
         try (IndexWriter indexWriter = new IndexWriter(directory, config)) {
-            log.debug("기존 인덱스 삭제 중...");
             indexWriter.deleteAll();
 
             log.debug("ContentMetadata 조회 시작");

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
@@ -1,0 +1,133 @@
+package com.example.udtbe.domain.content.service;
+
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.repository.ContentMetadataRepository;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.Directory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LuceneIndexService {
+
+    private final ContentMetadataRepository contentMetadataRepository;
+    private final Analyzer analyzer;
+    private final Directory directory;
+
+    private volatile boolean indexBuilt = false;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void buildIndexOnStartup() {
+        log.info("===== Lucene 인덱스 초기화 시작 =====");
+        long startTime = System.currentTimeMillis();
+
+        try {
+            buildIndex();
+            long endTime = System.currentTimeMillis();
+            log.info("===== Lucene 인덱스 빌드 완료 =====");
+            log.info("인덱스 빌드 시간: {}ms, 상태: {}", endTime - startTime, indexBuilt);
+        } catch (Exception e) {
+            log.error("Lucene 인덱스 빌드 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public synchronized void buildIndex() throws IOException {
+        log.debug("Lucene 인덱스 빌드 세부 작업 시작");
+        IndexWriterConfig config = new IndexWriterConfig(analyzer);
+        log.debug("IndexWriter 설정 생성 완료: analyzer={}", analyzer.getClass().getSimpleName());
+
+        try (IndexWriter indexWriter = new IndexWriter(directory, config)) {
+            log.debug("기존 인덱스 삭제 중...");
+            indexWriter.deleteAll();
+
+            log.debug("ContentMetadata 조회 시작");
+            List<ContentMetadata> allContentMetadata = contentMetadataRepository.findByIsDeletedFalse();
+            log.info("인덱싱 대상 ContentMetadata: {}개", allContentMetadata.size());
+
+            int indexedCount = 0;
+            for (ContentMetadata metadata : allContentMetadata) {
+                try {
+                    Document doc = createDocument(metadata);
+                    indexWriter.addDocument(doc);
+                    indexedCount++;
+
+                    if (indexedCount % 100 == 0) {
+                        log.debug("인덱싱 진행률: {}/{}", indexedCount, allContentMetadata.size());
+                    }
+
+                } catch (Exception e) {
+                    log.warn("문서 인덱싱 실패 - contentId={}: {}",
+                            metadata.getContent().getId(), e.getMessage());
+                }
+            }
+
+            indexWriter.commit();
+            indexBuilt = true;
+            log.info("Lucene 인덱스 빌드 성공: {}개 문서 인덱싱 완료", indexedCount);
+        }
+    }
+
+    private Document createDocument(ContentMetadata metadata) {
+        Document doc = new Document();
+        Long contentId = metadata.getContent().getId();
+
+        doc.add(new LongPoint("contentId", contentId));
+        doc.add(new StringField("contentId", contentId.toString(), Field.Store.YES));
+        doc.add(new TextField("title", metadata.getTitle(), Field.Store.YES));
+
+        // List<String> 타입의 태그들을 쉼표로 구분된 문자열로 변환
+        String platformTag = metadata.getPlatformTag() != null ?
+                String.join(",", metadata.getPlatformTag()) : "";
+        String genreTag = metadata.getGenreTag() != null ?
+                String.join(",", metadata.getGenreTag()) : "";
+        String directorTag = metadata.getDirectorTag() != null ?
+                String.join(",", metadata.getDirectorTag()) : "";
+        String rating = metadata.getRating() != null ? metadata.getRating() : "";
+
+        doc.add(new TextField("platformTag", platformTag, Field.Store.YES));
+        doc.add(new TextField("genreTag", genreTag, Field.Store.YES));
+//        doc.add(new TextField("directorTag", directorTag, Field.Store.YES));
+//        doc.add(new StringField("rating", rating, Field.Store.YES));
+
+        log.trace("문서 생성: contentId={}, title='{}', platforms='{}', genres='{}', rating='{}'",
+                contentId, metadata.getTitle(), platformTag, genreTag, rating);
+
+        return doc;
+    }
+
+    public DirectoryReader getIndexReader() throws IOException {
+        if (!indexBuilt) {
+            log.warn("인덱스가 빌드되지 않음 - 즉시 빌드 시작");
+            buildIndex();
+        }
+        log.debug("DirectoryReader 생성: indexBuilt={}", indexBuilt);
+        return DirectoryReader.open(directory);
+    }
+
+    public Analyzer getAnalyzer() {
+        log.trace("Analyzer 반환: {}", analyzer.getClass().getSimpleName());
+        return analyzer;
+    }
+
+    public boolean isIndexBuilt() {
+        log.trace("인덱스 빌드 상태 확인: {}", indexBuilt);
+        return indexBuilt;
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
-    Optional<Survey> findSurveyByMemberId(Long Long);
-
     boolean existsByMember(Member member);
+    Optional<Survey> findByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
@@ -23,7 +23,7 @@ public class SurveyQuery {
     }
 
     public Survey findSurveyByMemberId(Long memberId) {
-        return surveyRepository.findSurveyByMemberId(memberId)
+        return surveyRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new RestApiException(SurveyErrorCode.SURVEY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/udtbe/global/config/LuceneConfig.java
+++ b/src/main/java/com/example/udtbe/global/config/LuceneConfig.java
@@ -1,0 +1,22 @@
+package com.example.udtbe.global.config;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.ko.KoreanAnalyzer;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LuceneConfig {
+
+    @Bean
+    public Analyzer koreanAnalyzer() {
+        return new KoreanAnalyzer();
+    }
+
+    @Bean
+    public Directory luceneDirectory() {
+        return new ByteBuffersDirectory();
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/ContentFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentFixture.java
@@ -24,9 +24,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.NoArgsConstructor;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @NoArgsConstructor(access = PRIVATE)
 public class ContentFixture {
+
     public static Content content(String title, String description) {
         return Content.of(
                 title,
@@ -94,5 +96,84 @@ public class ContentFixture {
         });
 
         return list;
+    }
+    // === ID가 미리 설정된 실제 영화 데이터 (1L~10L) ===
+
+    public static Content parasite() {
+        return createMovieWithId(1L, "기생충", "전 세계를 놀라게 한 봉준호 감독의 걸작",
+                "15세이상관람가", LocalDateTime.of(2019, 5, 30, 0, 0), 132);
+    }
+
+    public static Content oldboy() {
+        return createMovieWithId(2L, "올드보이", "박찬욱 감독의 복수 스릴러",
+                "청소년관람불가", LocalDateTime.of(2003, 11, 21, 0, 0), 120);
+    }
+
+    public static Content interstellar() {
+        return createMovieWithId(3L, "인터스텔라", "크리스토퍼 놀란의 SF 대작",
+                "12세이상관람가", LocalDateTime.of(2014, 11, 6, 0, 0), 169);
+    }
+
+    public static Content avatar() {
+        return createMovieWithId(4L, "아바타: 물의 길", "제임스 카메론의 아바타 속편",
+                "12세이상관람가", LocalDateTime.of(2022, 12, 14, 0, 0), 192);
+    }
+
+    public static Content topGun() {
+        return createMovieWithId(5L, "탑건: 매버릭", "톰 크루즈의 액션 블록버스터",
+                "12세이상관람가", LocalDateTime.of(2022, 6, 22, 0, 0), 130);
+    }
+
+    public static Content laLaLand() {
+        return createMovieWithId(6L, "라라랜드", "뮤지컬 로맨스의 대작",
+                "12세이상관람가", LocalDateTime.of(2016, 12, 7, 0, 0), 128);
+    }
+
+    public static Content getOut() {
+        return createMovieWithId(7L, "겟 아웃", "조던 필의 사회풍자 호러",
+                "15세이상관람가", LocalDateTime.of(2017, 5, 17, 0, 0), 104);
+    }
+
+    public static Content blackPanther() {
+        return createMovieWithId(8L, "블랙 팬서", "MCU의 아프리카 슈퍼히어로",
+                "12세이상관람가", LocalDateTime.of(2018, 2, 14, 0, 0), 134);
+    }
+
+    public static Content joker() {
+        return createMovieWithId(9L, "조커", "호아킨 피닉스의 빌런 오리진",
+                "15세이상관람가", LocalDateTime.of(2019, 10, 2, 0, 0), 122);
+    }
+
+    public static Content spiderMan() {
+        return createMovieWithId(10L, "스파이더맨: 노 웨이 홈", "멀티버스 스파이더맨",
+                "12세이상관람가", LocalDateTime.of(2021, 12, 15, 0, 0), 148);
+    }
+
+    // === Helper 메서드 ===
+
+    private static Content createMovieWithId(Long id, String title, String description,
+            String rating, LocalDateTime openDate, int runningTime) {
+        Content content = Content.of(
+                title,
+                description,
+                "https://example.com/poster/" + id + ".jpg",
+                "https://example.com/backdrop/" + id + ".jpg",
+                "https://example.com/trailer/" + id + ".mp4",
+                openDate,
+                runningTime,
+                1,
+                rating
+        );
+        ReflectionTestUtils.setField(content, "id", id);
+        return content;
+    }
+
+    // === 모든 영화 리스트 반환 ===
+
+    public static List<Content> allTestMovies() {
+        return List.of(
+                parasite(), oldboy(), interstellar(), avatar(), topGun(),
+                laLaLand(), getOut(), blackPanther(), joker(), spiderMan()
+        );
     }
 }

--- a/src/test/java/com/example/udtbe/common/fixture/ContentMetadataFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentMetadataFixture.java
@@ -1,0 +1,259 @@
+package com.example.udtbe.common.fixture;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import java.util.Arrays;
+import java.util.List;
+import lombok.NoArgsConstructor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@NoArgsConstructor(access = PRIVATE)
+public class ContentMetadataFixture {
+
+    public static ContentMetadata metadata(Content content, String platformTag, String genreTag) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "15세 이상",
+                List.of("MOVIE"),
+                parseTagString(genreTag),
+                parseTagString(platformTag),
+                List.of("감독1", "감독2"),
+                List.of("배우1", "배우2"),
+                content
+        );
+    }
+
+    public static ContentMetadata metadata(Content content, String platformTag, String genreTag,
+            String directorTag) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "15세 이상",
+                List.of("MOVIE"),
+                parseTagString(genreTag),
+                parseTagString(platformTag),
+                parseTagString(directorTag),
+                List.of("배우1", "배우2"),
+                content
+        );
+    }
+
+    public static ContentMetadata netflixActionMetadata(Content content) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "15세 이상",
+                List.of("MOVIE"),
+                List.of("ACTION", "DRAMA"),
+                List.of("NETFLIX"),
+                List.of("감독1", "감독2"),
+                List.of("배우1", "배우2"),
+                content
+        );
+    }
+
+    public static ContentMetadata watchaComedyMetadata(Content content) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "12세 이상",
+                List.of("MOVIE"),
+                List.of("COMEDY", "ROMANCE"),
+                List.of("WATCHA"),
+                List.of("감독3", "감독4"),
+                List.of("배우3", "배우4"),
+                content
+        );
+    }
+
+    public static ContentMetadata netflixThrillerMetadata(Content content) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "18세 이상",
+                List.of("MOVIE"),
+                List.of("드라마", "스릴러"),
+                List.of("넷플릭스", "웨이브"),
+                List.of("감독5", "감독6"),
+                List.of("배우5", "배우6"),
+                content
+        );
+    }
+
+    public static ContentMetadata deletedMetadata(Content content) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "전체 이용가",
+                List.of("MOVIE"),
+                List.of("기타"),
+                List.of("기타플랫폼"),
+                List.of("미상"),
+                List.of("미상배우"),
+                content
+        );
+    }
+
+    public static ContentMetadata customMetadata(Content content, String title, String rating,
+            String genreTag, String platformTag, String directorTag, List<String> categoryTag,
+            List<String> castTag) {
+        return ContentMetadata.of(
+                title,
+                rating,
+                categoryTag,
+                parseTagString(genreTag),
+                parseTagString(platformTag),
+                parseTagString(directorTag),
+                castTag,
+                content
+        );
+    }
+
+    public static ContentMetadata dramaMetadata(Content content) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "15세 이상",
+                List.of("DRAMA"),
+                List.of("로맨스", "멜로"),
+                List.of("넷플릭스", "티빙"),
+                List.of("드라마감독1"),
+                List.of("드라마배우1", "드라마배우2"),
+                content
+        );
+    }
+
+    public static ContentMetadata animationMetadata(Content content) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "전체 이용가",
+                List.of("ANIMATION"),
+                List.of("모험", "판타지"),
+                List.of("디즈니플러스", "넷플릭스"),
+                List.of("애니감독1"),
+                List.of("성우1", "성우2"),
+                content
+        );
+    }
+
+    public static ContentMetadata varietyMetadata(Content content) {
+        return ContentMetadata.of(
+                content.getTitle(),
+                "12세 이상",
+                List.of("VARIETY"),
+                List.of("예능", "리얼리티"),
+                List.of("유튜브", "웨이브"),
+                List.of("예능PD1"),
+                List.of("출연자1", "출연자2"),
+                content
+        );
+    }
+
+    // === 실제 영화 데이터에 맞는 메타데이터 (ContentFixture와 연동) ===
+
+    public static ContentMetadata parasiteMetadata() {
+        Content content = ContentFixture.parasite(); // ID 1L 이미 설정됨
+        return createMetadataWithId(content, "기생충", "15세이상관람가", 
+                List.of("MOVIE"), List.of("THRILLER", "DRAMA", "CRIME"),
+                List.of("NETFLIX", "WATCHA"), List.of("봉준호"));
+    }
+
+    public static ContentMetadata oldboyMetadata() {
+        Content content = ContentFixture.oldboy(); // ID 2L 이미 설정됨
+        return createMetadataWithId(content, "올드보이", "청소년관람불가",
+                List.of("MOVIE"), List.of("THRILLER", "MYSTERY", "CRIME"),
+                List.of("NETFLIX", "TVING"), List.of("박찬욱"));
+    }
+
+    public static ContentMetadata interstellarMetadata() {
+        Content content = ContentFixture.interstellar(); // ID 3L 이미 설정됨
+        return createMetadataWithId(content, "인터스텔라", "12세이상관람가",
+                List.of("MOVIE"), List.of("SF", "ADVENTURE", "DRAMA"),
+                List.of("NETFLIX", "WATCHA", "WAVVE"), List.of("크리스토퍼 놀란"));
+    }
+
+    public static ContentMetadata avatarMetadata() {
+        Content content = ContentFixture.avatar(); // ID 4L 이미 설정됨
+        return createMetadataWithId(content, "아바타: 물의 길", "12세이상관람가",
+                List.of("MOVIE"), List.of("SF", "ADVENTURE", "FANTASY"),
+                List.of("DISNEY_PLUS", "COUPANG_PLAY"), List.of("제임스 카메론"));
+    }
+
+    public static ContentMetadata topGunMetadata() {
+        Content content = ContentFixture.topGun(); // ID 5L 이미 설정됨
+        return createMetadataWithId(content, "탑건: 매버릭", "12세이상관람가",
+                List.of("MOVIE"), List.of("ACTION", "ADVENTURE", "DRAMA"),
+                List.of("NETFLIX", "COUPANG_PLAY", "APPLE_TV"), List.of("조셉 코신스키"));
+    }
+
+    public static ContentMetadata laLaLandMetadata() {
+        Content content = ContentFixture.laLaLand(); // ID 6L 이미 설정됨
+        return createMetadataWithId(content, "라라랜드", "12세이상관람가",
+                List.of("MOVIE"), List.of("MUSICAL", "ROMANCE", "DRAMA"),
+                List.of("NETFLIX", "WATCHA", "TVING"), List.of("데미언 셔젤"));
+    }
+
+    public static ContentMetadata getOutMetadata() {
+        Content content = ContentFixture.getOut(); // ID 7L 이미 설정됨
+        return createMetadataWithId(content, "겟 아웃", "15세이상관람가",
+                List.of("MOVIE"), List.of("HORROR", "THRILLER", "MYSTERY"),
+                List.of("NETFLIX", "WATCHA"), List.of("조던 필"));
+    }
+
+    public static ContentMetadata blackPantherMetadata() {
+        Content content = ContentFixture.blackPanther(); // ID 8L 이미 설정됨
+        return createMetadataWithId(content, "블랙 팬서", "12세이상관람가",
+                List.of("MOVIE"), List.of("ACTION", "ADVENTURE", "SF"),
+                List.of("DISNEY_PLUS", "NETFLIX"), List.of("라이언 쿠글러"));
+    }
+
+    public static ContentMetadata jokerMetadata() {
+        Content content = ContentFixture.joker(); // ID 9L 이미 설정됨
+        return createMetadataWithId(content, "조커", "15세이상관람가",
+                List.of("MOVIE"), List.of("THRILLER", "DRAMA", "CRIME"),
+                List.of("NETFLIX", "WATCHA", "TVING"), List.of("토드 필립스"));
+    }
+
+    public static ContentMetadata spiderManMetadata() {
+        Content content = ContentFixture.spiderMan(); // ID 10L 이미 설정됨
+        return createMetadataWithId(content, "스파이더맨: 노 웨이 홈", "12세이상관람가",
+                List.of("MOVIE"), List.of("ACTION", "ADVENTURE", "SF"),
+                List.of("NETFLIX", "COUPANG_PLAY"), List.of("존 왓츠"));
+    }
+
+    // === Helper 메서드 ===
+
+    private static ContentMetadata createMetadataWithId(Content content, String title, String rating,
+            List<String> categoryTag, List<String> genreTag,
+            List<String> platformTag, List<String> directorTag) {
+        ContentMetadata metadata = ContentMetadata.of(
+                title,
+                rating,
+                categoryTag,
+                genreTag,
+                platformTag,
+                directorTag,
+                List.of("배우1", "배우2"), // 기본 캐스트
+                content
+        );
+        // ContentMetadata ID는 Content ID와 다를 수 있으므로 별도 설정하지 않음
+        return metadata;
+    }
+
+    // === 모든 메타데이터 리스트 반환 ===
+
+    public static List<ContentMetadata> allTestMetadata() {
+        return List.of(
+                parasiteMetadata(), oldboyMetadata(), interstellarMetadata(), avatarMetadata(),
+                topGunMetadata(), laLaLandMetadata(), getOutMetadata(), blackPantherMetadata(),
+                jokerMetadata(), spiderManMetadata()
+        );
+    }
+
+    // 문자열을 쉼표로 분리해서 List로 변환하는 헬퍼 메서드
+    private static List<String> parseTagString(String tagString) {
+        if (tagString == null || tagString.trim().isEmpty()) {
+            return List.of();
+        }
+        return Arrays.stream(tagString.split(","))
+                .map(String::trim)
+                .filter(tag -> !tag.isEmpty())
+                .toList();
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/FeedbackFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/FeedbackFixture.java
@@ -1,0 +1,29 @@
+package com.example.udtbe.common.fixture;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.entity.enums.FeedbackType;
+import com.example.udtbe.domain.member.entity.Member;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class FeedbackFixture {
+
+    public static Feedback feedback(Member member, Content content, FeedbackType type) {
+        return Feedback.of(type, false, member, content);
+    }
+
+    public static Feedback like(Member member, Content content) {
+        return feedback(member, content, FeedbackType.LIKE);
+    }
+
+    public static Feedback dislike(Member member, Content content) {
+        return feedback(member, content, FeedbackType.DISLIKE);
+    }
+
+    public static Feedback uninterested(Member member, Content content) {
+        return feedback(member, content, FeedbackType.UNINTERESTED);
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/SurveyFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/SurveyFixture.java
@@ -30,4 +30,86 @@ public class SurveyFixture {
                 member
         );
     }
+
+    // === 특정 장르 선호 설문 메서드들 ===
+
+    public static Survey actionThrillerSurvey(Member member) {
+        return Survey.of(
+                List.of("NETFLIX", "WATCHA"),
+                List.of("ACTION", "THRILLER"),
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey scienceFictionSurvey(Member member) {
+        return Survey.of(
+                List.of("DISNEY_PLUS", "NETFLIX"),
+                List.of("SF", "FANTASY"),
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey netflixOnlySurvey(Member member) {
+        return Survey.of(
+                List.of("NETFLIX"),
+                List.of("ACTION", "DRAMA"),
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey disneyPlusSurvey(Member member) {
+        return Survey.of(
+                List.of("DISNEY_PLUS"),
+                List.of("ACTION", "ADVENTURE"),
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey musicalRomanceSurvey(Member member) {
+        return Survey.of(
+                List.of("NETFLIX", "WATCHA", "TVING"),
+                List.of("MUSICAL", "ROMANCE"),
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey horrorThrillerSurvey(Member member) {
+        return Survey.of(
+                List.of("NETFLIX", "WATCHA"),
+                List.of("HORROR", "THRILLER", "MYSTERY"),
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey familyFriendlySurvey(Member member) {
+        return Survey.of(
+                List.of("DISNEY_PLUS", "NETFLIX"),
+                List.of("ANIMATION", "ADVENTURE", "FAMILY"),
+                List.of(""),
+                false,
+                member
+        );
+    }
+
+    public static Survey emptyPlatformSurvey(Member member) {
+        return Survey.of(
+                List.of(), // 빈 플랫폼 리스트
+                List.of("ACTION"),
+                List.of(""),
+                false,
+                member
+        );
+    }
 }

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -1,0 +1,462 @@
+package com.example.udtbe.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentMetadataFixture;
+import com.example.udtbe.common.fixture.FeedbackFixture;
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.common.fixture.SurveyFixture;
+import com.example.udtbe.domain.content.dto.ContentRecommendationResponse;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.entity.enums.FeedbackType;
+import com.example.udtbe.domain.content.service.ContentRecommendationQuery;
+import com.example.udtbe.domain.content.service.ContentRecommendationService;
+import com.example.udtbe.domain.content.service.LuceneIndexService;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
+import com.example.udtbe.domain.survey.entity.Survey;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.lucene.analysis.ko.KoreanAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ContentRecommendationServiceTest {
+
+    @Mock
+    private ContentRecommendationQuery contentRecommendationQuery;
+
+    @Mock
+    private LuceneIndexService luceneIndexService;
+
+    @InjectMocks
+    private ContentRecommendationService contentRecommendationService;
+
+    private Member testMember;
+    private Survey testSurvey;
+    private List<ContentMetadata> testMetadataList;
+    private Map<Long, ContentMetadata> testMetadataCache;
+    private List<Content> testContents;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 데이터 초기화 (실제 DB 데이터와 동일) 순서가 매우 중요
+        testMember = createTestMember();
+        testContents = createRealTestContents();
+        testMetadataList = createRealTestMetadata();
+        testMetadataCache = createTestMetadataCache();
+        //테스트 멤버 기준으로 생성
+        testSurvey = createTestSurvey();
+    }
+
+    @Nested
+    @DisplayName("recommendContents(Member member, int limit) 테스트")
+    class RecommendContentsTest {
+
+        @Test
+        @DisplayName("액션/스릴러 선호 사용자 - 기생충, 올드보이, 블랙팬서 높은 순위")
+        void shouldRecommendActionThrillerContent() throws Exception {
+            // given - 액션/스릴러 선호, 넷플릭스 사용자
+            setupBasicLuceneMocks();
+            Survey actionThrillerSurvey = createActionThrillerSurvey();
+
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(Optional.of(actionThrillerSurvey));
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            mockFeedbackData();
+            mockContentQueryWithOrder(List.of(1L, 2L, 8L)); // 기생충, 올드보이, 블랙팬서
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendContents(testMember, 3);
+
+            // then
+            assertThat(result).hasSize(3);
+
+            // 첫 번째 추천이 액션/스릴러 장르를 포함하는지 확인
+            assertThat(result.get(0).genres())
+                    .anyMatch(genre -> genre.contains("ACTION") || genre.contains("THRILLER"));
+
+            verify(contentRecommendationQuery).findSurveyByMemberId(testMember.getId());
+            verify(luceneIndexService).getIndexReader();
+        }
+
+        @Test
+        @DisplayName("SF/판타지 선호 사용자 - 인터스텔라, 아바타, 스파이더맨 높은 순위")
+        void shouldRecommendScienceFictionContent() throws Exception {
+            // given - SF/판타지 선호, 디즈니+ 사용자
+            setupBasicLuceneMocks();
+            Survey sfFantasySurvey = createScienceFictionSurvey();
+
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(Optional.of(sfFantasySurvey));
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            mockFeedbackData();
+            mockContentQueryWithOrder(List.of(3L, 4L, 10L)); // 인터스텔라, 아바타, 스파이더맨
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendContents(testMember, 3);
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).genres())
+                    .anyMatch(genre -> genre.contains("SF") || genre.contains("FANTASY"));
+        }
+
+        @Test
+        @DisplayName("설문 없는 사용자 - 인기 콘텐츠 반환")
+        void shouldReturnPopularContents_WhenSurveyNotExists() {
+            // given
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(Optional.empty());
+            when(contentRecommendationQuery.findPopularContentMetadata(5))
+                    .thenReturn(testMetadataList.subList(0, 5));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendContents(testMember, 5);
+
+            // then
+            assertThat(result).hasSize(5);
+            verify(contentRecommendationQuery).findPopularContentMetadata(5);
+            verifyNoInteractions(luceneIndexService);
+        }
+    }
+
+    @Nested
+    @DisplayName("플랫폼 필터링 테스트")
+    class PlatformFilteringTest {
+
+        @Test
+        @DisplayName("넷플릭스 전용 사용자 - 넷플릭스 콘텐츠만 추천")
+        void shouldFilterByNetflixOnly() throws Exception {
+            // given
+            setupBasicLuceneMocks();
+            Survey netflixOnlySurvey = createNetflixOnlySurvey();
+
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+            mockFeedbackData();
+            // 넷플릭스 콘텐츠만 반환: 기생충, 올드보이, 인터스텔라, 탑건, 라라랜드 등
+            mockContentQueryWithOrder(List.of(1L, 2L, 3L, 5L, 6L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .searchRecommendations(netflixOnlySurvey, testMember, 5);
+
+            // then
+            assertThat(result).hasSize(5);
+            assertThat(result).allMatch(response ->
+                    response.platforms().contains("NETFLIX"));
+        }
+
+        @Test
+        @DisplayName("디즈니+ 전용 사용자 - 디즈니+ 콘텐츠만 추천")
+        void shouldFilterByDisneyPlusOnly() throws Exception {
+            // given
+            setupBasicLuceneMocks();
+            Survey disneyPlusSurvey = createDisneyPlusSurvey();
+
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+            mockFeedbackData();
+            // 디즈니+ 콘텐츠만 반환: 아바타, 블랙팬서
+            mockContentQueryWithOrder(List.of(4L, 8L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .searchRecommendations(disneyPlusSurvey, testMember, 5);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).allMatch(response ->
+                    response.platforms().contains("DISNEY_PLUS"));
+        }
+    }
+
+    @Nested
+    @DisplayName("피드백 기반 추천 테스트")
+    class FeedbackBasedRecommendationTest {
+
+        @Test
+        @DisplayName("스릴러 좋아요 피드백 - 다양한 장르에서 스릴러가 상위권에 위치")
+        void shouldBoostThrillerGenre_WhenUserLikesThrillerContent() throws Exception {
+            // given
+            setupBasicLuceneMocks();
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            // 기생충(스릴러)에 좋아요 피드백
+            mockPositiveFeedbackForThriller();
+            // 모든 장르 포함: 스릴러(기생충,올드보이,겟아웃,조커), 액션(탑건,블랙팬서,스파이더맨), SF(인터스텔라,아바타), 뮤지컬(라라랜드)
+            // 이때 결정된 갯수가 hasSize()랑 동일
+            mockContentQueryWithOrder(List.of(1L, 2L, 7L, 9L, 5L, 8L, 10L, 3L, 4L, 6L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .searchRecommendations(testSurvey, testMember, 10);
+
+            // then
+            assertThat(result).hasSize(10);
+            // 상위 3개 중에 스릴러 장르가 포함된 콘텐츠가 최소 2개는 있어야 함
+            long thrillerCountInTop3 = result.subList(0, 3).stream()
+                    .mapToLong(response -> response.genres().stream()
+                            .mapToLong(genre -> genre.contains("THRILLER") ? 1L : 0L)
+                            .sum())
+                    .sum();
+            assertThat(thrillerCountInTop3).isGreaterThanOrEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("액션 싫어요 피드백 - 액션 포함한 풀에서 액션이 하위권에 위치")
+        void shouldReduceActionGenreScore_WhenUserDislikesActionContent() throws Exception {
+            // given
+            setupBasicLuceneMocks();
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            // 액션 콘텐츠에 싫어요 피드백 (탑건, 블랙팬서)
+            mockNegativeFeedbackForAction();
+            // 비액션 우선, 액션은 하위에: 스릴러(기생충,올드보이,조커), 뮤지컬(라라랜드), SF(인터스텔라,아바타), 액션(탑건,블랙팬서,스파이더맨)
+            mockContentQueryWithOrder(List.of(1L, 2L, 9L, 6L, 3L, 4L, 7L, 5L, 8L, 10L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .searchRecommendations(testSurvey, testMember, 8);
+
+            // then
+            assertThat(result).hasSize(8);
+            // 상위 4개 중에는 액션 장르가 최대 1개만 있어야 함 (피드백으로 점수가 낮아졌으므로)
+            long actionCountInTop4 = result.subList(0, 4).stream()
+                    .mapToLong(response -> response.genres().stream()
+                            .mapToLong(genre -> genre.contains("ACTION") ? 1L : 0L)
+                            .sum())
+                    .sum();
+            assertThat(actionCountInTop4).isLessThanOrEqualTo(1L);
+
+            // 하위 4개 중에는 액션 장르가 최소 2개는 있어야 함
+            long actionCountInBottom4 = result.subList(4, 8).stream()
+                    .mapToLong(response -> response.genres().stream()
+                            .mapToLong(genre -> genre.contains("ACTION") ? 1L : 0L)
+                            .sum())
+                    .sum();
+            assertThat(actionCountInBottom4).isGreaterThanOrEqualTo(2L);
+        }
+    }
+
+    // === Helper 메서드들 ===
+
+    private Member createTestMember() {
+        Member member = MemberFixture.member("test@example.com", Role.ROLE_USER);
+        ReflectionTestUtils.setField(member, "id", 1L);
+        return member;
+    }
+
+    private Survey createTestSurvey() {
+        return SurveyFixture.actionThrillerSurvey(testMember);
+    }
+
+    private Survey createActionThrillerSurvey() {
+        return SurveyFixture.actionThrillerSurvey(testMember);
+    }
+
+    private Survey createScienceFictionSurvey() {
+        return SurveyFixture.scienceFictionSurvey(testMember);
+    }
+
+    private Survey createNetflixOnlySurvey() {
+        return SurveyFixture.netflixOnlySurvey(testMember);
+    }
+
+    private Survey createDisneyPlusSurvey() {
+        return SurveyFixture.disneyPlusSurvey(testMember);
+    }
+
+    //10개의 초기 영화 데이터 세팅
+    private List<Content> createRealTestContents() {
+        return ContentFixture.allTestMovies();
+    }
+
+    private List<ContentMetadata> createRealTestMetadata() {
+        return ContentMetadataFixture.allTestMetadata();
+    }
+
+    private Map<Long, ContentMetadata> createTestMetadataCache() {
+        return testMetadataList.stream()
+                .collect(Collectors.toMap(
+                        metadata -> metadata.getContent().getId(),
+                        metadata -> metadata
+                ));
+    }
+
+    private void setupBasicLuceneMocks() throws Exception {
+        KoreanAnalyzer analyzer = new KoreanAnalyzer();
+        Directory directory = new ByteBuffersDirectory();
+
+        // 실제 인덱스에 테스트 데이터 추가
+        IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer));
+
+        // 각 테스트 콘텐츠를 인덱스에 추가
+        for (ContentMetadata metadata : testMetadataList) {
+            Document doc = new Document();
+            doc.add(new StringField("contentId", metadata.getContent().getId().toString(),
+                    Field.Store.YES));
+            doc.add(new TextField("title", metadata.getTitle(), Field.Store.YES));
+            doc.add(new TextField("genreTag", String.join(",", metadata.getGenreTag()),
+                    Field.Store.YES));
+            doc.add(new TextField("platformTag", String.join(",", metadata.getPlatformTag()),
+                    Field.Store.YES));
+            writer.addDocument(doc);
+        }
+        writer.close();
+
+        DirectoryReader reader = DirectoryReader.open(directory);
+
+        when(luceneIndexService.getAnalyzer()).thenReturn(analyzer);
+        when(luceneIndexService.getIndexReader()).thenReturn(reader);
+    }
+
+    private void mockContentQueryWithOrder(List<Long> contentIds) {
+        List<Content> orderedContents = contentIds.stream()
+                .map(id -> testContents.stream()
+                        .filter(content -> content.getId().equals(id))
+                        .findFirst()
+                        .orElseThrow())
+                .collect(Collectors.toList());
+
+        when(contentRecommendationQuery.findContentsByIds(anyList()))
+                .thenReturn(orderedContents);
+    }
+
+    private void mockFeedbackData() {
+        // 기본 피드백 데이터 (필요에 따라 각 테스트에서 오버라이드)
+        when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                .thenReturn(new ArrayList<>());
+    }
+
+    private void mockPositiveFeedbackForThriller() {
+        List<Feedback> feedbacks = List.of(
+                createFeedback(testContents.get(0), FeedbackType.LIKE) // 기생충 좋아요
+        );
+        when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                .thenReturn(feedbacks);
+    }
+
+    private void mockNegativeFeedbackForAction() {
+        List<Feedback> feedbacks = List.of(
+                createFeedback(testContents.get(4), FeedbackType.DISLIKE), // 탑건 싫어요
+                createFeedback(testContents.get(7), FeedbackType.DISLIKE)  // 블랙팬서 싫어요
+        );
+        when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                .thenReturn(feedbacks);
+    }
+
+    private Feedback createFeedback(Content content, FeedbackType type) {
+        return FeedbackFixture.feedback(testMember, content, type);
+    }
+
+    @Test
+    @DisplayName("예외 상황 - Lucene 인덱스 읽기 실패시 인기 콘텐츠 fallback 전략")
+    void shouldFallbackToPopularContents_WhenLuceneIndexFails() throws Exception {
+        // given
+        when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                .thenReturn(Optional.of(testSurvey));
+        when(luceneIndexService.getIndexReader())
+                .thenThrow(new IOException("인덱스 읽기 실패"));
+        when(contentRecommendationQuery.findPopularContentMetadata(5))
+                .thenReturn(testMetadataList.subList(0, 5));
+
+        // when
+        List<ContentRecommendationResponse> result = contentRecommendationService
+                .recommendContents(testMember, 5);
+
+        // then
+        assertThat(result).hasSize(5);
+        verify(contentRecommendationQuery).findPopularContentMetadata(5);
+    }
+
+    @Test
+    @DisplayName("장르 태그가 없는 콘텐츠(이상치 데이터) 처리")
+    void shouldHandleNullGenreTags() throws Exception {
+        // given
+        setupBasicLuceneMocks();
+        ContentMetadata metadataWithNullGenre = ContentMetadataFixture.customMetadata(
+                testContents.get(0), "테스트 콘텐츠", "15세이상관람가",
+                "", "NETFLIX", "테스트 감독", List.of("MOVIE"), List.of("테스트 배우")
+        );
+
+        Map<Long, ContentMetadata> cacheWithNull = Map.of(1L, metadataWithNullGenre);
+
+        when(contentRecommendationQuery.findContentMetadataCache())
+                .thenReturn(cacheWithNull);
+
+        mockFeedbackData();
+        mockContentQueryWithOrder(List.of(1L));
+
+        // when
+        List<ContentRecommendationResponse> result = contentRecommendationService
+                .searchRecommendations(testSurvey, testMember, 1);
+
+        // then 예외가 발생하지 않고 정상 처리되어야..
+        assertThat(result).hasSize(1);
+
+    }
+
+    @Test
+    @DisplayName("빈 플랫폼 태그로 검색시 모든 콘텐츠 반환")
+    void shouldReturnAllContents_WhenPlatformTagsEmpty() throws Exception {
+        // given
+        setupBasicLuceneMocks();
+        Survey surveyWithEmptyPlatforms = SurveyFixture.emptyPlatformSurvey(testMember);
+
+        when(contentRecommendationQuery.findContentMetadataCache())
+                .thenReturn(testMetadataCache);
+
+        mockFeedbackData();
+
+        List<Long> allContentIds = testMetadataList.stream()
+                .map(metadata -> metadata.getContent().getId())
+                .collect(Collectors.toList());
+        mockContentQueryWithOrder(allContentIds);
+
+        // when
+        List<ContentRecommendationResponse> result = contentRecommendationService
+                .searchRecommendations(surveyWithEmptyPlatforms, testMember, 10);
+
+        // then
+        assertThat(result).hasSize(10); // 모든 콘텐츠 반환
+    }
+}


### PR DESCRIPTION
# 📝 요약(Summary)

## 🎯 무엇을, 왜 구현했는가?

**Apache Lucene 기반 개인화 콘텐츠 추천 시스템**을 구현했습니다. 기존의 단순한 인기도 기반 추천에서 벗어나 **사용자 설문조사와 실제 피드백을 활용한 개인화 추천**으로 발전시켰습니다.

### 핵심 문제점
- 모든 사용자에게 동일한 인기 콘텐츠만 추천
- 개인의 취향과 플랫폼 선호도 미반영
- 사용자 행동 데이터(좋아요/싫어요) 활용 부족

### 해결 방법
**3단계 점수 계산 시스템**으로 정교한 개인화 추천을 구현:
1. **Lucene TF-IDF 기본 점수** (콘텐츠 유사도)
2. **설문 기반 장르 부스트** (사용자 선호 장르 가중치)
3. **피드백 기반 점수 조정** (실제 사용자 행동 반영)

---

## 🔍 추천 알고리즘 동작 원리

### 1️⃣ Lucene 검색 엔진 활용
```
최종 점수 = Lucene 점수 + (장르 부스트 × 2.0) + 피드백 점수
```

**TF-IDF 스코어링 원리:**
- **TF (Term Frequency)**: 문서에서 검색어가 얼마나 자주 등장하는가?
- **IDF (Inverse Document Frequency)**: 전체 문서에서 검색어가 얼마나 희귀한가?
- **직관적 이해**: "자주 나오지만 희귀한 단어일수록 중요하다"

### 2️⃣ 개인화 점수 계산 과정

#### A. 플랫폼 필터링 (1차 필터)
```java
// 사용자가 선호하는 플랫폼의 콘텐츠만 추출
if (userSurvey.getPlatformTag().contains("NETFLIX")) {
    // 넷플릭스 콘텐츠만 검색 대상에 포함
}
```

#### B. 장르 유사도 부스트 (2차 가중치)
```java
// 사용자 선호 장르와 일치할 때마다 +1.0 점수
for (String userGenre : userGenres) {
    if (contentGenres.contains(userGenre)) {
        genreBoost += 1.0f;
    }
}
finalScore += genreBoost * 2.0f; // 2배 가중치 적용
```

#### C. 피드백 기반 학습 (3차 개인화)
```java
// 사용자의 과거 행동 패턴을 장르별로 점수화
Map<String, Float> genreFeedbackScores = new HashMap<>();
- LIKE → +1.0 점수
- DISLIKE → -1.0 점수  
- UNINTERESTED → -0.5 점수
```

### 3️⃣ 한국어 검색 최적화
- **Nori 한국어 분석기** 사용으로 정확한 형태소 분석
- **실시간 인덱스 빌드**로 새로운 콘텐츠 즉시 반영

---

## 🏗️ 시스템 아키텍처

```mermaid
graph TD
    A[사용자 요청] --> B[설문 데이터 조회]
    B --> C[플랫폼 필터링]
    C --> D[Lucene 검색 실행]
    D --> E[TF-IDF 기본 점수]
    E --> F[장르 부스트 적용]
    F --> G[피드백 점수 적용]
    G --> H[최종 추천 결과]
    
    I[ContentMetadata 캐시] --> C
    J[사용자 피드백 이력] --> G
```

### 핵심 컴포넌트
- **LuceneIndexService**: 검색 인덱스 관리 및 검색 실행
- **ContentRecommendationService**: 추천 로직 핵심 구현체  
- **ContentRecommendationQuery**: 데이터 조회 최적화
- **Korean Analyzer**: 한국어 자연어 처리

---

## 📊 성능 최적화 전략

### 1️⃣ 메타데이터 캐시 전략
```java
// 전체 ContentMetadata를 한 번에 조회하여 캐시 생성
Map<Long, ContentMetadata> metadataCache = 
    contentMetadataRepository.findByIsDeletedFalse()
        .stream()
        .collect(Collectors.toMap(
            metadata -> metadata.getContent().getId(),
            metadata -> metadata
        ));
```

### 2️⃣ 인덱스 최적화
- **애플리케이션 시작 시 자동 인덱스 빌드**
- **메모리 기반 Directory 사용**으로 빠른 검색
- **배치 처리**로 인덱싱 성능 향상

### 3️⃣ 검색 성능
- **플랫폼 사전 필터링**으로 검색 범위 축소
- **점수 계산 최적화**로 실시간 응답 보장
- **Fallback 전략**: Lucene 오류 시 인기 콘텐츠 반환

---

## 🧪 테스트 전략

### 단위 테스트 커버리지
- **개인화 추천 시나리오**: 액션/스릴러 선호 사용자 테스트
- **플랫폼 필터링**: 넷플릭스/디즈니+ 전용 사용자 테스트
- **피드백 기반 학습**: 좋아요/싫어요 패턴 학습 검증
- **예외 처리**: Lucene 인덱스 오류 시 Fallback 동작

### 테스트 데이터 설계
```java
// 실제 영화 데이터로 현실적인 테스트 환경 구축
- 기생충 (스릴러/드라마/넷플릭스)
- 인터스텔라 (SF/어드벤처/넷플릭스)  
- 아바타 (SF/판타지/디즈니+)
// 총 10개 영화 × 다양한 장르/플랫폼 조합
```

---

## 💬 공유사항 to 리뷰어

### 🔍 중점 리뷰 포인트
1. **점수 계산 로직의 적절성**: `luceneScore + genreBoost * 2.0f + feedbackScore` 가중치가 아직은 적절하지 않다고 생각해요..
2. **성능 최적화**: 메타데이터 캐시 전략과 Lucene 인덱스 관리 방식
3. **예외 처리**: Lucene 오류 시 Fallback 로직의 견고성

### 🤔 논의하고 싶은 부분
- **장르 부스트 가중치 (현재 2.0배)**: 더 정교한 조정이 필요할까요?
- **피드백 점수 범위**: LIKE(+1.0), DISLIKE(-1.0), UNINTERESTED(-0.5) 가 적절한 범위인가요?
- **캐시 전략**: 전체 메타데이터를 메모리에 올리는 것 vs 필요시 조회하는 것의 트레이드오프
- **인덱스 리빌드 주기**: 실시간 vs 배치 처리의 적절한 균형점

---

## 📸 스크린샷

### 추천할 스크린샷들:

<img width="1328" height="504" alt="image" src="https://github.com/user-attachments/assets/17e22740-f19f-4e03-bcb7-e633d0e0eae2" />

---

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 성능 테스트 및 벤치마크를 수행했습니다.
- [x] 예외 상황 처리 및 Fallback 로직을 검증했습니다.

## 🤔 Review 예상 시간
- **기본 리뷰**: 15-20분
- **심화 리뷰**: 30-40분 (알고리즘 로직 상세 검토 포함)