### PR TITLE
feat/UDT-77-OTT-콘텐츠-필터링-목록-조회

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/dto/common/CastDTO.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/common/CastDTO.java
@@ -1,8 +1,8 @@
 package com.example.udtbe.domain.admin.dto.common;
 
-public record CastDTO (
-    String castName,
-    String castImageUrl
-){
+public record CastDTO(
+        String castName,
+        String castImageUrl
+) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/common/CategoryDTO.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/common/CategoryDTO.java
@@ -2,9 +2,9 @@ package com.example.udtbe.domain.admin.dto.common;
 
 import java.util.List;
 
-public record CategoryDTO (
+public record CategoryDTO(
         String categoryType,
         List<String> genres
-){
+) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/common/ContentDTO.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/common/ContentDTO.java
@@ -3,10 +3,11 @@ package com.example.udtbe.domain.admin.dto.common;
 import java.time.LocalDateTime;
 
 public record ContentDTO(
-    Long contentId,
-    String title,
-    String posterUrl,
-    LocalDateTime openDate,
-    String rating
+        Long contentId,
+        String title,
+        String posterUrl,
+        LocalDateTime openDate,
+        String rating
 ) {
+
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/common/PlatformDTO.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/common/PlatformDTO.java
@@ -1,9 +1,9 @@
 package com.example.udtbe.domain.admin.dto.common;
 
-public record PlatformDTO (
+public record PlatformDTO(
         String platformType,
         String watchUrl,
         boolean isAvailable
-){
+) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/ContentGetDetailResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/ContentGetDetailResponse.java
@@ -21,6 +21,6 @@ public record ContentGetDetailResponse(
         List<String> directors,
         List<CastDTO> casts,
         List<PlatformDTO> platforms
-){
+) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/ContentRegisterResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/ContentRegisterResponse.java
@@ -1,7 +1,7 @@
 package com.example.udtbe.domain.admin.dto.response;
 
-public record ContentRegisterResponse (
-    long contentId
-){
+public record ContentRegisterResponse(
+        long contentId
+) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/ContentUpdateResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/ContentUpdateResponse.java
@@ -1,6 +1,7 @@
 package com.example.udtbe.domain.admin.dto.response;
 
-public record ContentUpdateResponse (
+public record ContentUpdateResponse(
         long contentId
-){
+) {
+
 }

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -38,50 +38,50 @@ public class AdminQuery {
     private final CountryRepository countryRepository;
 
 
-    public Content findContentByContentId(Long contentId){
-        return contentRepository.findById(contentId).orElseThrow( ()->
+    public Content findContentByContentId(Long contentId) {
+        return contentRepository.findById(contentId).orElseThrow(() ->
                 new RestApiException(ContentErrorCode.CONTENT_NOT_FOUND)
         );
     }
 
-    public ContentMetadata findContentMetadateByContentId(Long contentId){
-        return contentMetadataRepository.findByContent_Id(contentId).orElseThrow( ()->
+    public ContentMetadata findContentMetadateByContentId(Long contentId) {
+        return contentMetadataRepository.findByContent_Id(contentId).orElseThrow(() ->
                 new RestApiException(ContentErrorCode.CONTENT_METADATA_NOT_FOUND)
         );
     }
 
-    public Category findByCategoryType(CategoryType categoryType){
-        return categoryRepository.findByCategoryType(categoryType).orElseThrow( ()->
+    public Category findByCategoryType(CategoryType categoryType) {
+        return categoryRepository.findByCategoryType(categoryType).orElseThrow(() ->
                 new RestApiException(ContentErrorCode.CATEGORY_NOT_FOUND)
         );
     }
 
-    public Genre findByGenreTypeAndCategory(GenreType genreType, Category ccategory){
-        return genreRepository.findByGenreTypeAndCategory(genreType,ccategory).orElseThrow( ()->
+    public Genre findByGenreTypeAndCategory(GenreType genreType, Category ccategory) {
+        return genreRepository.findByGenreTypeAndCategory(genreType, ccategory).orElseThrow(() ->
                 new RestApiException(ContentErrorCode.GENRE_NOT_FOUND)
         );
     }
 
-    public Platform findByPlatform(PlatformType platformType){
-        return platformRepository.findByPlatformType(platformType).orElseThrow( ()->
+    public Platform findByPlatform(PlatformType platformType) {
+        return platformRepository.findByPlatformType(platformType).orElseThrow(() ->
                 new RestApiException(ContentErrorCode.PLATFORM_NOT_FOUND)
         );
     }
 
-    public Cast findOrSaveCast(String castName, String castImageUrl){
-        return castRepository.findByCastNameAndCastImageUrl(castName, castImageUrl).orElseGet( ()->
+    public Cast findOrSaveCast(String castName, String castImageUrl) {
+        return castRepository.findByCastNameAndCastImageUrl(castName, castImageUrl).orElseGet(() ->
                 castRepository.save(Cast.of(castName, castImageUrl))
         );
     }
 
-    public Director findOrSaveDirector(String directorName){
-        return directorRepository.findByDirectorName(directorName).orElseGet( ()->
+    public Director findOrSaveDirector(String directorName) {
+        return directorRepository.findByDirectorName(directorName).orElseGet(() ->
                 directorRepository.save(Director.of(directorName))
         );
     }
 
-    public Country findOrSaveCountry(String countryName){
-        return countryRepository.findByCountryName(countryName).orElseGet( ()->
+    public Country findOrSaveCountry(String countryName) {
+        return countryRepository.findByCountryName(countryName).orElseGet(() ->
                 countryRepository.save(Country.of(countryName))
         );
     }

--- a/src/main/java/com/example/udtbe/domain/content/controller/ContentController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/ContentController.java
@@ -1,7 +1,11 @@
 package com.example.udtbe.domain.content.controller;
 
+import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
 import com.example.udtbe.domain.content.service.ContentService;
+import com.example.udtbe.global.dto.CursorPageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,4 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContentController implements ContentControllerApiSpec {
 
     private final ContentService contentService;
+
+    @Override
+    public ResponseEntity<CursorPageResponse<ContentsGetResponse>> getContents(
+            ContentsGetRequest request) {
+        CursorPageResponse<ContentsGetResponse> response = contentService.getContents(request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/content/controller/ContentControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/ContentControllerApiSpec.java
@@ -1,8 +1,23 @@
 package com.example.udtbe.domain.content.controller;
 
+import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.global.dto.CursorPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "콘텐츠 API", description = "콘텐츠 관련 API")
 public interface ContentControllerApiSpec {
 
+    @Operation(summary = "콘텐츠 필터링 목록 조회 API", description = "필터링 조건에 따른 콘텐츠 목록을 가져온다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @PostMapping("/api/contents")
+    public ResponseEntity<CursorPageResponse<ContentsGetResponse>> getContents(
+            @ModelAttribute @Valid ContentsGetRequest request
+    );
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/common/ContentSearchConditionDTO.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/common/ContentSearchConditionDTO.java
@@ -1,0 +1,16 @@
+package com.example.udtbe.domain.content.dto.common;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ContentSearchConditionDTO(
+
+        List<String> categories,
+        List<String> platforms,
+        List<String> countries,
+        List<LocalDateTime> openDates,
+        List<String> ratings,
+        List<String> genres
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/content/dto/request/ContentsGetRequest.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/request/ContentsGetRequest.java
@@ -1,0 +1,17 @@
+package com.example.udtbe.domain.content.dto.request;
+
+import com.example.udtbe.domain.content.dto.common.ContentSearchConditionDTO;
+import java.util.Objects;
+
+public record ContentsGetRequest(
+        String cursor,
+        Integer size,
+        ContentSearchConditionDTO contentSearchConditionDTO
+) {
+
+    public ContentsGetRequest {
+        if (Objects.isNull(size)) {
+            size = 20;
+        }
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/dto/response/ContentsGetResponse.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/response/ContentsGetResponse.java
@@ -1,0 +1,18 @@
+package com.example.udtbe.domain.content.dto.response;
+
+import com.example.udtbe.domain.content.entity.Content;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ContentsGetResponse(
+        Long contentId,
+        String title,
+        String posterUrl
+) {
+
+    @QueryProjection
+    public ContentsGetResponse(
+            Content content
+    ) {
+        this(content.getId(), content.getTitle(), content.getPosterUrl());
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/exception/ContentErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/content/exception/ContentErrorCode.java
@@ -11,10 +11,9 @@ public enum ContentErrorCode implements ErrorCode {
 
     CONTENT_METADATA_NOT_FOUND(HttpStatus.NOT_FOUND, "콘텐츠 메타데이터를 찾을 수 없습니다."),
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "콘텐츠를 찾을 수 없습니다."),
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"분류를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "분류를 찾을 수 없습니다."),
     GENRE_NOT_FOUND(HttpStatus.NOT_FOUND, "장르를 찾을 수 없습니다."),
-    PLATFORM_NOT_FOUND(HttpStatus.NOT_FOUND, "플랫폼을 찾을 수 없습니다.")
-    ;
+    PLATFORM_NOT_FOUND(HttpStatus.NOT_FOUND, "플랫폼을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryCustom.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryCustom.java
@@ -1,9 +1,13 @@
 package com.example.udtbe.domain.content.repository;
 
 import com.example.udtbe.domain.admin.dto.common.ContentDTO;
+import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
 import com.example.udtbe.global.dto.CursorPageResponse;
 
 public interface ContentRepositoryCustom {
 
     CursorPageResponse<ContentDTO> findContentsAdminByCursor(Long cursor, int size);
+
+    CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request);
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
@@ -1,13 +1,31 @@
 package com.example.udtbe.domain.content.repository;
 
+import static com.example.udtbe.domain.content.entity.QCategory.category;
 import static com.example.udtbe.domain.content.entity.QContent.content;
+import static com.example.udtbe.domain.content.entity.QContentCategory.contentCategory;
+import static com.example.udtbe.domain.content.entity.QContentCountry.contentCountry;
+import static com.example.udtbe.domain.content.entity.QContentGenre.contentGenre;
+import static com.example.udtbe.domain.content.entity.QContentPlatform.contentPlatform;
+import static com.example.udtbe.domain.content.entity.QCountry.country;
+import static com.example.udtbe.domain.content.entity.QGenre.genre;
+import static com.example.udtbe.domain.content.entity.QPlatform.platform;
 
 import com.example.udtbe.domain.admin.dto.common.ContentDTO;
+import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.QContentsGetResponse;
+import com.example.udtbe.domain.content.entity.enums.CategoryType;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.domain.content.entity.enums.PlatformType;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,13 +33,11 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ContentRepositoryImpl implements ContentRepositoryCustom {
 
+    private static final String DELIMITER = "|";
     private final JPAQueryFactory queryFactory;
 
     @Override
     public CursorPageResponse<ContentDTO> findContentsAdminByCursor(Long cursor, int size) {
-
-        BooleanExpression cursorCondition = (cursor != null) ? content.id.lt(cursor) : null;
-        BooleanExpression notDeleted = content.isDeleted.eq(false);
 
         List<ContentDTO> dtos = queryFactory
                 .select(Projections.constructor(
@@ -33,7 +49,7 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
                         content.rating
                 ))
                 .from(content)
-                .where(cursorCondition, notDeleted)
+                .where(cursorFilter(cursor), deletedFilter())
                 .orderBy(content.id.desc())
                 .limit(size + 1)
                 .fetch();
@@ -48,5 +64,214 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
                 : null;
 
         return new CursorPageResponse<>(dtos, nextCursor, hasNext);
+    }
+
+    @Override
+    public CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request) {
+        Long cursorId = null;
+        LocalDateTime cursorOpenDate = null;
+
+        String cursor = request.cursor();
+        if (Objects.nonNull(cursor) && cursor.contains(DELIMITER)) {
+            String[] parts = cursor.split("\\|");
+            cursorId = Long.parseLong(parts[0]);
+            cursorOpenDate = LocalDateTime.parse(parts[1]);
+        }
+
+        List<Long> allContentIds = queryFactory
+                .select(content.id)
+                .from(content)
+                .fetch();
+
+        List<Long> filteredByPlatForms = getContentIdsByPlatformTypes(
+                request.contentSearchConditionDTO().platforms(), allContentIds);
+        List<Long> filteredByCountries = getContentIdsByCountries(
+                request.contentSearchConditionDTO().countries(), allContentIds);
+        List<Long> filteredByOpenDates = getContentIdsByOpenDates(
+                request.contentSearchConditionDTO().openDates(), allContentIds);
+        List<Long> filteredRatings = getContentIdsByRatings(
+                request.contentSearchConditionDTO().ratings(), allContentIds);
+        List<Long> filteredCategories = getContentIdsByCategories(
+                request.contentSearchConditionDTO().categories(), allContentIds);
+        List<Long> filteredGenres = getContentIdsByGenres(
+                request.contentSearchConditionDTO().genres(), allContentIds);
+
+        Set<Long> filteredContentIds = new HashSet<>(filteredByPlatForms);
+        filteredContentIds.retainAll(filteredByCountries);
+        filteredContentIds.retainAll(filteredByOpenDates);
+        filteredContentIds.retainAll(filteredRatings);
+        filteredContentIds.retainAll(filteredCategories);
+        filteredContentIds.retainAll(filteredGenres);
+
+        List<ContentsGetResponse> items = queryFactory
+                .select(new QContentsGetResponse(content))
+                .from(content)
+                .where(
+                        deletedFilter(),
+                        content.id.in(filteredContentIds),
+                        complexCursorFilter(cursorOpenDate, cursorId)
+                )
+                .orderBy(content.openDate.desc(), content.id.desc())
+                .limit(request.size() + 1)
+                .fetch();
+
+        boolean hasNext = isNext(items.size(), request.size());
+
+        if (hasNext) {
+            items.remove(items.size() - 1);
+        }
+
+        String nextCursor = hasNext ?
+                items.get(items.size() - 1).contentId()
+                        + DELIMITER
+                        + fetchOpenDate(items.get(items.size() - 1).contentId())
+                : null;
+
+        return new CursorPageResponse<>(items, nextCursor, hasNext);
+    }
+
+    private List<Long> getContentIdsByPlatformTypes(List<String> platforms,
+            List<Long> allContentIds) {
+
+        if (isNullOrEmpty(platforms)) {
+            return allContentIds;
+        }
+
+        List<PlatformType> platformTypes = platforms.stream()
+                .map(PlatformType::fromByType)
+                .toList();
+
+        return queryFactory
+                .select(content.id)
+                .from(content)
+                .join(content.contentPlatforms, contentPlatform)
+                .on(contentPlatform.isAvailable.isTrue())
+                .join(contentPlatform.platform, platform)
+                .where(platform.platformType.in(platformTypes))
+                .fetch();
+    }
+
+    private List<Long> getContentIdsByCountries(List<String> countries, List<Long> allContentIds) {
+
+        if (isNullOrEmpty(countries)) {
+            return allContentIds;
+        }
+
+        return queryFactory
+                .select(content.id)
+                .from(content)
+                .join(content.contentCountries, contentCountry)
+                .join(contentCountry.country, country)
+                .where(country.countryName.in(countries))
+                .fetch();
+    }
+
+    private List<Long> getContentIdsByRatings(List<String> ratings,
+            List<Long> allContentIds) {
+
+        if (isNullOrEmpty(ratings)) {
+            return allContentIds;
+        }
+        return queryFactory
+                .select(content.id)
+                .from(content)
+                .where(content.rating.in(ratings))
+                .fetch();
+    }
+
+    private List<Long> getContentIdsByOpenDates(List<LocalDateTime> openDates,
+            List<Long> allContentIds) {
+
+        if (isNullOrEmpty(openDates)) {
+            return allContentIds;
+        }
+
+        List<Integer> years = openDates.stream()
+                .map(LocalDateTime::getYear)
+                .distinct()
+                .toList();
+
+        return queryFactory
+                .select(content.id)
+                .from(content)
+                .where(content.openDate.year().in(years))
+                .fetch();
+    }
+
+    private List<Long> getContentIdsByCategories(List<String> categories,
+            List<Long> allContentIds) {
+
+        if (isNullOrEmpty(categories)) {
+            return allContentIds;
+        }
+
+        List<CategoryType> categoryTypes = categories.stream()
+                .map(CategoryType::fromByType)
+                .toList();
+
+        return queryFactory
+                .select(content.id)
+                .from(content)
+                .join(content.contentCategories, contentCategory)
+                .join(contentCategory.category, category)
+                .where(category.categoryType.in(categoryTypes))
+                .fetch();
+    }
+
+    private List<Long> getContentIdsByGenres(List<String> genres,
+            List<Long> allContentIds) {
+
+        if (isNullOrEmpty(genres)) {
+            return allContentIds;
+        }
+
+        List<GenreType> genreTypes = genres.stream()
+                .map(GenreType::fromByType)
+                .toList();
+
+        return queryFactory
+                .select(content.id)
+                .from(content)
+                .join(content.contentGenres, contentGenre)
+                .join(contentGenre.genre, genre)
+                .where(genre.genreType.in(genreTypes))
+                .fetch();
+    }
+
+    private <T> boolean isNullOrEmpty(List<T> list) {
+        return Objects.isNull(list) || list.isEmpty();
+    }
+
+    private BooleanExpression complexCursorFilter(LocalDateTime cursorOpenDate, Long cursorId) {
+        if (cursorOpenDate == null || cursorId == null) {
+            return null;
+        }
+
+        return content.openDate.lt(cursorOpenDate)
+                .or(content.openDate.eq(cursorOpenDate).and(content.id.lt(cursorId)));
+    }
+
+    private boolean isNext(int itemSize, int requestSize) {
+        return itemSize > requestSize;
+    }
+
+    private LocalDateTime fetchOpenDate(Long contentId) {
+        return queryFactory
+                .select(content.openDate)
+                .from(content)
+                .where(content.id.eq(contentId))
+                .fetchOne();
+    }
+
+    private BooleanExpression cursorFilter(Long cursor) {
+        if (Objects.isNull(cursor)) {
+            return null;
+        }
+
+        return content.id.lt(cursor);
+    }
+
+    private BooleanExpression deletedFilter() {
+        return content.isDeleted.eq(false);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentQuery.java
@@ -1,5 +1,7 @@
 package com.example.udtbe.domain.content.service;
 
+import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
 import com.example.udtbe.domain.content.repository.CastRepository;
 import com.example.udtbe.domain.content.repository.CategoryRepository;
 import com.example.udtbe.domain.content.repository.ContentCastRepository;
@@ -13,6 +15,7 @@ import com.example.udtbe.domain.content.repository.CountryRepository;
 import com.example.udtbe.domain.content.repository.DirectorRepository;
 import com.example.udtbe.domain.content.repository.GenreRepository;
 import com.example.udtbe.domain.content.repository.PlatformRepository;
+import com.example.udtbe.global.dto.CursorPageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -34,4 +37,7 @@ public class ContentQuery {
     private final ContentMetadataRepository contentMetadataRepository;
     private final ContentPlatformRepository contentPlatformRepository;
 
+    public CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request) {
+        return contentRepository.getContents(request);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
@@ -1,11 +1,20 @@
 package com.example.udtbe.domain.content.service;
 
+import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.global.dto.CursorPageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ContentService {
 
     private final ContentQuery contentQuery;
+
+    @Transactional(readOnly = true)
+    public CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request) {
+        return contentQuery.getContents(request);
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,60 +1,57 @@
-
 -- 1) 카테고리 데이터 삽입
 INSERT INTO category (category_id, category_type, created_at, updated_at, is_deleted)
-VALUES
-    (1, 'MOVIE',       NOW(), NOW(), false),
-    (2, 'DRAMA',       NOW(), NOW(), false),
-    (3, 'ANIMATION',   NOW(), NOW(), false),
-    (4, 'VARIETY',     NOW(), NOW(), false);
+VALUES (1, 'MOVIE', NOW(), NOW(), false),
+       (2, 'DRAMA', NOW(), NOW(), false),
+       (3, 'ANIMATION', NOW(), NOW(), false),
+       (4, 'VARIETY', NOW(), NOW(), false);
 
 -- 2) 장르 데이터 삽입 (genre_id는 PK이므로 고유하게 부여)
 INSERT INTO genre (genre_id, genre_type, created_at, updated_at, category_id, is_deleted)
 VALUES
     -- ▶ MOVIE 분류에 속하는 영화 장르
-    ( 1, 'ACTION',           NOW(), NOW(), 1, false),
-    ( 2, 'FANTASY',          NOW(), NOW(), 1, false),
-    ( 3, 'SF',               NOW(), NOW(), 1, false),
-    ( 4, 'THRILLER',         NOW(), NOW(), 1, false),
-    ( 5, 'MYSTERY',          NOW(), NOW(), 1, false),
-    ( 6, 'ADVENTURE',        NOW(), NOW(), 1, false),
-    ( 7, 'MUSICAL',          NOW(), NOW(), 1, false),
-    ( 8, 'COMEDY',           NOW(), NOW(), 1, false),
-    ( 9, 'WESTERN',          NOW(), NOW(), 1, false),
-    (10, 'ROMANCE',          NOW(), NOW(), 1, false),
-    (11, 'DRAMA',            NOW(), NOW(), 1, false),
-    (12, 'HORROR',           NOW(), NOW(), 1, false),
-    (13, 'DOCUMENTARY',      NOW(), NOW(), 1, false),
-    (14, 'CRIME',            NOW(), NOW(), 1, false),
-    (15, 'MARTIAL_ARTS',     NOW(), NOW(), 1, false),
+    (1, 'ACTION', NOW(), NOW(), 1, false),
+    (2, 'FANTASY', NOW(), NOW(), 1, false),
+    (3, 'SF', NOW(), NOW(), 1, false),
+    (4, 'THRILLER', NOW(), NOW(), 1, false),
+    (5, 'MYSTERY', NOW(), NOW(), 1, false),
+    (6, 'ADVENTURE', NOW(), NOW(), 1, false),
+    (7, 'MUSICAL', NOW(), NOW(), 1, false),
+    (8, 'COMEDY', NOW(), NOW(), 1, false),
+    (9, 'WESTERN', NOW(), NOW(), 1, false),
+    (10, 'ROMANCE', NOW(), NOW(), 1, false),
+    (11, 'DRAMA', NOW(), NOW(), 1, false),
+    (12, 'HORROR', NOW(), NOW(), 1, false),
+    (13, 'DOCUMENTARY', NOW(), NOW(), 1, false),
+    (14, 'CRIME', NOW(), NOW(), 1, false),
+    (15, 'MARTIAL_ARTS', NOW(), NOW(), 1, false),
     (16, 'HISTORICAL_DRAMA', NOW(), NOW(), 1, false),
-    (17, 'ADULT',            NOW(), NOW(), 1, false),
-    (18, 'KIDS',             NOW(), NOW(), 1, false),
+    (17, 'ADULT', NOW(), NOW(), 1, false),
+    (18, 'KIDS', NOW(), NOW(), 1, false),
 
     -- ▶ DRAMA 분류에 속하는 드라마 장르
-    (19, 'DRAMA',            NOW(), NOW(), 2, false),
-    (20, 'ROMANCE',          NOW(), NOW(), 2, false),
-    (21, 'MYSTERY',          NOW(), NOW(), 2, false),
-    (22, 'THRILLER',         NOW(), NOW(), 2, false),
+    (19, 'DRAMA', NOW(), NOW(), 2, false),
+    (20, 'ROMANCE', NOW(), NOW(), 2, false),
+    (21, 'MYSTERY', NOW(), NOW(), 2, false),
+    (22, 'THRILLER', NOW(), NOW(), 2, false),
     (23, 'HISTORICAL_DRAMA', NOW(), NOW(), 2, false),
 
     -- ▶ ANIMATION 분류에 속하는 애니메이션 장르
-    (24, 'ANIMATION',        NOW(), NOW(), 3, false),
-    (25, 'KIDS',             NOW(), NOW(), 3, false),
+    (24, 'ANIMATION', NOW(), NOW(), 3, false),
+    (25, 'KIDS', NOW(), NOW(), 3, false),
 
     -- ▶ VARIETY 분류에 속하는 버라이어티 장르
-    (26, 'VARIETY',          NOW(), NOW(), 4, false),
-    (27, 'TALK_SHOW',        NOW(), NOW(), 4, false),
-    (28, 'SURVIVAL',         NOW(), NOW(), 4, false),
-    (29, 'REALITY',          NOW(), NOW(), 4, false),
-    (30, 'STAND_UP_COMEDY',  NOW(), NOW(), 4, false);
+    (26, 'VARIETY', NOW(), NOW(), 4, false),
+    (27, 'TALK_SHOW', NOW(), NOW(), 4, false),
+    (28, 'SURVIVAL', NOW(), NOW(), 4, false),
+    (29, 'REALITY', NOW(), NOW(), 4, false),
+    (30, 'STAND_UP_COMEDY', NOW(), NOW(), 4, false);
 
 -- 3) 플랫폼 데이터 삽입
 INSERT INTO platform (platform_id, platform_type, created_at, updated_at, is_deleted)
-VALUES
-    (1, 'NETFLIX',       NOW(), NOW(), false),
-    (2, 'TVING',         NOW(), NOW(), false),
-    (3, 'COUPANG_PLAY',  NOW(), NOW(), false),
-    (4, 'WAVVE',         NOW(), NOW(), false),
-    (5, 'DISNEY_PLUS',   NOW(), NOW(), false),
-    (6, 'WATCHA',        NOW(), NOW(), false),
-    (7, 'APPLE_TV',      NOW(), NOW(), false);
+VALUES (1, 'NETFLIX', NOW(), NOW(), false),
+       (2, 'TVING', NOW(), NOW(), false),
+       (3, 'COUPANG_PLAY', NOW(), NOW(), false),
+       (4, 'WAVVE', NOW(), NOW(), false),
+       (5, 'DISNEY_PLUS', NOW(), NOW(), false),
+       (6, 'WATCHA', NOW(), NOW(), false),
+       (7, 'APPLE_TV', NOW(), NOW(), false);

--- a/src/test/java/com/example/udtbe/common/fixture/CategoryFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/CategoryFixture.java
@@ -1,0 +1,33 @@
+package com.example.udtbe.common.fixture;
+
+import static com.example.udtbe.domain.content.entity.enums.CategoryType.ANIMATION;
+import static com.example.udtbe.domain.content.entity.enums.CategoryType.DRAMA;
+import static com.example.udtbe.domain.content.entity.enums.CategoryType.MOVIE;
+import static com.example.udtbe.domain.content.entity.enums.CategoryType.VARIETY;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.Category;
+import com.example.udtbe.domain.content.entity.enums.CategoryType;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class CategoryFixture {
+
+    public static List<Category> categories() {
+        List<CategoryType> platformTypes = List.of(
+                MOVIE,
+                DRAMA,
+                ANIMATION,
+                VARIETY
+        );
+
+        List<Category> categories = new ArrayList<>();
+        for (CategoryType categoryType : platformTypes) {
+            categories.add(Category.of((categoryType)));
+        }
+
+        return categories;
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/ContentCategoryFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentCategoryFixture.java
@@ -23,4 +23,8 @@ public class ContentCategoryFixture {
         list.add(contentCategory3);
         return list;
     }
+
+    public static ContentCategory contentCategory(Content content, Category category) {
+        return ContentCategory.of(content, category);
+    }
 }

--- a/src/test/java/com/example/udtbe/common/fixture/ContentCountryFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentCountryFixture.java
@@ -19,4 +19,8 @@ public class ContentCountryFixture {
         });
         return list;
     }
+
+    public static ContentCountry contentCountry(Content content, Country country) {
+        return ContentCountry.of(content, country);
+    }
 }

--- a/src/test/java/com/example/udtbe/common/fixture/ContentFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentFixture.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public class ContentFixture {
+
     public static Content content(String title, String description) {
         return Content.of(
                 title,
@@ -94,5 +95,19 @@ public class ContentFixture {
         });
 
         return list;
+    }
+
+    public static Content content(String title, LocalDateTime openDate, String rating) {
+        return Content.of(
+                title,
+                "description",
+                "https://example.com/default-poster.jpg",
+                "https://example.com/default-backdrop.jpg",
+                "https://example.com/default-trailer.mp4",
+                openDate,
+                120,
+                1,
+                rating
+        );
     }
 }

--- a/src/test/java/com/example/udtbe/common/fixture/ContentGenreFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentGenreFixture.java
@@ -41,4 +41,8 @@ public class ContentGenreFixture {
         });
         return list;
     }
+
+    public static ContentGenre contentGenre(Content content, Genre genre) {
+        return ContentGenre.of(content, genre);
+    }
 }

--- a/src/test/java/com/example/udtbe/common/fixture/ContentPlatformFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentPlatformFixture.java
@@ -22,4 +22,13 @@ public class ContentPlatformFixture {
         });
         return list;
     }
+
+    public static ContentPlatform contentPlatform(Content content, Platform platform) {
+        return ContentPlatform.of(
+                "watch_URL",
+                true,
+                content,
+                platform
+        );
+    }
 }

--- a/src/test/java/com/example/udtbe/common/fixture/CountryFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/CountryFixture.java
@@ -1,0 +1,35 @@
+package com.example.udtbe.common.fixture;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.Country;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class CountryFixture {
+
+    public static List<Country> countries() {
+        List<String> countryNames = List.of(
+                "한국",
+                "일본",
+                "중국",
+                "미국",
+                "대만",
+                "프랑스",
+                "홍콩",
+                "이탈리아",
+                "인도",
+                "벨기에",
+                "스웨덴"
+        );
+
+        List<Country> countries = new ArrayList<>();
+        for (String countryName : countryNames) {
+            countries.add(Country.of(countryName));
+        }
+
+        return countries;
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/GenreFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/GenreFixture.java
@@ -1,0 +1,74 @@
+package com.example.udtbe.common.fixture;
+
+import static com.example.udtbe.domain.content.entity.enums.GenreType.ACTION;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.ADULT;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.ADVENTURE;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.ANIMATION;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.COMEDY;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.CRIME;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.DOCUMENTARY;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.DRAMA;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.FANTASY;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.HISTORICAL_DRAMA;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.HORROR;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.KIDS;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.MARTIAL_ARTS;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.MUSICAL;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.MYSTERY;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.REALITY;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.ROMANCE;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.SF;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.STAND_UP_COMEDY;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.SURVIVAL;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.TALK_SHOW;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.THRILLER;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.VARIETY;
+import static com.example.udtbe.domain.content.entity.enums.GenreType.WESTERN;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.Category;
+import com.example.udtbe.domain.content.entity.Genre;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class GenreFixture {
+
+    public static List<Genre> genres(Category category) {
+        List<GenreType> genreTypes = List.of(
+                ACTION,
+                FANTASY,
+                SF,
+                THRILLER,
+                MYSTERY,
+                ADVENTURE,
+                MUSICAL,
+                COMEDY,
+                WESTERN,
+                ROMANCE,
+                DRAMA,
+                ANIMATION,
+                HORROR,
+                DOCUMENTARY,
+                CRIME,
+                MARTIAL_ARTS,
+                HISTORICAL_DRAMA,
+                ADULT,
+                KIDS,
+                VARIETY,
+                TALK_SHOW,
+                SURVIVAL,
+                REALITY,
+                STAND_UP_COMEDY
+        );
+
+        List<Genre> genres = new ArrayList<>();
+        for (GenreType genreType : genreTypes) {
+            genres.add(Genre.of(genreType, category));
+        }
+
+        return genres;
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/PlatformFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/PlatformFixture.java
@@ -1,0 +1,40 @@
+package com.example.udtbe.common.fixture;
+
+import static com.example.udtbe.domain.content.entity.enums.PlatformType.APPLE_TV;
+import static com.example.udtbe.domain.content.entity.enums.PlatformType.COUPANG_PLAY;
+import static com.example.udtbe.domain.content.entity.enums.PlatformType.DISNEY_PLUS;
+import static com.example.udtbe.domain.content.entity.enums.PlatformType.NETFLIX;
+import static com.example.udtbe.domain.content.entity.enums.PlatformType.TVING;
+import static com.example.udtbe.domain.content.entity.enums.PlatformType.WATCHA;
+import static com.example.udtbe.domain.content.entity.enums.PlatformType.WAVVE;
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.Platform;
+import com.example.udtbe.domain.content.entity.enums.PlatformType;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class PlatformFixture {
+
+    public static List<Platform> platforms() {
+        List<PlatformType> platformTypes = List.of(
+                NETFLIX,
+                TVING,
+                COUPANG_PLAY,
+                WAVVE,
+                DISNEY_PLUS,
+                WATCHA,
+                APPLE_TV
+        );
+
+        List<Platform> platforms = new ArrayList<>();
+        for (PlatformType platformType : platformTypes) {
+            platforms.add(Platform.of(platformType));
+        }
+
+        return platforms;
+    }
+
+}

--- a/src/test/java/com/example/udtbe/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/example/udtbe/content/controller/ContentControllerTest.java
@@ -1,0 +1,336 @@
+package com.example.udtbe.content.controller;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.udtbe.common.fixture.CategoryFixture;
+import com.example.udtbe.common.fixture.ContentCategoryFixture;
+import com.example.udtbe.common.fixture.ContentCountryFixture;
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentGenreFixture;
+import com.example.udtbe.common.fixture.ContentPlatformFixture;
+import com.example.udtbe.common.fixture.CountryFixture;
+import com.example.udtbe.common.fixture.GenreFixture;
+import com.example.udtbe.common.fixture.PlatformFixture;
+import com.example.udtbe.common.support.ApiSupport;
+import com.example.udtbe.domain.content.controller.ContentController;
+import com.example.udtbe.domain.content.entity.Category;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentCategory;
+import com.example.udtbe.domain.content.entity.ContentCountry;
+import com.example.udtbe.domain.content.entity.ContentGenre;
+import com.example.udtbe.domain.content.entity.ContentPlatform;
+import com.example.udtbe.domain.content.entity.Country;
+import com.example.udtbe.domain.content.entity.Genre;
+import com.example.udtbe.domain.content.entity.Platform;
+import com.example.udtbe.domain.content.repository.CategoryRepository;
+import com.example.udtbe.domain.content.repository.ContentCategoryRepository;
+import com.example.udtbe.domain.content.repository.ContentCountryRepository;
+import com.example.udtbe.domain.content.repository.ContentGenreRepository;
+import com.example.udtbe.domain.content.repository.ContentPlatformRepository;
+import com.example.udtbe.domain.content.repository.ContentRepository;
+import com.example.udtbe.domain.content.repository.CountryRepository;
+import com.example.udtbe.domain.content.repository.GenreRepository;
+import com.example.udtbe.domain.content.repository.PlatformRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ContentControllerTest extends ApiSupport {
+
+    @Autowired
+    ContentController contentController;
+
+    @Autowired
+    ContentRepository contentRepository;
+
+    @Autowired
+    ContentPlatformRepository contentPlatformRepository;
+
+    @Autowired
+    ContentCountryRepository contentCountryRepository;
+
+    @Autowired
+    PlatformRepository platformRepository;
+
+    @Autowired
+    CountryRepository countryRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    ContentCategoryRepository contentCategoryRepository;
+
+    @Autowired
+    GenreRepository genreRepository;
+
+    @Autowired
+    ContentGenreRepository contentGenreRepository;
+
+    @AfterEach
+    void tearDown() {
+        contentPlatformRepository.deleteAllInBatch();
+        contentCountryRepository.deleteAllInBatch();
+        platformRepository.deleteAllInBatch();
+        countryRepository.deleteAllInBatch();
+        contentRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("OTT 플랫폼, 국가, 방영일, 등급, 카테고리, 장르 등 필터링에 따른 콘텐츠 목록을 조회한다.")
+    @Test
+    void getFilteredContents_V1() throws Exception {
+        // given
+        final String koreaMovie = "한국영화";
+        final String usaMovie = "미국영화";
+        final String japanMovie = "일본영화";
+        final String ratingAll = "전체 관람가";
+        final String rating12 = "12세 이상";
+        final String rating15 = "15세 이상";
+        final String rating18 = "청소년 관람불가";
+        final int year2020 = 2020;
+        final int year2021 = 2021;
+        final int year2022 = 2022;
+        final int year2023 = 2023;
+        final int year2024 = 2024;
+
+        List<Country> savedCountries = countryRepository.saveAll(CountryFixture.countries());
+        List<Platform> savedPlatforms = platformRepository.saveAll(PlatformFixture.platforms());
+        List<Category> savedCategories = categoryRepository.saveAll(CategoryFixture.categories());
+        List<Genre> savedGenres = genreRepository.saveAll(
+                GenreFixture.genres(savedCategories.get(0)));
+
+        List<Content> contents = new ArrayList<>();
+        initContent(contents, koreaMovie + "1", year2020, ratingAll);
+        initContent(contents, koreaMovie + "2", year2022, rating15);
+        initContent(contents, koreaMovie + "3", year2021, rating18);
+        initContent(contents, usaMovie + "1", year2024, rating15);
+        initContent(contents, usaMovie + "2", year2023, rating15);
+        initContent(contents, usaMovie + "3", year2021, rating12);
+        initContent(contents, japanMovie + "1", year2024, rating18);
+        initContent(contents, japanMovie + "2", year2024, ratingAll);
+        initContent(contents, japanMovie + "3", year2022, rating12);
+
+        List<Content> savedContents = contentRepository.saveAll(contents);
+
+        List<ContentCountry> contentCountries = new ArrayList<>();
+        initContentCountry(contentCountries, savedContents.get(0), savedCountries.get(0));
+        initContentCountry(contentCountries, savedContents.get(1), savedCountries.get(0));
+        initContentCountry(contentCountries, savedContents.get(2), savedCountries.get(0));
+        initContentCountry(contentCountries, savedContents.get(3), savedCountries.get(3));
+        initContentCountry(contentCountries, savedContents.get(4), savedCountries.get(3));
+        initContentCountry(contentCountries, savedContents.get(5), savedCountries.get(3));
+        initContentCountry(contentCountries, savedContents.get(6), savedCountries.get(1));
+        initContentCountry(contentCountries, savedContents.get(7), savedCountries.get(1));
+        initContentCountry(contentCountries, savedContents.get(8), savedCountries.get(1));
+        contentCountryRepository.saveAll(contentCountries);
+
+        List<ContentPlatform> contentPlatforms = new ArrayList<>();
+        initContentPlatform(contentPlatforms, savedContents.get(0), savedPlatforms.get(0));
+        initContentPlatform(contentPlatforms, savedContents.get(0), savedPlatforms.get(4));
+        initContentPlatform(contentPlatforms, savedContents.get(1), savedPlatforms.get(1));
+        initContentPlatform(contentPlatforms, savedContents.get(2), savedPlatforms.get(0));
+        initContentPlatform(contentPlatforms, savedContents.get(2), savedPlatforms.get(3));
+        initContentPlatform(contentPlatforms, savedContents.get(2), savedPlatforms.get(5));
+        initContentPlatform(contentPlatforms, savedContents.get(3), savedPlatforms.get(1));
+        initContentPlatform(contentPlatforms, savedContents.get(4), savedPlatforms.get(2));
+        initContentPlatform(contentPlatforms, savedContents.get(5), savedPlatforms.get(4));
+        initContentPlatform(contentPlatforms, savedContents.get(6), savedPlatforms.get(3));
+        initContentPlatform(contentPlatforms, savedContents.get(7), savedPlatforms.get(5));
+        initContentPlatform(contentPlatforms, savedContents.get(8), savedPlatforms.get(6));
+        contentPlatformRepository.saveAll(contentPlatforms);
+
+        List<ContentCategory> contentCategories = new ArrayList<>();
+        initContentCategory(contentCategories, savedContents.get(0), savedCategories.get(0));
+        initContentCategory(contentCategories, savedContents.get(1), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(2), savedCategories.get(2));
+        initContentCategory(contentCategories, savedContents.get(3), savedCategories.get(3));
+        initContentCategory(contentCategories, savedContents.get(4), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(5), savedCategories.get(0));
+        initContentCategory(contentCategories, savedContents.get(6), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(7), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(8), savedCategories.get(0));
+        contentCategoryRepository.saveAll(contentCategories);
+
+        List<ContentGenre> contentGenres = new ArrayList<>();
+        initContentGenre(contentGenres, savedContents.get(0), savedGenres.get(0));
+        initContentGenre(contentGenres, savedContents.get(0), savedGenres.get(2));
+        initContentGenre(contentGenres, savedContents.get(1), savedGenres.get(12));
+        initContentGenre(contentGenres, savedContents.get(2), savedGenres.get(13));
+        initContentGenre(contentGenres, savedContents.get(3), savedGenres.get(12));
+        initContentGenre(contentGenres, savedContents.get(4), savedGenres.get(10));
+        initContentGenre(contentGenres, savedContents.get(5), savedGenres.get(3));
+        initContentGenre(contentGenres, savedContents.get(5), savedGenres.get(5));
+        initContentGenre(contentGenres, savedContents.get(6), savedGenres.get(6));
+        initContentGenre(contentGenres, savedContents.get(7), savedGenres.get(0));
+        initContentGenre(contentGenres, savedContents.get(8), savedGenres.get(3));
+        contentGenreRepository.saveAll(contentGenres);
+
+        // when  // then
+        mockMvc.perform(post("/api/contents")
+                        .param("size", "3")
+                        .param("contentSearchConditionDTO.platforms", "넷플릭스", "디즈니+")
+                        .param("contentSearchConditionDTO.countries", "한국", "미국")
+                        .param("contentSearchConditionDTO.openDates", "2020-01-01T00:00:00",
+                                "2021-01-01T00:00:00")
+                        .param("contentSearchConditionDTO.ratings", "전체 관람가", "12세 이상")
+                        .param("contentSearchConditionDTO.categories", "영화")
+                        .param("contentSearchConditionDTO.genres", "액션", "스릴러", "SF", "어드벤처")
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfMember)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item").isArray())
+                .andExpect(jsonPath("$.item.length()").value(2))
+                .andExpect(jsonPath("$.item[0].title").value(usaMovie + "3"))
+                .andExpect(jsonPath("$.item[1].title").value(koreaMovie + "1"))
+                .andExpect(jsonPath("$.nextCursor", is(nullValue())))
+                .andExpect(jsonPath("$.hasNext").value(false))
+        ;
+    }
+
+    @DisplayName("OTT 플랫폼, 국가, 방영일, 등급, 카테고리, 장르 등 필터링에 따른 콘텐츠 목록을 조회한다.")
+    @Test
+    void getFilteredContents_V2() throws Exception {
+        // given
+        final String koreaMovie = "한국영화";
+        final String usaMovie = "미국영화";
+        final String japanMovie = "일본영화";
+        final String ratingAll = "전체 관람가";
+        final String rating12 = "12세 이상";
+        final String rating15 = "15세 이상";
+        final String rating18 = "청소년 관람불가";
+        final int year2020 = 2020;
+        final int year2021 = 2021;
+        final int year2022 = 2022;
+        final int year2023 = 2023;
+        final int year2024 = 2024;
+
+        List<Country> savedCountries = countryRepository.saveAll(CountryFixture.countries());
+        List<Platform> savedPlatforms = platformRepository.saveAll(PlatformFixture.platforms());
+        List<Category> savedCategories = categoryRepository.saveAll(CategoryFixture.categories());
+        List<Genre> savedGenres = genreRepository.saveAll(
+                GenreFixture.genres(savedCategories.get(0)));
+
+        List<Content> contents = new ArrayList<>();
+        initContent(contents, koreaMovie + "1", year2020, ratingAll);
+        initContent(contents, koreaMovie + "2", year2022, rating15);
+        initContent(contents, koreaMovie + "3", year2021, rating18);
+        initContent(contents, usaMovie + "1", year2024, rating15);
+        initContent(contents, usaMovie + "2", year2023, rating15);
+        initContent(contents, usaMovie + "3", year2021, rating12);
+        initContent(contents, japanMovie + "1", year2024, rating18);
+        initContent(contents, japanMovie + "2", year2024, ratingAll);
+        initContent(contents, japanMovie + "3", year2022, rating12);
+
+        List<Content> savedContents = contentRepository.saveAll(contents);
+
+        List<ContentCountry> contentCountries = new ArrayList<>();
+        initContentCountry(contentCountries, savedContents.get(0), savedCountries.get(0));
+        initContentCountry(contentCountries, savedContents.get(1), savedCountries.get(0));
+        initContentCountry(contentCountries, savedContents.get(2), savedCountries.get(0));
+        initContentCountry(contentCountries, savedContents.get(3), savedCountries.get(3));
+        initContentCountry(contentCountries, savedContents.get(4), savedCountries.get(3));
+        initContentCountry(contentCountries, savedContents.get(5), savedCountries.get(3));
+        initContentCountry(contentCountries, savedContents.get(6), savedCountries.get(1));
+        initContentCountry(contentCountries, savedContents.get(7), savedCountries.get(1));
+        initContentCountry(contentCountries, savedContents.get(8), savedCountries.get(1));
+        contentCountryRepository.saveAll(contentCountries);
+
+        List<ContentPlatform> contentPlatforms = new ArrayList<>();
+        initContentPlatform(contentPlatforms, savedContents.get(0), savedPlatforms.get(0));
+        initContentPlatform(contentPlatforms, savedContents.get(0), savedPlatforms.get(4));
+        initContentPlatform(contentPlatforms, savedContents.get(1), savedPlatforms.get(1));
+        initContentPlatform(contentPlatforms, savedContents.get(2), savedPlatforms.get(0));
+        initContentPlatform(contentPlatforms, savedContents.get(2), savedPlatforms.get(3));
+        initContentPlatform(contentPlatforms, savedContents.get(2), savedPlatforms.get(5));
+        initContentPlatform(contentPlatforms, savedContents.get(3), savedPlatforms.get(1));
+        initContentPlatform(contentPlatforms, savedContents.get(4), savedPlatforms.get(2));
+        initContentPlatform(contentPlatforms, savedContents.get(5), savedPlatforms.get(4));
+        initContentPlatform(contentPlatforms, savedContents.get(6), savedPlatforms.get(3));
+        initContentPlatform(contentPlatforms, savedContents.get(7), savedPlatforms.get(5));
+        initContentPlatform(contentPlatforms, savedContents.get(8), savedPlatforms.get(6));
+        contentPlatformRepository.saveAll(contentPlatforms);
+
+        List<ContentCategory> contentCategories = new ArrayList<>();
+        initContentCategory(contentCategories, savedContents.get(0), savedCategories.get(0));
+        initContentCategory(contentCategories, savedContents.get(1), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(2), savedCategories.get(2));
+        initContentCategory(contentCategories, savedContents.get(3), savedCategories.get(3));
+        initContentCategory(contentCategories, savedContents.get(4), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(5), savedCategories.get(0));
+        initContentCategory(contentCategories, savedContents.get(6), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(7), savedCategories.get(1));
+        initContentCategory(contentCategories, savedContents.get(8), savedCategories.get(0));
+        contentCategoryRepository.saveAll(contentCategories);
+
+        List<ContentGenre> contentGenres = new ArrayList<>();
+        initContentGenre(contentGenres, savedContents.get(0), savedGenres.get(0));
+        initContentGenre(contentGenres, savedContents.get(0), savedGenres.get(2));
+        initContentGenre(contentGenres, savedContents.get(1), savedGenres.get(12));
+        initContentGenre(contentGenres, savedContents.get(2), savedGenres.get(13));
+        initContentGenre(contentGenres, savedContents.get(3), savedGenres.get(12));
+        initContentGenre(contentGenres, savedContents.get(4), savedGenres.get(10));
+        initContentGenre(contentGenres, savedContents.get(5), savedGenres.get(3));
+        initContentGenre(contentGenres, savedContents.get(5), savedGenres.get(5));
+        initContentGenre(contentGenres, savedContents.get(6), savedGenres.get(6));
+        initContentGenre(contentGenres, savedContents.get(7), savedGenres.get(0));
+        initContentGenre(contentGenres, savedContents.get(8), savedGenres.get(3));
+        contentGenreRepository.saveAll(contentGenres);
+
+        // when  // then
+        mockMvc.perform(post("/api/contents")
+                        .param("size", "1")
+                        .param("contentSearchConditionDTO.platforms", "넷플릭스", "디즈니+")
+                        .param("contentSearchConditionDTO.countries", "한국", "미국")
+                        .param("contentSearchConditionDTO.openDates", "2020-01-01T00:00:00",
+                                "2021-01-01T00:00:00")
+                        .param("contentSearchConditionDTO.ratings", "전체 관람가", "12세 이상")
+                        .param("contentSearchConditionDTO.categories", "영화")
+                        .param("contentSearchConditionDTO.genres", "액션", "스릴러", "SF", "어드벤처")
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfMember)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.item").isArray())
+                .andExpect(jsonPath("$.item.length()").value(1))
+                .andExpect(jsonPath("$.item[0].title").value(usaMovie + "3"))
+                .andExpect(jsonPath("$.nextCursor").value(
+                        savedContents.get(5).getId() + "|" + savedContents.get(5).getOpenDate())
+                )
+                .andExpect(jsonPath("$.hasNext").value(true))
+        ;
+    }
+
+    private void initContent(List<Content> contents, String title, int year, String rating) {
+        contents.add(ContentFixture.content(title, LocalDateTime.of(year, 1, 1, 0, 0), rating));
+    }
+
+    private void initContentCountry(List<ContentCountry> contentCountries,
+            Content content, Country country) {
+        contentCountries.add(ContentCountryFixture.contentCountry(content, country));
+    }
+
+    private void initContentPlatform(List<ContentPlatform> contentPlatforms,
+            Content content, Platform platform) {
+        contentPlatforms.add(ContentPlatformFixture.contentPlatform(content, platform));
+    }
+
+    private void initContentCategory(List<ContentCategory> contentCategories,
+            Content content, Category category) {
+        contentCategories.add(ContentCategoryFixture.contentCategory(content, category));
+    }
+
+    private void initContentGenre(List<ContentGenre> contentGenres,
+            Content content, Genre genre) {
+        contentGenres.add(ContentGenreFixture.contentGenre(content, genre));
+    }
+}

--- a/src/test/resources/data-test.sql
+++ b/src/test/resources/data-test.sql
@@ -1,61 +1,58 @@
-
 -- 1) 카테고리 데이터 삽입
 INSERT INTO category (category_id, category_type, created_at, updated_at, is_deleted)
-VALUES
-    (1, 'MOVIE',       NOW(), NOW(), false),
-    (2, 'DRAMA',       NOW(), NOW(), false),
-    (3, 'ANIMATION',   NOW(), NOW(), false),
-    (4, 'VARIETY',     NOW(), NOW(), false);
+VALUES (1, 'MOVIE', NOW(), NOW(), false),
+       (2, 'DRAMA', NOW(), NOW(), false),
+       (3, 'ANIMATION', NOW(), NOW(), false),
+       (4, 'VARIETY', NOW(), NOW(), false);
 
 -- 2) 장르 데이터 삽입 (genre_id는 PK이므로 고유하게 부여)
 INSERT INTO genre (genre_id, genre_type, created_at, updated_at, category_id, is_deleted)
 VALUES
 
     -- ▶ MOVIE 분류에 속하는 영화 장르
-    ( 1, 'ACTION',           NOW(), NOW(), 1, false),
-    ( 2, 'FANTASY',          NOW(), NOW(), 1, false),
-    ( 3, 'SF',               NOW(), NOW(), 1, false),
-    ( 4, 'THRILLER',         NOW(), NOW(), 1, false),
-    ( 5, 'MYSTERY',          NOW(), NOW(), 1, false),
-    ( 6, 'ADVENTURE',        NOW(), NOW(), 1, false),
-    ( 7, 'MUSICAL',          NOW(), NOW(), 1, false),
-    ( 8, 'COMEDY',           NOW(), NOW(), 1, false),
-    ( 9, 'WESTERN',          NOW(), NOW(), 1, false),
-    (10, 'ROMANCE',          NOW(), NOW(), 1, false),
-    (11, 'DRAMA',            NOW(), NOW(), 1, false),
-    (12, 'HORROR',           NOW(), NOW(), 1, false),
-    (13, 'DOCUMENTARY',      NOW(), NOW(), 1, false),
-    (14, 'CRIME',            NOW(), NOW(), 1, false),
-    (15, 'MARTIAL_ARTS',     NOW(), NOW(), 1, false),
+    (1, 'ACTION', NOW(), NOW(), 1, false),
+    (2, 'FANTASY', NOW(), NOW(), 1, false),
+    (3, 'SF', NOW(), NOW(), 1, false),
+    (4, 'THRILLER', NOW(), NOW(), 1, false),
+    (5, 'MYSTERY', NOW(), NOW(), 1, false),
+    (6, 'ADVENTURE', NOW(), NOW(), 1, false),
+    (7, 'MUSICAL', NOW(), NOW(), 1, false),
+    (8, 'COMEDY', NOW(), NOW(), 1, false),
+    (9, 'WESTERN', NOW(), NOW(), 1, false),
+    (10, 'ROMANCE', NOW(), NOW(), 1, false),
+    (11, 'DRAMA', NOW(), NOW(), 1, false),
+    (12, 'HORROR', NOW(), NOW(), 1, false),
+    (13, 'DOCUMENTARY', NOW(), NOW(), 1, false),
+    (14, 'CRIME', NOW(), NOW(), 1, false),
+    (15, 'MARTIAL_ARTS', NOW(), NOW(), 1, false),
     (16, 'HISTORICAL_DRAMA', NOW(), NOW(), 1, false),
-    (17, 'ADULT',            NOW(), NOW(), 1, false),
-    (18, 'KIDS',             NOW(), NOW(), 1, false),
+    (17, 'ADULT', NOW(), NOW(), 1, false),
+    (18, 'KIDS', NOW(), NOW(), 1, false),
 
     -- ▶ DRAMA 분류에 속하는 드라마 장르
-    (19, 'DRAMA',            NOW(), NOW(), 2, false),
-    (20, 'ROMANCE',          NOW(), NOW(), 2, false),
-    (21, 'MYSTERY',          NOW(), NOW(), 2, false),
-    (22, 'THRILLER',         NOW(), NOW(), 2, false),
+    (19, 'DRAMA', NOW(), NOW(), 2, false),
+    (20, 'ROMANCE', NOW(), NOW(), 2, false),
+    (21, 'MYSTERY', NOW(), NOW(), 2, false),
+    (22, 'THRILLER', NOW(), NOW(), 2, false),
     (23, 'HISTORICAL_DRAMA', NOW(), NOW(), 2, false),
 
     -- ▶ ANIMATION 분류에 속하는 애니메이션 장르
-    (24, 'ANIMATION',        NOW(), NOW(), 3, false),
-    (25, 'KIDS',             NOW(), NOW(), 3, false),
+    (24, 'ANIMATION', NOW(), NOW(), 3, false),
+    (25, 'KIDS', NOW(), NOW(), 3, false),
 
     -- ▶ VARIETY 분류에 속하는 버라이어티 장르
-    (26, 'VARIETY',          NOW(), NOW(), 4, false),
-    (27, 'TALK_SHOW',        NOW(), NOW(), 4, false),
-    (28, 'SURVIVAL',         NOW(), NOW(), 4, false),
-    (29, 'REALITY',          NOW(), NOW(), 4, false),
-    (30, 'STAND_UP_COMEDY',  NOW(), NOW(), 4, false);
+    (26, 'VARIETY', NOW(), NOW(), 4, false),
+    (27, 'TALK_SHOW', NOW(), NOW(), 4, false),
+    (28, 'SURVIVAL', NOW(), NOW(), 4, false),
+    (29, 'REALITY', NOW(), NOW(), 4, false),
+    (30, 'STAND_UP_COMEDY', NOW(), NOW(), 4, false);
 
 -- 3) 플랫폼 데이터 삽입
 INSERT INTO platform (platform_id, platform_type, created_at, updated_at, is_deleted)
-VALUES
-    (1, 'NETFLIX',       NOW(), NOW(), false),
-    (2, 'TVING',         NOW(), NOW(), false),
-    (3, 'COUPANG_PLAY',  NOW(), NOW(), false),
-    (4, 'WAVVE',         NOW(), NOW(), false),
-    (5, 'DISNEY_PLUS',   NOW(), NOW(), false),
-    (6, 'WATCHA',        NOW(), NOW(), false),
-    (7, 'APPLE_TV',      NOW(), NOW(), false);
+VALUES (1, 'NETFLIX', NOW(), NOW(), false),
+       (2, 'TVING', NOW(), NOW(), false),
+       (3, 'COUPANG_PLAY', NOW(), NOW(), false),
+       (4, 'WAVVE', NOW(), NOW(), false),
+       (5, 'DISNEY_PLUS', NOW(), NOW(), false),
+       (6, 'WATCHA', NOW(), NOW(), false),
+       (7, 'APPLE_TV', NOW(), NOW(), false);


### PR DESCRIPTION
## 📝 요약(Summary)

- OTT 콘텐츠 목록 조회 API 구현
  - 필터링에 따른 OTT 콘텐츠 목록 조회를 가능하게 한다.
  - 필터링 조건
    1. OTT 플랫폼
    2. 국가
    3. 개봉일
    4. 등급
    5. 카테고리
    6. 장르

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- Join의 연속보다 계층형 필터링 구조로 구현했습니다.
  - 쿼리 수 / 성능 개선은 추후 리팩토링으로 생각하고 있습니다.
- QueryDSL에 대한 직접적인 테스트는 따로 진행하지 않았습니다. 대신, 통합 테스트를 통해 검증하였습니다.
- 통합 테스트 코드가 조금 복잡할 수 있어, Review 예상 시간을 넉넉하게 작성하였습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 15분
