### PR TITLE
feat/UDT-76-설문조사-후-회원-ROLE-업데이트

### DIFF
--- a/src/main/java/com/example/udtbe/domain/member/entity/Member.java
+++ b/src/main/java/com/example/udtbe/domain/member/entity/Member.java
@@ -82,4 +82,8 @@ public class Member extends TimeBaseEntity {
     public void updateLastLoginAt(LocalDateTime lastLoginAt) {
         this.lastLoginAt = lastLoginAt;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/example/udtbe/domain/survey/controller/SurveyController.java
@@ -3,6 +3,7 @@ package com.example.udtbe.domain.survey.controller;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
 import com.example.udtbe.domain.survey.service.SurveyService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,8 +15,9 @@ public class SurveyController implements SurveyControllerApiSpec {
     private final SurveyService surveyService;
 
     @Override
-    public ResponseEntity<Void> survey(SurveyCreateRequest request, Member member) {
-        surveyService.createSurvey(request, member);
+    public ResponseEntity<Void> survey(SurveyCreateRequest request, Member member,
+            HttpServletResponse response) {
+        surveyService.createSurvey(request, member, response);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/udtbe/domain/survey/controller/SurveyControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/survey/controller/SurveyControllerApiSpec.java
@@ -5,6 +5,7 @@ import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +20,7 @@ public interface SurveyControllerApiSpec {
     @PostMapping("/api/survey")
     public ResponseEntity<Void> survey(
             @RequestBody @Valid SurveyCreateRequest request,
-            @AuthenticationPrincipal Member member
+            @AuthenticationPrincipal Member member,
+            HttpServletResponse response
     );
 }

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
@@ -1,21 +1,29 @@
 package com.example.udtbe.domain.survey.service;
 
+import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_USER;
+
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.dto.SurveyMapper;
 import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
 import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.domain.survey.exception.SurveyErrorCode;
 import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class SurveyService {
 
     private final SurveyQuery surveyQuery;
+    private final CookieUtil cookieUtil;
 
-    public void createSurvey(SurveyCreateRequest request, Member member) {
+    @Transactional
+    public void createSurvey(SurveyCreateRequest request, Member member,
+            HttpServletResponse response) {
         if (surveyQuery.existsByMember(member)) {
             throw new RestApiException(SurveyErrorCode.SURVEY_ALREADY_EXISTS_FOR_MEMBER);
         }
@@ -23,5 +31,7 @@ public class SurveyService {
         Survey survey = SurveyMapper.toEntity(request, member);
         surveyQuery.save(survey);
 
+        member.updateRole(ROLE_USER);
+        cookieUtil.deleteCookie(response);
     }
 }

--- a/src/test/java/com/example/udtbe/survey/service/SurveyServiceTest.java
+++ b/src/test/java/com/example/udtbe/survey/service/SurveyServiceTest.java
@@ -4,6 +4,8 @@ import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_GUEST;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -15,20 +17,25 @@ import com.example.udtbe.domain.survey.exception.SurveyErrorCode;
 import com.example.udtbe.domain.survey.service.SurveyQuery;
 import com.example.udtbe.domain.survey.service.SurveyService;
 import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 @ExtendWith(MockitoExtension.class)
 class SurveyServiceTest {
 
     @Mock
     SurveyQuery surveyQuery;
+
+    @Mock
+    CookieUtil cookieUtil;
 
     @InjectMocks
     SurveyService surveyService;
@@ -38,17 +45,19 @@ class SurveyServiceTest {
     void createSurvey() {
         // given
         final String email = "test@naver.com";
+        final HttpServletResponse response = new MockHttpServletResponse();
 
         Member member = MemberFixture.member(email, ROLE_GUEST);
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디", "범죄");
         SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
 
-        BDDMockito.given(surveyQuery.existsByMember(member)).willReturn(Boolean.FALSE);
-        BDDMockito.given(surveyQuery.save(any(Survey.class))).willReturn(any(Survey.class));
+        given(surveyQuery.existsByMember(member)).willReturn(Boolean.FALSE);
+        given(surveyQuery.save(any(Survey.class))).willReturn(null);
+        willDoNothing().given(cookieUtil).deleteCookie(any(HttpServletResponse.class));
 
         // when
-        surveyService.createSurvey(request, member);
+        surveyService.createSurvey(request, member, response);
 
         // then
         assertAll(
@@ -62,16 +71,17 @@ class SurveyServiceTest {
     void throwExceptionIfSurveyAlreadyExists() {
         // given
         final String email = "test@naver.com";
+        final HttpServletResponse response = new MockHttpServletResponse();
 
         Member member = MemberFixture.member(email, ROLE_GUEST);
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디", "범죄");
         SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
 
-        BDDMockito.given(surveyQuery.existsByMember(member)).willReturn(Boolean.TRUE);
-
+        given(surveyQuery.existsByMember(member)).willReturn(Boolean.TRUE);
+        
         // when  // then
-        assertThatThrownBy(() -> surveyService.createSurvey(request, member))
+        assertThatThrownBy(() -> surveyService.createSurvey(request, member, response))
                 .isInstanceOf(RestApiException.class)
                 .hasMessage(SurveyErrorCode.SURVEY_ALREADY_EXISTS_FOR_MEMBER.getMessage());
     }


### PR DESCRIPTION
## 📝 요약(Summary)

- 설문조사 후 회원 ROLE_GUEST을 ROLE_USER로 업데이트한다.
- 설문조사 저장 로직 성공 후 임시 JWT 토큰을 제거한다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- 프론트 측에서 재로그인 플로우를 구현해둔 것 같아서 리디랙션을 시키지 않습니다.
- 추후 프론트 요청 시 리디랙션 플로우로 변경할 수 있습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 3분
