### PR TITLE
fix/UDT-106 마이페이지 장르, 플랫폼 정보 한국어로 반환

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/entity/enums/PlatformType.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/enums/PlatformType.java
@@ -17,7 +17,7 @@ public enum PlatformType {
     WAVVE("웨이브"),
     DISNEY_PLUS("디즈니+"),
     WATCHA("왓챠"),
-    APPLE_TV("Apple TV"),
+    APPLE_TV("애플티비"),
     ;
 
     private final String type;

--- a/src/main/java/com/example/udtbe/domain/member/dto/request/MemberCuratedContentGetsRequest.java
+++ b/src/main/java/com/example/udtbe/domain/member/dto/request/MemberCuratedContentGetsRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 public record MemberCuratedContentGetsRequest(
         Long cursor,
         @NotNull
-        int size
+        Integer size
 ) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/udtbe/domain/member/service/MemberService.java
@@ -33,11 +33,14 @@ public class MemberService {
         Member member = memberQuery.findMemberById(memberId);
         Survey survey = surveyQuery.findSurveyByMemberId(memberId);
 
+        List<String> koreanPlatformTags = PlatformType.toKoreanTypes(survey.getPlatformTag());
+        List<String> koreanGenreTags = GenreType.toKoreanTypes(survey.getGenreTag());
+
         return new MemberInfoResponse(
                 member.getName(),
                 member.getEmail(),
-                survey.getPlatformTag(),
-                survey.getGenreTag(),
+                koreanPlatformTags,
+                koreanGenreTags,
                 member.getProfileImageUrl());
     }
 

--- a/src/test/java/com/example/udtbe/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/example/udtbe/content/controller/ContentControllerTest.java
@@ -1,30 +1,73 @@
 package com.example.udtbe.content.controller;
 
-import com.example.udtbe.common.fixture.*;
+import static java.time.DayOfWeek.FRIDAY;
+import static java.time.DayOfWeek.MONDAY;
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.TUESDAY;
+import static java.time.DayOfWeek.WEDNESDAY;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.udtbe.common.fixture.CastFixture;
+import com.example.udtbe.common.fixture.CategoryFixture;
+import com.example.udtbe.common.fixture.ContentCastFixture;
+import com.example.udtbe.common.fixture.ContentCategoryFixture;
+import com.example.udtbe.common.fixture.ContentCountryFixture;
+import com.example.udtbe.common.fixture.ContentDirectorFixture;
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentGenreFixture;
+import com.example.udtbe.common.fixture.ContentPlatformFixture;
+import com.example.udtbe.common.fixture.CountryFixture;
+import com.example.udtbe.common.fixture.DirectorFixture;
+import com.example.udtbe.common.fixture.GenreFixture;
+import com.example.udtbe.common.fixture.PlatformFixture;
 import com.example.udtbe.common.support.ApiSupport;
 import com.example.udtbe.domain.content.controller.ContentController;
-import com.example.udtbe.domain.content.entity.*;
-import com.example.udtbe.domain.content.repository.*;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.util.ReflectionTestUtils;
-
+import com.example.udtbe.domain.content.entity.Cast;
+import com.example.udtbe.domain.content.entity.Category;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentCast;
+import com.example.udtbe.domain.content.entity.ContentCategory;
+import com.example.udtbe.domain.content.entity.ContentCountry;
+import com.example.udtbe.domain.content.entity.ContentDirector;
+import com.example.udtbe.domain.content.entity.ContentGenre;
+import com.example.udtbe.domain.content.entity.ContentPlatform;
+import com.example.udtbe.domain.content.entity.Country;
+import com.example.udtbe.domain.content.entity.Director;
+import com.example.udtbe.domain.content.entity.Genre;
+import com.example.udtbe.domain.content.entity.Platform;
+import com.example.udtbe.domain.content.repository.CastRepository;
+import com.example.udtbe.domain.content.repository.CategoryRepository;
+import com.example.udtbe.domain.content.repository.ContentCastRepository;
+import com.example.udtbe.domain.content.repository.ContentCategoryRepository;
+import com.example.udtbe.domain.content.repository.ContentCountryRepository;
+import com.example.udtbe.domain.content.repository.ContentDirectorRepository;
+import com.example.udtbe.domain.content.repository.ContentGenreRepository;
+import com.example.udtbe.domain.content.repository.ContentPlatformRepository;
+import com.example.udtbe.domain.content.repository.ContentRepository;
+import com.example.udtbe.domain.content.repository.CountryRepository;
+import com.example.udtbe.domain.content.repository.DirectorRepository;
+import com.example.udtbe.domain.content.repository.GenreRepository;
+import com.example.udtbe.domain.content.repository.PlatformRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static java.time.DayOfWeek.*;
-import static org.hamcrest.Matchers.*;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class ContentControllerTest extends ApiSupport {
 
@@ -361,7 +404,7 @@ class ContentControllerTest extends ApiSupport {
                 .andExpect(jsonPath("$.openDate", startsWith(openDate.toString())))
                 .andExpect(jsonPath("$.rating").value(rating))
                 .andExpect(jsonPath("$.platforms[0].platformType").value("웨이브"))
-                .andExpect(jsonPath("$.platforms[1].platformType").value("Apple TV"))
+                .andExpect(jsonPath("$.platforms[1].platformType").value("애플티비"))
                 .andExpect(jsonPath("$.casts[0].castName").value("마동석"))
                 .andExpect(jsonPath("$.casts[1].castName").value("황정민"))
                 .andExpect(jsonPath("$.casts[2].castName").value("토니스타크"))
@@ -461,12 +504,12 @@ class ContentControllerTest extends ApiSupport {
     }
 
     private void initContentDirectors(List<ContentDirector> contentDirectors, Content content,
-                                      Director director) {
+            Director director) {
         contentDirectors.add(ContentDirectorFixture.contentDirector(content, director));
     }
 
     private void initContentCasts(List<ContentCast> contentCasts, Content content,
-                                  Cast cast) {
+            Cast cast) {
         contentCasts.add(ContentCastFixture.contentCast(content, cast));
     }
 
@@ -476,22 +519,22 @@ class ContentControllerTest extends ApiSupport {
     }
 
     private void initContentCountry(List<ContentCountry> contentCountries,
-                                    Content content, Country country) {
+            Content content, Country country) {
         contentCountries.add(ContentCountryFixture.contentCountry(content, country));
     }
 
     private void initContentPlatform(List<ContentPlatform> contentPlatforms,
-                                     Content content, Platform platform) {
+            Content content, Platform platform) {
         contentPlatforms.add(ContentPlatformFixture.contentPlatform(content, platform));
     }
 
     private void initContentCategory(List<ContentCategory> contentCategories,
-                                     Content content, Category category) {
+            Content content, Category category) {
         contentCategories.add(ContentCategoryFixture.contentCategory(content, category));
     }
 
     private void initContentGenre(List<ContentGenre> contentGenres,
-                                  Content content, Genre genre) {
+            Content content, Genre genre) {
         contentGenres.add(ContentGenreFixture.contentGenre(content, genre));
     }
 }

--- a/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/udtbe/member/service/MemberServiceTest.java
@@ -1,5 +1,13 @@
 package com.example.udtbe.member.service;
 
+import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
 import com.example.udtbe.common.fixture.ContentFixture;
 import com.example.udtbe.common.fixture.MemberFixture;
 import com.example.udtbe.common.fixture.SurveyFixture;
@@ -22,22 +30,13 @@ import com.example.udtbe.domain.survey.service.SurveyQuery;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import com.example.udtbe.global.exception.RestApiException;
 import com.example.udtbe.global.exception.code.EnumErrorCode;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-
-import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_USER;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -77,8 +76,10 @@ class MemberServiceTest {
         assertAll(
                 () -> assertThat(response.name()).isEqualTo(member.getName()),
                 () -> assertThat(response.email()).isEqualTo(member.getEmail()),
-                () -> assertThat(response.platforms()).isEqualTo(survey.getPlatformTag()),
-                () -> assertThat(response.genres()).isEqualTo(survey.getGenreTag()),
+                () -> assertThat(response.platforms()).isEqualTo(
+                        PlatformType.toKoreanTypes(survey.getPlatformTag())),
+                () -> assertThat(response.genres()).isEqualTo(
+                        GenreType.toKoreanTypes(survey.getGenreTag())),
                 () -> assertThat(response.profileImageUrl()).isEqualTo(member.getProfileImageUrl())
         );
     }
@@ -125,7 +126,6 @@ class MemberServiceTest {
 
         CursorPageResponse<MemberCuratedContentGetResponse> secondResponse =
                 memberService.getCuratedContents(secondRequest, member);
-
 
         // then
         assertAll(


### PR DESCRIPTION
## 📝 요약(Summary)
- PlatformType enum 의 apple tv를 한국어로 수정했습니다.
- 마이페이지에서 정보를 조회할 시 한국어로 정보를 조회할 수 있도록 반환 값을 수정했습니다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 3분
