### PR TITLE
Feat/udt 84 엄선된 추천 알고리즘

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
@@ -26,4 +26,14 @@ public class RecommendContentController implements RecommendContentControllerApi
 
         return ResponseEntity.ok(recommendations);
     }
+
+    @Override
+    public ResponseEntity<List<ContentRecommendationResponse>> getCurated(
+            @AuthenticationPrincipal Member member,
+            @RequestParam(defaultValue = "6") int limit) {
+        List<ContentRecommendationResponse> recommendations = contentRecommendationService.recommendCuratedContents(
+                member, limit);
+
+        return ResponseEntity.ok(recommendations);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
@@ -38,4 +38,25 @@ public interface RecommendContentControllerApiSpec {
             )
             @RequestParam(defaultValue = "10") int limit
     );
+
+    @Operation(
+            summary = "엄선된 콘텐츠 추천 API",
+            description = "사용자의 설문조사보다 최근 사용자의 피드백 기반으로 개인화된 콘텐츠를 추천합니다. " +
+                    "개인화 추천이 불가능한 경우 인기 콘텐츠를 제공합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "엄선된 추천 콘텐츠 목록 조회 성공",
+            useReturnTypeSchema = true
+    )
+    @GetMapping("/recommendations/curated")
+    ResponseEntity<List<ContentRecommendationResponse>> getCurated(
+            @Parameter(description = "인증된 사용자 정보", required = true)
+            @AuthenticationPrincipal Member member,
+            @Parameter(
+                    description = "추천 콘텐츠 개수 (기본값: 6)",
+                    example = "6"
+            )
+            @RequestParam(defaultValue = "6") int limit
+    );
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -73,10 +73,10 @@ public class ContentRecommendationService {
         if (isCurated) {
             return executeCuratedRecommendation(userSurvey, member, limit, metadataCache,
                     platformFilteredContentIds);
-        } else {
-            return executeRegularRecommendation(userSurvey, member, limit, metadataCache,
-                    platformFilteredContentIds);
         }
+
+        return executeRegularRecommendation(userSurvey, member, limit, metadataCache,
+                platformFilteredContentIds);
     }
 
     private List<ContentRecommendationResponse> executeCuratedRecommendation(
@@ -133,12 +133,12 @@ public class ContentRecommendationService {
             float feedbackScore = calculateGenreFeedbackBoost(doc, feedbackScores);
             float finalScore;
 
-            if (isCurated) {//엄선된 추천은 설문조사 점수가 들어가진다.
+            if (isCurated) {
                 float feedbackGenreBoost = calculateGenreBoost(doc, primaryGenres);
                 float surveyGenreBoost = calculateGenreBoost(doc, secondaryGenres);
                 finalScore =
                         luceneScore + feedbackGenreBoost * 2.0f + surveyGenreBoost + feedbackScore;
-            } else {//일반 추천은
+            } else {
                 float genreBoost = calculateGenreBoost(doc, primaryGenres);
                 finalScore = luceneScore + genreBoost * 2.0f + feedbackScore;
             }
@@ -299,7 +299,7 @@ public class ContentRecommendationService {
         List<ContentMetadata> metadataList = contents.stream()
                 .map(content -> metadataCache.get(content.getId()))
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+                .toList();
 
         for (Content content : contents) {
             log.info("추출된 순서 : {}", String.join(", ", content.getTitle()));

--- a/src/test/java/com/example/udtbe/common/fixture/ContentMetadataFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/ContentMetadataFixture.java
@@ -7,7 +7,6 @@ import com.example.udtbe.domain.content.entity.ContentMetadata;
 import java.util.Arrays;
 import java.util.List;
 import lombok.NoArgsConstructor;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @NoArgsConstructor(access = PRIVATE)
 public class ContentMetadataFixture {
@@ -149,7 +148,7 @@ public class ContentMetadataFixture {
 
     public static ContentMetadata parasiteMetadata() {
         Content content = ContentFixture.parasite(); // ID 1L 이미 설정됨
-        return createMetadataWithId(content, "기생충", "15세이상관람가", 
+        return createMetadataWithId(content, "기생충", "15세이상관람가",
                 List.of("영화"), List.of("스릴러", "서사/드라마", "범죄"),
                 List.of("넷플릭스", "왓챠"), List.of("봉준호"));
     }
@@ -192,7 +191,7 @@ public class ContentMetadataFixture {
     public static ContentMetadata getOutMetadata() {
         Content content = ContentFixture.getOut(); // ID 7L 이미 설정됨
         return createMetadataWithId(content, "겟 아웃", "15세이상관람가",
-                List.of("영화"), List.of("공포(호러),", "스릴러", "미스터리"),
+                List.of("영화"), List.of("공포(호러)", "스릴러", "미스터리"),
                 List.of("넷플릭스", "왓챠"), List.of("조던 필"));
     }
 
@@ -219,7 +218,8 @@ public class ContentMetadataFixture {
 
     // === Helper 메서드 ===
 
-    private static ContentMetadata createMetadataWithId(Content content, String title, String rating,
+    private static ContentMetadata createMetadataWithId(Content content, String title,
+            String rating,
             List<String> categoryTag, List<String> genreTag,
             List<String> platformTag, List<String> directorTag) {
         ContentMetadata metadata = ContentMetadata.of(

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -178,6 +178,8 @@ class ContentRecommendationServiceTest {
             // given
             Survey netflixOnlySurvey = createNetflixOnlySurvey();
 
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(netflixOnlySurvey);
             when(contentRecommendationQuery.findContentMetadataCache())
                     .thenReturn(testMetadataCache);
 
@@ -187,7 +189,7 @@ class ContentRecommendationServiceTest {
 
             // when
             List<ContentRecommendationResponse> result = contentRecommendationService
-                    .searchRecommendations(netflixOnlySurvey, testMember, 5);
+                    .recommendContents(testMember, 5);
 
             // then
             assertThat(result).hasSize(5);
@@ -211,8 +213,10 @@ class ContentRecommendationServiceTest {
             mockContentQueryWithOrder(List.of(4L, 8L));
 
             // when
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(disneyPlusSurvey);
             List<ContentRecommendationResponse> result = contentRecommendationService
-                    .searchRecommendations(disneyPlusSurvey, testMember, 5);
+                    .recommendContents(testMember, 5);
 
             // then
             assertThat(result).hasSize(2);
@@ -239,8 +243,10 @@ class ContentRecommendationServiceTest {
             mockContentQueryWithOrder(List.of(1L, 2L, 7L, 9L, 5L, 8L, 10L, 3L, 4L, 6L));
 
             // when
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
             List<ContentRecommendationResponse> result = contentRecommendationService
-                    .searchRecommendations(testSurvey, testMember, 10);
+                    .recommendContents(testMember, 10);
 
             // then
             assertThat(result).hasSize(10);
@@ -267,8 +273,10 @@ class ContentRecommendationServiceTest {
             mockContentQueryWithOrder(List.of(1L, 2L, 6L, 3L, 5L, 8L, 10L, 4L, 7L, 9L));
 
             // when
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
             List<ContentRecommendationResponse> result = contentRecommendationService
-                    .searchRecommendations(testSurvey, testMember, 10);
+                    .recommendContents(testMember, 10);
 
             // then
             assertThat(result).hasSize(10);
@@ -338,6 +346,55 @@ class ContentRecommendationServiceTest {
 
         DirectoryReader reader = DirectoryReader.open(directory);
         when(luceneIndexService.getIndexReader()).thenReturn(reader);
+    }
+
+    private void mockLuceneSearchServiceForCurated(List<Long> contentIds) throws Exception {
+        ScoreDoc[] scoreDocs = new ScoreDoc[contentIds.size()];
+        for (int i = 0; i < contentIds.size(); i++) {
+            scoreDocs[i] = new ScoreDoc(i, 1.0f + (contentIds.size() - i) * 0.1f); // 점수 내림차순
+        }
+        TotalHits totalHits = new TotalHits(scoreDocs.length, TotalHits.Relation.EQUAL_TO);
+        TopDocs topDocs = new TopDocs(totalHits, scoreDocs);
+
+        when(luceneSearchService.searchCuratedRecommendations(anyList(), anyList(), anyInt()))
+                .thenReturn(topDocs);
+
+        // 독립적인 Directory와 Reader 생성
+        KoreanAnalyzer analyzer = new KoreanAnalyzer();
+        Directory curatedDirectory = new ByteBuffersDirectory();
+
+        IndexWriter curatedWriter = new IndexWriter(curatedDirectory,
+                new IndexWriterConfig(analyzer));
+
+        for (int i = 0; i < contentIds.size(); i++) {
+            Long contentId = contentIds.get(i);
+            ContentMetadata metadata = testMetadataCache.get(contentId);
+            if (metadata != null) {
+                Document doc = new Document();
+                doc.add(new StringField("contentId", contentId.toString(), Field.Store.YES));
+                doc.add(new TextField("title", metadata.getTitle(), Field.Store.YES));
+                doc.add(new TextField("genreTag", String.join(",", metadata.getGenreTag()),
+                        Field.Store.YES));
+                doc.add(new TextField("platformTag", String.join(",", metadata.getPlatformTag()),
+                        Field.Store.YES));
+                curatedWriter.addDocument(doc);
+            }
+        }
+
+        if (contentIds.isEmpty()) {
+            Document emptyDoc = new Document();
+            emptyDoc.add(new StringField("contentId", "0", Field.Store.YES));
+            emptyDoc.add(new TextField("title", "empty", Field.Store.YES));
+            emptyDoc.add(new TextField("genreTag", "", Field.Store.YES));
+            emptyDoc.add(new TextField("platformTag", "", Field.Store.YES));
+            curatedWriter.addDocument(emptyDoc);
+        }
+
+        curatedWriter.close();
+
+        DirectoryReader curatedReader = DirectoryReader.open(curatedDirectory);
+        // 엄선된 추천을 위한 별도의 reader 설정
+        when(luceneIndexService.getIndexReader()).thenReturn(curatedReader);
     }
 
     private Member createTestMember() {
@@ -462,8 +519,10 @@ class ContentRecommendationServiceTest {
         mockContentQueryWithOrder(List.of(1L));
 
         // when
+        when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                .thenReturn(testSurvey);
         List<ContentRecommendationResponse> result = contentRecommendationService
-                .searchRecommendations(testSurvey, testMember, 1);
+                .recommendContents(testMember, 1);
 
         // then 예외가 발생하지 않고 정상 처리되어야..
         assertThat(result).hasSize(1);
@@ -488,11 +547,279 @@ class ContentRecommendationServiceTest {
         mockContentQueryWithOrder(allContentIds);
 
         // when
+        when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                .thenReturn(surveyWithEmptyPlatforms);
         List<ContentRecommendationResponse> result = contentRecommendationService
-                .searchRecommendations(surveyWithEmptyPlatforms, testMember, 10);
+                .recommendContents(testMember, 10);
 
         // then
         assertThat(result).hasSize(10); // 모든 콘텐츠 반환
+    }
+
+    @Nested
+    @DisplayName("recommendCuratedContents 엄선된 추천 테스트")
+    class CuratedRecommendationTest {
+
+        @Test
+        @DisplayName("피드백 기반 엄선된 추천 - 피드백 장르가 상위에 위치")
+        void shouldRecommendCuratedContentsBasedOnFeedback() throws Exception {
+            // given - 스릴러 좋아요, 액션 싫어요 피드백
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            // 스릴러 좋아요, 액션 싫어요 피드백 설정
+            List<Feedback> feedbacks = List.of(
+                    createFeedback(testContents.get(0), FeedbackType.LIKE), // 기생충 (스릴러)
+                    createFeedback(testContents.get(1), FeedbackType.LIKE), // 올드보이 (스릴러)
+                    createFeedback(testContents.get(4), FeedbackType.DISLIKE), // 탑건 (액션)
+                    createFeedback(testContents.get(7), FeedbackType.DISLIKE)  // 블랙팬서 (액션)
+            );
+            when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                    .thenReturn(feedbacks);
+
+            mockLuceneSearchServiceForCurated(List.of(1L, 2L, 6L, 9L, 3L, 5L, 8L, 10L, 4L, 7L));
+            mockContentQueryWithOrder(List.of(1L, 2L, 6L, 9L, 3L, 5L, 8L, 10L, 4L, 7L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendCuratedContents(testMember, 10);
+
+            // then
+            assertThat(result).hasSize(10);
+
+            // 상위 3개 중 스릴러 장르가 포함된 콘텐츠가 최소 2개는 있어야 함
+            long thrillerCountInTop3 = result.subList(0, 3).stream()
+                    .mapToLong(response -> response.genres().stream()
+                            .mapToLong(genre -> genre.contains("스릴러") ? 1L : 0L)
+                            .sum())
+                    .sum();
+            assertThat(thrillerCountInTop3).isGreaterThanOrEqualTo(2L);
+
+            // 하위 3개 중 액션 장르가 포함된 콘텐츠가 최소 2개는 있어야 함
+            long actionCountInBottom3 = result.subList(5, 8).stream()
+                    .mapToLong(response -> response.genres().stream()
+                            .mapToLong(genre -> genre.contains("액션") ? 1L : 0L)
+                            .sum())
+                    .sum();
+            assertThat(actionCountInBottom3).isGreaterThanOrEqualTo(2L);
+
+            verify(luceneSearchService).searchCuratedRecommendations(anyList(), anyList(),
+                    anyInt());
+        }
+
+        @Test
+        @DisplayName("피드백 없는 사용자 - 설문 기반 엄선된 추천")
+        void shouldRecommendCuratedContentsWithoutFeedback() throws Exception {
+            // given - 피드백 없음
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                    .thenReturn(new ArrayList<>());
+
+            mockLuceneSearchServiceForCurated(List.of(1L, 2L, 8L, 3L, 5L));
+            mockContentQueryWithOrder(List.of(1L, 2L, 8L, 3L, 5L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendCuratedContents(testMember, 5);
+
+            // then
+            assertThat(result).hasSize(5);
+
+            // 설문 기반 장르(액션/스릴러)가 상위에 위치해야 함
+            assertThat(result.get(0).genres())
+                    .anyMatch(genre -> genre.contains("액션") || genre.contains("스릴러"));
+
+            verify(luceneSearchService).searchCuratedRecommendations(anyList(), anyList(),
+                    anyInt());
+        }
+
+        @Test
+        @DisplayName("긍정적 피드백만 고려 - LIKE만 선호 장르로 추출")
+        void shouldExtractPreferredGenresFromPositiveFeedbackOnly() throws Exception {
+            // given - 다양한 피드백 타입
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            List<Feedback> feedbacks = List.of(
+                    createFeedback(testContents.get(0), FeedbackType.LIKE),        // 기생충 (스릴러) - 선호
+                    createFeedback(testContents.get(1), FeedbackType.LIKE),
+                    // 올드보이 (스릴러) - 선호
+                    createFeedback(testContents.get(2), FeedbackType.UNINTERESTED),
+                    // 인터스텔라 (SF) - 0.2점
+                    createFeedback(testContents.get(4), FeedbackType.DISLIKE),      // 탑건 (액션) - 비선호
+                    createFeedback(testContents.get(5), FeedbackType.LIKE)
+                    // 어벤져스 (액션) - 선호
+            );
+            when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                    .thenReturn(feedbacks);
+
+            mockLuceneSearchServiceForCurated(List.of(1L, 2L, 5L, 3L, 6L, 8L, 9L, 10L, 4L, 7L));
+            mockContentQueryWithOrder(List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendCuratedContents(testMember, 10);
+
+            // then
+            assertThat(result).hasSize(10);
+
+            // 스릴러(2개 LIKE)가 액션(1개 LIKE, 1개 DISLIKE)보다 상위에 위치해야 함
+            List<String> topGenres = result.subList(0, 5).stream()
+                    .flatMap(response -> response.genres().stream())
+                    .collect(Collectors.toList());
+
+            long thrillerCount = topGenres.stream()
+                    .mapToLong(genre -> genre.contains("스릴러") ? 1L : 0L).sum();
+            assertThat(thrillerCount).isGreaterThanOrEqualTo(2L);
+
+            verify(luceneSearchService).searchCuratedRecommendations(anyList(), anyList(),
+                    anyInt());
+        }
+
+        @Test
+        @DisplayName("엄선된 추천 vs 일반 추천 비교 - 피드백 반영 차이")
+        void shouldShowDifferenceFromRegularRecommendation() throws Exception {
+            // given - 동일한 조건 설정
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            // 로맨스 장르 선호 피드백 (설문과 다른 선호)
+            List<Feedback> feedbacks = List.of(
+                    createFeedback(testContents.get(5), FeedbackType.LIKE), // 어벤져스 (액션)
+                    createFeedback(testContents.get(6), FeedbackType.LIKE)  // 타이타닉 (로맨스)
+            );
+            when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                    .thenReturn(feedbacks);
+
+            // 일반 추천 mock
+            mockLuceneSearchService(List.of(1L, 2L, 8L, 3L, 4L, 5L, 6L, 7L, 9L, 10L));
+            // 엄선된 추천 mock (피드백 기반 장르 우선)
+            mockLuceneSearchServiceForCurated(List.of(5L, 6L, 1L, 2L, 8L, 3L, 4L, 7L, 9L, 10L));
+            mockContentQueryWithOrder(List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L));
+
+            // when
+            List<ContentRecommendationResponse> regularResult = contentRecommendationService
+                    .recommendContents(testMember, 5);
+            List<ContentRecommendationResponse> curatedResult = contentRecommendationService
+                    .recommendCuratedContents(testMember, 5);
+
+            // then
+            assertThat(regularResult).hasSize(10);
+            assertThat(curatedResult).hasSize(10);
+
+            // 엄선된 추천에서 피드백 기반 장르가 더 상위에 위치해야 함
+            assertThat(curatedResult.get(0).genres())
+                    .anyMatch(genre -> genre.contains("액션") || genre.contains("로맨스"));
+
+            // 두 추천 결과가 달라야 함
+            assertThat(curatedResult.get(0).contentId()).isNotEqualTo(
+                    regularResult.get(0).contentId());
+
+            verify(luceneSearchService).searchRecommendations(anyList(), anyList(), anyInt());
+            verify(luceneSearchService).searchCuratedRecommendations(anyList(), anyList(),
+                    anyInt());
+        }
+
+        @Test
+        @DisplayName("설문 없는 사용자 - 인기 콘텐츠 fallback")
+        void shouldFallbackToPopularContents_WhenSurveyNotExists() {
+            // given
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenThrow(new RestApiException(RecommendContentErrorCode.SURVEY_NOT_FOUND));
+            when(contentRecommendationQuery.findPopularContentMetadata(6))
+                    .thenReturn(testMetadataList.subList(0, 6));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendCuratedContents(testMember, 6);
+
+            // then
+            assertThat(result).hasSize(6);
+            verify(contentRecommendationQuery).findPopularContentMetadata(6);
+            verifyNoInteractions(luceneSearchService);
+        }
+
+        @Test
+        @DisplayName("Lucene 검색 실패 - 인기 콘텐츠 fallback")
+        void shouldFallbackToPopularContents_WhenLuceneSearchFails() throws Exception {
+            // given
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+            when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                    .thenReturn(new ArrayList<>());
+
+            when(luceneSearchService.searchCuratedRecommendations(anyList(), anyList(), anyInt()))
+                    .thenThrow(new IOException("Lucene 검색 실패"));
+            when(contentRecommendationQuery.findPopularContentMetadata(6))
+                    .thenReturn(testMetadataList.subList(0, 6));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendCuratedContents(testMember, 6);
+
+            // then
+            assertThat(result).hasSize(6);
+            verify(contentRecommendationQuery).findPopularContentMetadata(6);
+            verify(luceneSearchService).searchCuratedRecommendations(anyList(), anyList(),
+                    anyInt());
+        }
+
+        @Test
+        @DisplayName("많은 피드백 데이터 - 상위 5개 장르만 추출")
+        void shouldExtractTop5PreferredGenres() throws Exception {
+            // given - 7개 장르에 대한 피드백 (상위 5개만 추출되어야 함)
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(testSurvey);
+            when(contentRecommendationQuery.findContentMetadataCache())
+                    .thenReturn(testMetadataCache);
+
+            List<Feedback> feedbacks = List.of(
+                    // 스릴러: 3개 LIKE = 3.0점 (1위)
+                    createFeedback(testContents.get(0), FeedbackType.LIKE), // 기생충 (스릴러)
+                    createFeedback(testContents.get(1), FeedbackType.LIKE), // 올드보이 (스릴러)
+                    createFeedback(testContents.get(6), FeedbackType.LIKE), // 타이타닉 (로맨스, 스릴러)
+                    // 액션: 2개 LIKE = 2.0점 (2위)
+                    createFeedback(testContents.get(4), FeedbackType.LIKE), // 탑건 (액션)
+                    createFeedback(testContents.get(5), FeedbackType.LIKE), // 어벤져스 (액션)
+                    // SF: 1개 LIKE = 1.0점 (3위)
+                    createFeedback(testContents.get(2), FeedbackType.LIKE)  // 인터스텔라 (SF)
+            );
+            when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                    .thenReturn(feedbacks);
+
+            mockLuceneSearchServiceForCurated(List.of(1L, 2L, 6L, 4L, 5L, 3L, 8L, 9L));
+            mockContentQueryWithOrder(List.of(1L, 2L, 3L, 4L, 5L, 6L, 8L, 9L));
+
+            // when
+            List<ContentRecommendationResponse> result = contentRecommendationService
+                    .recommendCuratedContents(testMember, 8);
+
+            // then
+            assertThat(result).hasSize(8);
+
+            // 상위 5개 중 스릴러가 가장 많아야 함
+            long thrillerCount = result.subList(0, 5).stream()
+                    .mapToLong(response -> response.genres().stream()
+                            .mapToLong(genre -> genre.contains("스릴러") ? 1L : 0L)
+                            .sum())
+                    .sum();
+            assertThat(thrillerCount).isGreaterThanOrEqualTo(2L);
+
+            verify(luceneSearchService).searchCuratedRecommendations(anyList(), anyList(),
+                    anyInt());
+        }
     }
 
     @Nested
@@ -513,8 +840,10 @@ class ContentRecommendationServiceTest {
             mockContentQueryWithOrder(List.of(1L, 2L, 5L));
 
             // when
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(englishGenreSurvey);
             List<ContentRecommendationResponse> result = contentRecommendationService
-                    .searchRecommendations(englishGenreSurvey, testMember, 3);
+                    .recommendContents(testMember, 3);
 
             // then
             assertThat(result).hasSize(3);
@@ -540,8 +869,10 @@ class ContentRecommendationServiceTest {
             mockContentQueryWithOrder(List.of(1L, 2L, 3L));
 
             // when
+            when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                    .thenReturn(englishPlatformSurvey);
             List<ContentRecommendationResponse> result = contentRecommendationService
-                    .searchRecommendations(englishPlatformSurvey, testMember, 3);
+                    .recommendContents(testMember, 3);
 
             // then
             assertThat(result).hasSize(3);


### PR DESCRIPTION
# 📝 요약(Summary)

## 🎯 무엇을, 왜 구현했는가?

**Apache Lucene 기반 이중 추천 시스템**을 구현했습니다. 사용자의 **설문조사 데이터**와 **실제 피드백 행동 패턴**을 분석하여 **일반 추천**과 **엄선된 큐레이션 추천** 두 가지 방식을 제공합니다.

### 핵심 문제점

- 현재 기본 추천 알고리즘(설문조사의 가중치 > 최근 사용자의 피드백의 가중치)에 따른 루즈함
- 사용자의 실제 행동 데이터(좋아요/싫어요) 활용 부족
- 시간에 따른 취향 변화 대응 불가
    - 예시) 사용자는 설문 조사에서 액션을 좋아했지만, 실제 긍정적 피드백의 결과는 로맨스인 경우
    - 이때 기본 추천 알고리즘은 액션 중점, 현재 알고리즘은 로맨스 중점

### 서브 문제점

- 멜로/로맨스,서사/드라마, 사극/시대극 의 장르는 이스케이프 문자를 포함중이여서 Lucene query parse할 때 이스케이프 문자 문제 발생

### 해결 방법

**이중 추천 전략**으로 다양한 사용자 니즈 대응:

### 1️⃣ 일반 추천 (`/recommendations`)

```
최종점수 = (Lucene점수 × 3.0) + (설문장르부스트 × 2.0) + 피드백점수
```

- **기반 데이터**: 초기 설문조사 장르 선호도
- **적용 대상**: 신규 사용자, 안정적인 추천 선호 사용자

### 2️⃣ 엄선된 추천 (`/recommendations/curated`)

```
최종점수 = (Lucene점수 × 3.0) + (피드백장르부스트 × 2.0) + 설문장르부스트 + 피드백점수
```

- **기반 데이터**: 실제 피드백에서 추출한 선호 장르 (상위 3개, 0.5점 이상)
- **적용 대상**: 활발한 피드백 사용자, 취향이 진화하는 사용자

### 3️⃣ 이스케이프 처리

```java
String escapedGenre = QueryParser.escape(feedbackGenre);
```

- escape("멜로/로맨스") → 멜로\/로맨스

---

## 🔍 추천 알고리즘 상세 분석

### 🏗️ Flow Chart

```mermaid
graph TB
    A[RecommendContentController] --> B[ContentRecommendationService]
    B --> C[LuceneIndexService]
    B --> D[LuceneSearchService]
    B --> E[ContentRecommendationQuery]

    D --> F[일반 추천 쿼리]
    D --> G[큐레이션 추천 쿼리]

    F --> H[설문 기반 장르 검색]
    G --> I[피드백 기반 장르 검색]

```

### 📊 점수 계산 시스템 비교

| 구분 | 일반 추천 | 엄선된 추천 |
| --- | --- | --- |
| **Lucene 점수** | `scoreDoc.score × 3.0f` | `scoreDoc.score × 3.0f` |
| **1차 장르 부스트** | 설문 장르 × 2.0 | **피드백 장르 × 2.0** |
| **2차 장르 부스트** | - | 설문 장르 × 1.0 |
| **피드백 점수** | 누적 피드백 점수 | 누적 피드백 점수 |
| **검색 배수** | `limit × 3` | `limit × 2` |

### 🎯 엄선된 추천의 핵심 로직

### A. 피드백 기반 선호 장르 추출

```java
List<String> preferredGenres = genreScores.entrySet().stream()
    .filter(entry -> entry.getValue() > 0.5f) // 긍정적 피드백만
    .sorted(Map.Entry.<String, Float>comparingByValue().reversed())
    .limit(3) // 상위 3개 장르만
    .map(Map.Entry::getKey)
    .collect(Collectors.toList());
```

### B. 피드백 점수 계산 업데이트

```java
float score = switch (feedback.getFeedbackType()) {
    case LIKE -> 1.0f;           // 긍정적 피드백
    case DISLIKE -> -1.0f;       // 부정적 피드백
    case UNINTERESTED -> 0.2f;   // 무관심 (기존 -0.5f에서 변경)
};
```

### C. Lucene 검색 쿼리 차별화

```java
// 일반 추천: 설문 장르 기반 + QueryParser.escape() 적용
buildRecommendationQuery(platformFilteredContentIds, userGenres, analyzer)

// 엄선된 추천: 피드백 장르 기반 + QueryParser.escape() 적용
buildCuratedRecommendationQuery(platformFilteredContentIds, feedbackGenres, analyzer)
```

---

## 🚀 핵심 개선사항

### 1️⃣ 이중 추천 시스템 구현

### **API 엔드포인트 분리**

- **GET** `/api/v1/contents/recommendations` - 일반 개인화 추천 (기본 10개)
- **GET** `/api/v1/contents/recommendations/curated` - 엄선된 추천 (기본 6개)

### **서비스 계층 분리**

```java
@Transactional(readOnly = true)
public List<ContentRecommendationResponse> recommendContents(Member member, int limit) {
    return performRecommendation(member, limit, false);
}

@Transactional(readOnly = true)
public List<ContentRecommendationResponse> recommendCuratedContents(Member member, int limit) {
    return performRecommendation(member, limit, true);
}
```

### 2️⃣ 정교한 점수 계산 알고리즘

### **Lucene 점수 가중치 증가**

- **Before**: `scoreDoc.score`
- **After**: `scoreDoc.score × 3.0f`
- **이유**: 콘텐츠 유사도의 중요성 강화

### **UNINTERESTED 피드백 재평가**

- **Before**: `0.5f` (부정적 점수)
- **After**: `+0.2f` (약간의 긍정적 점수)
- **이유**: "무관심"을 완전 배제보다는 낮은 우선순위로 처리

### 3️⃣ 검색 엔진 최적화

### **쿼리 이스케이핑 추가**

```java
String escapedGenre = QueryParser.escape(feedbackGenre);
```

- **목적**: 특수문자가 포함된 장르명 안전 처리
- **효과**: 검색 오류 방지 및 정확도 향상

### **상세 디버깅 시스템**

```java
private void debugTopDocs(TopDocs topDocs, IndexSearcher searcher) {
    log.info("🔍 ===== TopDocs 상세 분석 =====");
    // 상위 10개 결과의 상세 정보 로깅
}
```

---

## 📊 성능 최적화 고민

### 1️⃣ 현재 메타데이터 캐싱

```java
// 전체 ContentMetadata 한 번에 조회 후 캐시 활용
Map<Long, ContentMetadata> metadataCache =
    contentRecommendationQuery.findContentMetadataCache();
```

- ContentMetadata는 캐시메모리로 설정해놓고 사용자마다 TopDocs(사용자 피드백 반영 직전) 캐싱을 할 것인가..?
    - 추가적으로 TopDocs가 다 응답되기 전까지 TopDocs세팅까지의 중복 작업 최소화

### 2️⃣ 인덱스 관리

- **자동 인덱스 빌드**: 애플리케이션 시작 시 자동 실행
- **메모리 기반**: 빠른 검색을 위한 인메모리 Directory 사용

### 3️⃣ 검색 배수 전략

- **일반 추천**: `limit × 3` (다양성 확보)
- **엄선된 추천**: `limit × 2` (정확성 우선)

---

## 🧪 테스트 시나리오

### 1️⃣ **엄선된 추천 테스트**

```java
@Test
@DisplayName("피드백 기반 엄선된 추천 - 피드백 장르가 상위에 위치")
void shouldRecommendCuratedContentsBasedOnFeedback() {
    // Given: 스릴러 2개 LIKE, 액션 2개 DISLIKE
    // When: recommendCuratedContents() 호출
    // Then: 스릴러 장르가 상위 3개 중 2개 이상 위치
}

@Test
@DisplayName("긍정적 피드백만 고려 - LIKE만 선호 장르로 추출")
void shouldExtractPreferredGenresFromPositiveFeedbackOnly() {
    // Given: LIKE(2), DISLIKE(1), UNINTERESTED(1) 피드백
    // When: extractPreferredGenresFromFeedback() 호출
    // Then: 0.5f 이상 점수 장르만 추출 (LIKE 장르만)
}

@Test
@DisplayName("엄선된 추천 vs 일반 추천 비교 - 피드백 반영 차이")
void shouldShowDifferenceFromRegularRecommendation() {
    // Given: 설문(액션/스릴러) vs 피드백(로맨스 선호)
    // When: 두 API 동시 호출
    // Then: 엄선된 추천에서 로맨스가 더 상위에 위치
}

```

---

## 💬 공유사항 to 리뷰어

### 🔍 중점 리뷰 포인트

1. **점수 계산 로직의 밸런스 (데이터 세팅이후, 실제 인사이트를 얻고 고민해보기)**
    
    ```java
    // 일반 추천
    finalScore = luceneScore + genreBoost * 2.0f + feedbackScore;
    
    // 엄선된 추천
    finalScore = luceneScore + feedbackGenreBoost * 2.0f + surveyGenreBoost + feedbackScore;
    ```
    
    **질문**: 엄선된 추천에서 설문 점수를 1.0배로 낮춘 것이 적절한가?
    
2. **피드백 점수 재조정**
    - `UNINTERESTED: -0.5f → +0.2f` 변경의 타당성 (관심 없음은 부정적인 영향보다는 소극적 긍정이라 판단)
    - 완전 배제 vs 낮은 우선순위 전략
3. **검색 배수 차별화**
    - 일반 추천 `limit × 3` vs 엄선된 추천 `limit × 2`

### 🤔 논의하고 싶은 부분

- **Lucene 점수 가중치**: `× 3.0f`가 과도하지 않은지?
- **캐시 전략**: 전체 메타데이터 메모리 적재의 확장성 이슈
- **API 설계**: 기본 limit 값 (일반 10개 vs 엄선 6개)의 근거
- **피드백 임계값**: 엄선된 추천에서 `0.5f` 기준의 적절성

### 🚨 알려진 이슈

1. **메모리 사용량**: 전체 메타데이터 캐시로 인한 메모리 증가
2. **콜드 스타트**: 피드백이 없는 신규 사용자의 엄선된 추천 품질
3. **실시간 업데이트**: 새 콘텐츠 추가 시 인덱스 재빌드 필요

---

## 📸 API 스크린샷

<img width="1221" height="520" alt="image" src="https://github.com/user-attachments/assets/b77db5b2-193c-4bc8-ac5e-fcced8cdcaa3" />


### 결과

<img width="1629" height="537" alt="image" src="https://github.com/user-attachments/assets/19428ada-7c87-4b44-b500-1b6bfba29644" />


---

## ✅ PR Checklist

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  이중 추천 시스템 구현 및 테스트를 완료했습니다.
- [x]  OpenAPI 문서화를 완비했습니다.
- [x]  점수 계산 로직 최적화 및 검증했습니다.

## 🤔 Review 예상 시간

- **기본 리뷰**: 20-25분 (이중 추천 로직 이해)
- **심화 리뷰**: 40-50분 (점수 계산 알고리즘 및 성능 최적화 검토)