### PR TITLE
feat/UDT-96-OTT-콘텐츠-인기-목록-조회

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/controller/ContentController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/ContentController.java
@@ -1,9 +1,11 @@
 package com.example.udtbe.domain.content.controller;
 
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.PopularContentsRequest;
 import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.PopularContentsResponse;
 import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
 import com.example.udtbe.domain.content.service.ContentService;
 import com.example.udtbe.global.dto.CursorPageResponse;
@@ -36,6 +38,13 @@ public class ContentController implements ContentControllerApiSpec {
             WeeklyRecommendationRequest request) {
         List<WeeklyRecommendedContentsResponse> response =
                 contentService.getWeeklyRecommendedContents(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<List<PopularContentsResponse>> getPopularContents(
+            PopularContentsRequest request) {
+        List<PopularContentsResponse> response = contentService.getPopularContents(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/controller/ContentControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/ContentControllerApiSpec.java
@@ -1,9 +1,11 @@
 package com.example.udtbe.domain.content.controller;
 
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.PopularContentsRequest;
 import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.PopularContentsResponse;
 import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,5 +41,12 @@ public interface ContentControllerApiSpec {
     @GetMapping("/api/contents/weekly")
     public ResponseEntity<List<WeeklyRecommendedContentsResponse>> getWeeklyRecommendedContents(
             @ModelAttribute @Valid WeeklyRecommendationRequest request
+    );
+
+    @Operation(summary = "인기 콘텐츠 목록 조회 API", description = "인기 콘텐츠 목록을 조회한다.")
+    @ApiResponse(useReturnTypeSchema = true)
+    @GetMapping("/api/contents/popular")
+    public ResponseEntity<List<PopularContentsResponse>> getPopularContents(
+            @ModelAttribute @Valid PopularContentsRequest request
     );
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/FeedbackMapper.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/FeedbackMapper.java
@@ -2,10 +2,12 @@ package com.example.udtbe.domain.content.dto;
 
 import com.example.udtbe.domain.content.dto.common.FeedbackContentDTO;
 import com.example.udtbe.domain.content.dto.common.FeedbackCreateDTO;
+import com.example.udtbe.domain.content.dto.response.PopularContentsResponse;
 import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
 import com.example.udtbe.domain.content.service.FeedbackQuery;
 import com.example.udtbe.domain.member.entity.Member;
+import java.util.ArrayList;
 import java.util.List;
 
 public class FeedbackMapper {
@@ -42,6 +44,18 @@ public class FeedbackMapper {
         return feedbacks.stream()
                 .map(FeedbackMapper::toResponse)
                 .toList();
+    }
+
+    public static List<PopularContentsResponse> toPopularContentsResponses(List<Content> contents) {
+        List<PopularContentsResponse> popularContentsResponses = new ArrayList<>();
+
+        for (Content content : contents) {
+            popularContentsResponses.add(new PopularContentsResponse(
+                    content.getId(), content.getPosterUrl()
+            ));
+        }
+
+        return popularContentsResponses;
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/request/PopularContentsRequest.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/request/PopularContentsRequest.java
@@ -1,0 +1,12 @@
+package com.example.udtbe.domain.content.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record PopularContentsRequest(
+        @Min(value = 1, message = "요청 크기는 최소 1개입니다.")
+        @Max(value = 10, message = "요청 크기는 최대 10개입니다.")
+        int size
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/content/dto/response/PopularContentsResponse.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/response/PopularContentsResponse.java
@@ -1,0 +1,15 @@
+package com.example.udtbe.domain.content.dto.response;
+
+import com.example.udtbe.domain.content.entity.Content;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record PopularContentsResponse(
+        Long contentId,
+        String posterUrl
+) {
+
+    @QueryProjection
+    public PopularContentsResponse(Content content) {
+        this(content.getId(), content.getPosterUrl());
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
@@ -1,13 +1,30 @@
 package com.example.udtbe.domain.content.repository;
 
+import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long>, FeedbackQueryDSL {
 
     Optional<Feedback> findFeedbackById(Long feedbackId);
 
     List<Feedback> findByMemberIdAndIsDeletedFalse(Long memberId);
+
+    @Query("""
+            SELECT c
+            FROM Feedback f
+            JOIN f.content c
+            WHERE f.isDeleted = false
+            GROUP BY c
+            ORDER BY
+              SUM(CASE WHEN f.feedbackType = 'LIKE'  THEN 1
+                       WHEN f.feedbackType = 'DISLIKE' THEN -1
+                       ELSE 0 END) DESC,
+              c.id ASC
+            """)
+    List<Content> findTopRankedContents(Pageable pageable);
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
@@ -1,11 +1,14 @@
 package com.example.udtbe.domain.content.service;
 
 import com.example.udtbe.domain.content.dto.request.ContentsGetRequest;
+import com.example.udtbe.domain.content.dto.request.PopularContentsRequest;
 import com.example.udtbe.domain.content.dto.request.WeeklyRecommendationRequest;
 import com.example.udtbe.domain.content.dto.response.ContentDetailsGetResponse;
 import com.example.udtbe.domain.content.dto.response.ContentsGetResponse;
+import com.example.udtbe.domain.content.dto.response.PopularContentsResponse;
 import com.example.udtbe.domain.content.dto.response.WeeklyRecommendedContentsResponse;
 import com.example.udtbe.domain.content.entity.enums.GenreType;
+import com.example.udtbe.domain.content.util.PopularContentStore;
 import com.example.udtbe.global.config.WeeklyGenrePolicyProperties;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import java.time.LocalDate;
@@ -20,6 +23,7 @@ public class ContentService {
 
     private final ContentQuery contentQuery;
     private final WeeklyGenrePolicyProperties weeklyGenrePolicyProperties;
+    private final PopularContentStore popularContentStore;
 
     @Transactional(readOnly = true)
     public CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request) {
@@ -36,5 +40,15 @@ public class ContentService {
         List<GenreType> genreTypes = weeklyGenrePolicyProperties.getGenreForToday(
                 LocalDate.now().getDayOfWeek());
         return contentQuery.getWeeklyRecommendedContents(request, genreTypes);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PopularContentsResponse> getPopularContents(PopularContentsRequest request) {
+        List<PopularContentsResponse> popularContentsResponses = popularContentStore.get();
+        if (popularContentsResponses.size() > request.size()) {
+            return popularContentsResponses.subList(0, request.size());
+        }
+
+        return popularContentsResponses;
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentService.java
@@ -42,7 +42,6 @@ public class ContentService {
         return contentQuery.getWeeklyRecommendedContents(request, genreTypes);
     }
 
-    @Transactional(readOnly = true)
     public List<PopularContentsResponse> getPopularContents(PopularContentsRequest request) {
         List<PopularContentsResponse> popularContentsResponses = popularContentStore.get();
         if (popularContentsResponses.size() > request.size()) {

--- a/src/main/java/com/example/udtbe/domain/content/util/InMemoryPopularContentStore.java
+++ b/src/main/java/com/example/udtbe/domain/content/util/InMemoryPopularContentStore.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -46,6 +47,7 @@ public class InMemoryPopularContentStore implements PopularContentStore {
         return cache.isEmpty();
     }
 
+    @Transactional(readOnly = true)
     public CopyOnWriteArrayList<PopularContentsResponse> initCache() {
         List<PopularContentsResponse> popularContentsResponses = buildPopularContentReponses();
         return new CopyOnWriteArrayList<>(popularContentsResponses);

--- a/src/main/java/com/example/udtbe/domain/content/util/InMemoryPopularContentStore.java
+++ b/src/main/java/com/example/udtbe/domain/content/util/InMemoryPopularContentStore.java
@@ -1,0 +1,60 @@
+package com.example.udtbe.domain.content.util;
+
+import com.example.udtbe.domain.content.dto.FeedbackMapper;
+import com.example.udtbe.domain.content.dto.response.PopularContentsResponse;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.repository.FeedbackRepository;
+import jakarta.annotation.PostConstruct;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InMemoryPopularContentStore implements PopularContentStore {
+
+    private volatile CopyOnWriteArrayList<PopularContentsResponse> cache = new CopyOnWriteArrayList<>();
+
+    private final FeedbackRepository feedbackRepository;
+
+    @Override
+    public List<PopularContentsResponse> get() {
+        if (isEmpty()) {
+            update();
+        }
+
+        return Collections.unmodifiableList(cache);
+    }
+
+    @Override
+    @Scheduled(cron = "0 0 */12 * * *")
+    public void update() {
+        cache = initCache();
+    }
+
+    @PostConstruct
+    protected void init() {
+        update();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return cache.isEmpty();
+    }
+
+    public CopyOnWriteArrayList<PopularContentsResponse> initCache() {
+        List<PopularContentsResponse> popularContentsResponses = buildPopularContentReponses();
+        return new CopyOnWriteArrayList<>(popularContentsResponses);
+    }
+
+    private List<PopularContentsResponse> buildPopularContentReponses() {
+        List<Content> topRankedContents = feedbackRepository.findTopRankedContents(
+                PageRequest.of(0, 10));
+
+        return FeedbackMapper.toPopularContentsResponses(topRankedContents);
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/util/PopularContentStore.java
+++ b/src/main/java/com/example/udtbe/domain/content/util/PopularContentStore.java
@@ -1,0 +1,13 @@
+package com.example.udtbe.domain.content.util;
+
+import com.example.udtbe.domain.content.dto.response.PopularContentsResponse;
+import java.util.List;
+
+public interface PopularContentStore {
+
+    List<PopularContentsResponse> get();
+
+    void update();
+
+    boolean isEmpty();
+}

--- a/src/test/java/com/example/udtbe/content/repository/FeedbackRepositoryTest.java
+++ b/src/test/java/com/example/udtbe/content/repository/FeedbackRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.example.udtbe.content.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.FeedbackFixture;
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.common.support.DataJpaSupport;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.repository.ContentRepository;
+import com.example.udtbe.domain.content.repository.FeedbackRepository;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
+import com.example.udtbe.domain.member.repository.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+class FeedbackRepositoryTest extends DataJpaSupport {
+
+    @Autowired
+    FeedbackRepository feedbackRepository;
+
+    @Autowired
+    ContentRepository contentRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @DisplayName("인기 콘텐츠 목록 상위 8개 조회한다.")
+    @Test
+    void getPopularContents() {
+        // given
+        List<Integer> topRankedIndexes = List.of(3, 5, 8, 11, 14, 18, 21, 25);
+
+        List<Content> savedContents = contentRepository.saveAll(ContentFixture.contents(30));
+        List<Member> members = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            members.add(MemberFixture.member("email" + i, Role.ROLE_USER));
+        }
+        List<Member> savedMembers = memberRepository.saveAll(members);
+
+        List<Feedback> feedbacks = new ArrayList<>();
+
+        for (int i = 0; i < savedContents.size(); i++) {
+            Content content = savedContents.get(i);
+            for (int j = 0; j < 50; j++) {
+                Member member = savedMembers.get(j);
+                if (topRankedIndexes.contains(i)) {
+                    if (j < 40) {
+                        feedbacks.add(FeedbackFixture.like(member, content));
+                    } else {
+                        feedbacks.add(FeedbackFixture.dislike(member, content));
+                    }
+                } else {
+                    if (j < 20) {
+                        feedbacks.add(FeedbackFixture.dislike(member, content));
+                    } else {
+                        feedbacks.add(FeedbackFixture.like(member, content));
+                    }
+                }
+            }
+        }
+        List<Feedback> savedFeedbacks = feedbackRepository.saveAll(feedbacks);
+
+        // when
+        List<Content> topRankedContents = feedbackRepository.findTopRankedContents(
+                PageRequest.of(0, topRankedIndexes.size())
+        );
+
+        // then
+        assertAll(
+                () -> {
+                    List<Long> expectedIds = topRankedIndexes.stream()
+                            .map(i -> savedContents.get(i).getId())
+                            .toList();
+
+                    List<Long> actualIds = topRankedContents.stream()
+                            .map(Content::getId)
+                            .toList();
+
+                    assertThat(actualIds).containsExactlyElementsOf(expectedIds);
+                }
+        );
+
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- OTT 콘텐츠 인기 목록 조회 AP
- 피드백 테이블에서 인기 콘텐츠 계산 알고리즘 캐싱

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- 피드백 테이블에서 인기 콘텐츠 계산 알고리즘이 매번 계산될 필요가 없다고 생각해 캐싱 작업으로 진행했습니다.
- 최대 10개정도 데이터 크기 특성을 고려해 인메모리 캐싱으로 구현했습니다.
  - 추후 레디스로 확장할 수 있게 설계를 진행했습니다.
- 캐싱 데이터(공유 자원)에 대한 동시성, 메모리 가시성을 고려해 작업했습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분
