### PR TITLE
feat/UDT-89-OTT-요일별-추천-콘텐츠-목록-조회

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/controller/ContentController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/ContentController.java
@@ -1,10 +1,13 @@
 package com.example.udtbe.domain.content.controller;
 
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
 import com.example.udtbe.domain.content.service.ContentService;
 import com.example.udtbe.global.dto.CursorPageResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,6 +28,14 @@ public class ContentController implements ContentControllerApiSpec {
     @Override
     public ResponseEntity<ContentDetailsGetResponse> getContentDetails(Long contentId) {
         ContentDetailsGetResponse response = contentService.getContentDetails(contentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<List<WeeklyRecommendedContentsResponse>> getWeeklyRecommendedContents(
+            WeeklyRecommendationRequest request) {
+        List<WeeklyRecommendedContentsResponse> response =
+                contentService.getWeeklyRecommendedContents(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/controller/ContentControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/ContentControllerApiSpec.java
@@ -1,13 +1,16 @@
 package com.example.udtbe.domain.content.controller;
 
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -29,5 +32,12 @@ public interface ContentControllerApiSpec {
     @GetMapping("/api/contents/{contentId}")
     public ResponseEntity<ContentDetailsGetResponse> getContentDetails(
             @PathVariable(name = "contentId") Long contentId
+    );
+
+    @Operation(summary = "요일별 추천 콘텐츠 조회 API", description = "요일별 추천 콘텐츠 목록을 조회한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/api/contents/weekly")
+    public ResponseEntity<List<WeeklyRecommendedContentsResponse>> getWeeklyRecommendedContents(
+            @ModelAttribute @Valid WeeklyRecommendationRequest request
     );
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/request/WeeklyRecommendationRequest.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/request/WeeklyRecommendationRequest.java
@@ -1,0 +1,12 @@
+package com.example.udtbe.domain.content.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record WeeklyRecommendationRequest(
+        @Min(value = 1, message = "요청 크기는 최소 1개입니다.")
+        @Max(value = 10, message = "요청 크기는 최대 10개입니다.")
+        int size
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/content/dto/response/WeeklyRecommendedContentsResponse.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/response/WeeklyRecommendedContentsResponse.java
@@ -1,0 +1,16 @@
+package com.example.udtbe.domain.content.dto.response;
+
+import com.example.udtbe.domain.content.entity.Content;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record WeeklyRecommendedContentsResponse(
+        Long contentId,
+        String posterUrl
+) {
+
+    @QueryProjection
+    public WeeklyRecommendedContentsResponse(Content content) {
+        this(content.getId(), content.getPosterUrl());
+    }
+
+}

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryCustom.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryCustom.java
@@ -2,9 +2,13 @@ package com.example.udtbe.domain.content.repository;
 
 import com.example.udtbe.domain.admin.dto.common.ContentDTO;
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
 import com.example.udtbe.global.dto.CursorPageResponse;
+import java.util.List;
 
 public interface ContentRepositoryCustom {
 
@@ -13,4 +17,7 @@ public interface ContentRepositoryCustom {
     CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request);
 
     ContentDetailsGetResponse getContentDetails(Long contentId);
+
+    List<WeeklyRecommendedContentsResponse> getWeeklyRecommendedContents(
+            WeeklyRecommendationRequest request, List<GenreType> genreTypes);
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
@@ -16,9 +16,12 @@ import static com.example.udtbe.domain.content.entity.QPlatform.platform;
 
 import com.example.udtbe.domain.admin.dto.common.ContentDTO;
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
 import com.example.udtbe.domain.content.dto.response.QContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.QWeeklyRecommendedContentsResponse;
+import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
 import com.example.udtbe.domain.content.entity.Cast;
 import com.example.udtbe.domain.content.entity.Category;
 import com.example.udtbe.domain.content.entity.Content;
@@ -207,6 +210,26 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
         );
     }
 
+    @Override
+    public List<WeeklyRecommendedContentsResponse> getWeeklyRecommendedContents(
+            WeeklyRecommendationRequest request, List<GenreType> genreTypes) {
+
+        List<WeeklyRecommendedContentsResponse> items = queryFactory
+                .select(new QWeeklyRecommendedContentsResponse(content))
+                .from(content)
+                .leftJoin(content.contentGenres, contentGenre)
+                .leftJoin(contentGenre.genre, genre)
+                .where(
+                        deletedFilter(),
+                        genresFilter(genreTypes)
+                )
+                .orderBy(content.id.desc())
+                .limit(request.size())
+                .fetch();
+
+        return items;
+    }
+
     private List<Long> getContentIdsByPlatformTypes(List<String> platforms,
             List<Long> allContentIds) {
 
@@ -338,6 +361,10 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
                 .from(content)
                 .where(content.id.eq(contentId))
                 .fetchOne();
+    }
+
+    private BooleanExpression genresFilter(List<GenreType> genreTypes) {
+        return genre.genreType.in(genreTypes);
     }
 
     private BooleanExpression cursorFilter(Long cursor) {

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentQuery.java
@@ -1,8 +1,11 @@
 package com.example.udtbe.domain.content.service;
 
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
 import com.example.udtbe.domain.content.repository.CastRepository;
 import com.example.udtbe.domain.content.repository.CategoryRepository;
 import com.example.udtbe.domain.content.repository.ContentCastRepository;
@@ -17,6 +20,7 @@ import com.example.udtbe.domain.content.repository.DirectorRepository;
 import com.example.udtbe.domain.content.repository.GenreRepository;
 import com.example.udtbe.domain.content.repository.PlatformRepository;
 import com.example.udtbe.global.dto.CursorPageResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -44,5 +48,10 @@ public class ContentQuery {
 
     public ContentDetailsGetResponse getContentDetails(Long contentId) {
         return contentRepository.getContentDetails(contentId);
+    }
+
+    public List<WeeklyRecommendedContentsResponse> getWeeklyRecommendedContents(
+            WeeklyRecommendationRequest request, List<GenreType> genreTypes) {
+        return contentRepository.getWeeklyRecommendedContents(request, genreTypes);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
@@ -1,9 +1,15 @@
 package com.example.udtbe.domain.content.service;
 
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.global.config.WeeklyGenrePolicyProperties;
 import com.example.udtbe.global.dto.CursorPageResponse;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContentService {
 
     private final ContentQuery contentQuery;
+    private final WeeklyGenrePolicyProperties weeklyGenrePolicyProperties;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request) {
@@ -22,5 +29,12 @@ public class ContentService {
     @Transactional(readOnly = true)
     public ContentDetailsGetResponse getContentDetails(Long contentId) {
         return contentQuery.getContentDetails(contentId);
+    }
+
+    public List<WeeklyRecommendedContentsResponse> getWeeklyRecommendedContents(
+            WeeklyRecommendationRequest request) {
+        List<GenreType> genreTypes = weeklyGenrePolicyProperties.getGenreForToday(
+                LocalDate.now().getDayOfWeek());
+        return contentQuery.getWeeklyRecommendedContents(request, genreTypes);
     }
 }

--- a/src/main/java/com/example/udtbe/global/config/WeeklyGenrePolicyProperties.java
+++ b/src/main/java/com/example/udtbe/global/config/WeeklyGenrePolicyProperties.java
@@ -1,0 +1,23 @@
+package com.example.udtbe.global.config;
+
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import java.time.DayOfWeek;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "weekly-genre-policy")
+public class WeeklyGenrePolicyProperties {
+
+    private final Map<DayOfWeek, List<GenreType>> genreByDay = new EnumMap<>(DayOfWeek.class);
+
+    public List<GenreType> getGenreForToday(DayOfWeek today) {
+        return genreByDay.getOrDefault(today, Collections.emptyList());
+    }
+}

--- a/src/test/java/com/example/udtbe/policy/WeeklyGenrePolicyPropertiesTest.java
+++ b/src/test/java/com/example/udtbe/policy/WeeklyGenrePolicyPropertiesTest.java
@@ -1,0 +1,56 @@
+package com.example.udtbe.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.example.udtbe.common.support.ApiSupport;
+import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.global.config.WeeklyGenrePolicyProperties;
+import java.time.DayOfWeek;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(locations = "classpath:application.yml")
+@EnableConfigurationProperties(WeeklyGenrePolicyProperties.class)
+class WeeklyGenrePolicyPropertiesTest extends ApiSupport {
+
+    @Autowired
+    WeeklyGenrePolicyProperties weeklyGenrePolicyProperties;
+
+    @DisplayName("월요일 정책에 해당하는 장르를 가져온다.")
+    @Test
+    void getGenresForMondayPolicy() {
+        // given
+        DayOfWeek monday = DayOfWeek.MONDAY;
+
+        // when
+        List<GenreType> genreTypes = weeklyGenrePolicyProperties.getGenreForToday(monday);
+
+        // then
+        assertAll(
+                () -> assertThat(genreTypes.size()).isEqualTo(2),
+                () -> assertThat(genreTypes.get(0)).isEqualByComparingTo(GenreType.VARIETY),
+                () -> assertThat(genreTypes.get(1)).isEqualByComparingTo(GenreType.COMEDY)
+        );
+    }
+
+    @DisplayName("목요일 정책에 해당하는 장르를 가져온다.")
+    @Test
+    void getGenresForThursdayPolicy() {
+        // given
+        DayOfWeek monday = DayOfWeek.THURSDAY;
+
+        // when
+        List<GenreType> genreTypes = weeklyGenrePolicyProperties.getGenreForToday(monday);
+
+        // then
+        assertThat(genreTypes.size()).isZero();
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- 요일별 OTT 추천 콘텐츠 목록 조회 API
  - request.size(Min = 1, Max = 10)에 따라 요일에 따른 장르별 OTT 추천 콘텐츠 목록을 조회합니다.
  - 삭제되지 않은 콘텐츠 목록만 조회합니다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- 요일별 장르 정책에 따라 통합 테스트 결과가 바뀌는 점을 고려해 테스트를 작성하느라 시간이 지체되었습니다..
- 통합테스트 검증이 지금 썩 마음에 들지 않는 검증 방식입니다..

### 논의사안
- 사용자가 설문조사한 OTT 플랫폼 여부는 논의되지 않아 조건을 추가하지 않았습니다. 필요시 수정하겠습니다.
- 매 번 같아도 되는지 또는 매 번 달라야하는지(접근마다? 주차마다?) 논의되지 않아 `.limit(requset.size())`로 구현했습니다. 필요시 수정하겠습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분
