### PR TITLE
Fix/udt 110 피드백 중복 처리

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/dto/FeedbackMapper.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/FeedbackMapper.java
@@ -14,7 +14,7 @@ public class FeedbackMapper {
 
     private static Feedback createFeedback(FeedbackCreateDTO req, Member member,
             FeedbackQuery feedbackQuery) {
-        Content content = feedbackQuery.getContentById(req.contentId());
+        Content content = feedbackQuery.findContentById(req.contentId());
         return Feedback.of(req.feedback(), false, member, content);
     }
 

--- a/src/main/java/com/example/udtbe/domain/content/entity/Feedback.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/Feedback.java
@@ -71,7 +71,7 @@ public class Feedback extends TimeBaseEntity {
                 .build();
     }
 
-    public boolean softDeleted() {
-        return isDeleted = true;
+    public boolean switchDeleted() {
+        return !isDeleted;
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/entity/Feedback.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/Feedback.java
@@ -74,4 +74,8 @@ public class Feedback extends TimeBaseEntity {
     public boolean switchDeleted() {
         return this.isDeleted = !isDeleted;
     }
+
+    public void updateFeedbackType(FeedbackType feedbackType) {
+        this.feedbackType = feedbackType;
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/content/entity/Feedback.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/Feedback.java
@@ -72,6 +72,6 @@ public class Feedback extends TimeBaseEntity {
     }
 
     public boolean switchDeleted() {
-        return !isDeleted;
+        return this.isDeleted = !isDeleted;
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
@@ -29,6 +29,4 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long>, Feedb
               c.id ASC
             """)
     List<Content> findTopRankedContents(Pageable pageable);
-
-    Long content(Content content);
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
@@ -2,8 +2,6 @@ package com.example.udtbe.domain.content.repository;
 
 import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
-import com.example.udtbe.domain.content.entity.enums.FeedbackType;
-import com.example.udtbe.domain.member.entity.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -16,8 +14,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long>, Feedb
 
     List<Feedback> findByMemberIdAndIsDeletedFalse(Long memberId);
 
-    Optional<Feedback> findByMemberAndContentAndFeedbackType(Member member, Content content,
-            FeedbackType type);
+    Optional<Feedback> findFeedbackByMemberIdAndContentId(Long memberId, Long contentId);
 
     @Query("""
             SELECT c
@@ -32,4 +29,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long>, Feedb
               c.id ASC
             """)
     List<Content> findTopRankedContents(Pageable pageable);
+
+    Long content(Content content);
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
@@ -1,6 +1,9 @@
 package com.example.udtbe.domain.content.repository;
 
+import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.entity.enums.FeedbackType;
+import com.example.udtbe.domain.member.entity.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +13,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long>, Feedb
     Optional<Feedback> findFeedbackById(Long feedbackId);
 
     List<Feedback> findByMemberIdAndIsDeletedFalse(Long memberId);
+
+    Optional<Feedback> findByMemberAndContentAndFeedbackType(Member member, Content content,
+            FeedbackType type);
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
@@ -3,7 +3,6 @@ package com.example.udtbe.domain.content.service;
 import com.example.udtbe.domain.content.dto.request.FeedbackContentGetRequest;
 import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
-import com.example.udtbe.domain.content.entity.enums.FeedbackType;
 import com.example.udtbe.domain.content.exception.ContentErrorCode;
 import com.example.udtbe.domain.content.exception.FeedbackErrorCode;
 import com.example.udtbe.domain.content.repository.ContentRepository;
@@ -21,7 +20,7 @@ public class FeedbackQuery {
     private final ContentRepository contentRepository;
     private final FeedbackRepository feedbackRepository;
 
-    public Content getContentById(Long id) {
+    public Content findContentById(Long id) {
         return contentRepository.findById(id)
                 .orElseThrow(() -> new RestApiException(ContentErrorCode.CONTENT_NOT_FOUND));
     }
@@ -36,10 +35,8 @@ public class FeedbackQuery {
         return feedbackRepository.getFeedbacksByCursor(feedbackContentGetRequest, member);
     }
 
-    public Feedback findByMemberAndContentAndFeedbackType(Member member, Content content,
-            FeedbackType feedbackType) {
-        return feedbackRepository.findByMemberAndContentAndFeedbackType(member, content,
-                        feedbackType)
-                .orElseThrow(() -> new RestApiException(FeedbackErrorCode.FEEDBACK_NOT_FOUND));
+    public Feedback findFeedbackByMemberIdAndContentId(Long memberId, Long contentId) {
+        return feedbackRepository.findFeedbackByMemberIdAndContentId(memberId, contentId)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
@@ -36,7 +36,7 @@ public class FeedbackQuery {
         return feedbackRepository.getFeedbacksByCursor(feedbackContentGetRequest, member);
     }
 
-    public Optional<Feedback> findFeedback(Long memberId, Long contentId) {
+    public Optional<Feedback> findFeedbackByMemberIdAndContentId(Long memberId, Long contentId) {
         return feedbackRepository.findFeedbackByMemberIdAndContentId(memberId, contentId);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
@@ -10,6 +10,7 @@ import com.example.udtbe.domain.content.repository.FeedbackRepository;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.exception.RestApiException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -35,8 +36,7 @@ public class FeedbackQuery {
         return feedbackRepository.getFeedbacksByCursor(feedbackContentGetRequest, member);
     }
 
-    public Feedback findFeedbackByMemberIdAndContentId(Long memberId, Long contentId) {
-        return feedbackRepository.findFeedbackByMemberIdAndContentId(memberId, contentId)
-                .orElse(null);
+    public Optional<Feedback> findFeedback(Long memberId, Long contentId) {
+        return feedbackRepository.findFeedbackByMemberIdAndContentId(memberId, contentId);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
@@ -3,6 +3,7 @@ package com.example.udtbe.domain.content.service;
 import com.example.udtbe.domain.content.dto.request.FeedbackContentGetRequest;
 import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.entity.enums.FeedbackType;
 import com.example.udtbe.domain.content.exception.ContentErrorCode;
 import com.example.udtbe.domain.content.exception.FeedbackErrorCode;
 import com.example.udtbe.domain.content.repository.ContentRepository;
@@ -33,5 +34,12 @@ public class FeedbackQuery {
     public List<Feedback> getFeedbacksByCursor(Member member,
             FeedbackContentGetRequest feedbackContentGetRequest) {
         return feedbackRepository.getFeedbacksByCursor(feedbackContentGetRequest, member);
+    }
+
+    public Feedback findByMemberAndContentAndFeedbackType(Member member, Content content,
+            FeedbackType feedbackType) {
+        return feedbackRepository.findByMemberAndContentAndFeedbackType(member, content,
+                        feedbackType)
+                .orElseThrow(() -> new RestApiException(FeedbackErrorCode.FEEDBACK_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -36,9 +36,7 @@ public class FeedbackService {
 
             if (existing != null) {
                 if (existing.isDeleted()) {
-                    System.out.println("✅ switchDeleted() 실행 전: " + existing.isDeleted());
                     existing.switchDeleted();
-                    System.out.println("✅ switchDeleted() 실행 후: " + existing.isDeleted());
                     feedbacks.add(existing);
                 }
             } else {

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -36,7 +36,9 @@ public class FeedbackService {
 
             if (existing != null) {
                 if (existing.isDeleted()) {
+                    System.out.println("✅ switchDeleted() 실행 전: " + existing.isDeleted());
                     existing.switchDeleted();
+                    System.out.println("✅ switchDeleted() 실행 후: " + existing.isDeleted());
                     feedbacks.add(existing);
                 }
             } else {

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -29,16 +29,17 @@ public class FeedbackService {
         List<Feedback> feedbacks = new ArrayList<>();
 
         for (FeedbackCreateDTO feedbackCreateDTO : requests) {
-            Content content = feedbackQuery.getContentById(feedbackCreateDTO.contentId());
+            Content content = feedbackQuery.findContentById(feedbackCreateDTO.contentId());
 
-            Feedback existing = feedbackQuery.findByMemberAndContentAndFeedbackType(member,
-                    content, feedbackCreateDTO.feedback());
+            Feedback existing = feedbackQuery.findFeedbackByMemberIdAndContentId(member.getId(),
+                    content.getId());
 
             if (existing != null) {
                 if (existing.isDeleted()) {
                     existing.switchDeleted();
-                    feedbacks.add(existing);
                 }
+                existing.updateFeedbackType(feedbackCreateDTO.feedback());
+                feedbacks.add(existing);
             } else {
                 Feedback newFeedback = Feedback.of(feedbackCreateDTO.feedback(), false, member,
                         content);

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -32,12 +32,12 @@ public class FeedbackService {
         for (FeedbackCreateDTO feedbackCreateDTO : requests) {
             Content content = feedbackQuery.findContentById(feedbackCreateDTO.contentId());
 
-            Optional<Feedback> existing = feedbackQuery.findFeedback(
+            Optional<Feedback> findFeedback = feedbackQuery.findFeedbackByMemberIdAndContentId(
                     member.getId(),
                     content.getId());
 
-            if (existing.isPresent()) {
-                Feedback feedback = existing.get();
+            if (findFeedback.isPresent()) {
+                Feedback feedback = findFeedback.get();
                 if (feedback.isDeleted()) {
                     feedback.switchDeleted();
                 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -13,6 +13,7 @@ import com.example.udtbe.global.dto.CursorPageResponse;
 import com.example.udtbe.global.exception.RestApiException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,15 +32,17 @@ public class FeedbackService {
         for (FeedbackCreateDTO feedbackCreateDTO : requests) {
             Content content = feedbackQuery.findContentById(feedbackCreateDTO.contentId());
 
-            Feedback existing = feedbackQuery.findFeedbackByMemberIdAndContentId(member.getId(),
+            Optional<Feedback> existing = feedbackQuery.findFeedback(
+                    member.getId(),
                     content.getId());
 
-            if (existing != null) {
-                if (existing.isDeleted()) {
-                    existing.switchDeleted();
+            if (existing.isPresent()) {
+                Feedback feedback = existing.get();
+                if (feedback.isDeleted()) {
+                    feedback.switchDeleted();
                 }
-                existing.updateFeedbackType(feedbackCreateDTO.feedback());
-                feedbacks.add(existing);
+                feedback.updateFeedbackType(feedbackCreateDTO.feedback());
+                feedbacks.add(feedback);
             } else {
                 Feedback newFeedback = Feedback.of(feedbackCreateDTO.feedback(), false, member,
                         content);

--- a/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
@@ -25,6 +25,7 @@ import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.entity.enums.Role;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -84,8 +85,8 @@ public class FeedbackServiceTest {
         FeedbackCreateDTO request = new FeedbackCreateDTO(content.getId(), FeedbackType.DISLIKE);
 
         given(feedbackQuery.findContentById(1L)).willReturn(content);
-        given(feedbackQuery.findFeedbackByMemberIdAndContentId(member.getId(),
-                content.getId())).willReturn(existing);
+        given(feedbackQuery.findFeedback(member.getId(),
+                content.getId())).willReturn(Optional.ofNullable(existing));
 
         // when
         feedbackService.saveFeedbacks(List.of(request), member);
@@ -111,8 +112,8 @@ public class FeedbackServiceTest {
         FeedbackCreateDTO request = new FeedbackCreateDTO(1L, FeedbackType.DISLIKE);
 
         given(feedbackQuery.findContentById(1L)).willReturn(content);
-        given(feedbackQuery.findFeedbackByMemberIdAndContentId(member.getId(), content.getId()))
-                .willReturn(existing);
+        given(feedbackQuery.findFeedback(member.getId(), content.getId()))
+                .willReturn(Optional.ofNullable(existing));
 
         // when
         feedbackService.saveFeedbacks(List.of(request), member);

--- a/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
@@ -80,13 +80,13 @@ public class FeedbackServiceTest {
         Content content = ContentFixture.content("title", "description");
         ReflectionTestUtils.setField(content, "id", 1L);
 
-        Feedback existing = Feedback.of(FeedbackType.LIKE, true, member, content);
+        Feedback feedback = Feedback.of(FeedbackType.LIKE, true, member, content);
 
         FeedbackCreateDTO request = new FeedbackCreateDTO(content.getId(), FeedbackType.DISLIKE);
 
         given(feedbackQuery.findContentById(1L)).willReturn(content);
-        given(feedbackQuery.findFeedback(member.getId(),
-                content.getId())).willReturn(Optional.ofNullable(existing));
+        given(feedbackQuery.findFeedbackByMemberIdAndContentId(member.getId(),
+                content.getId())).willReturn(Optional.ofNullable(feedback));
 
         // when
         feedbackService.saveFeedbacks(List.of(request), member);
@@ -108,18 +108,18 @@ public class FeedbackServiceTest {
         Content content = ContentFixture.content("title", "description");
         ReflectionTestUtils.setField(content, "id", 1L);
 
-        Feedback existing = Feedback.of(FeedbackType.LIKE, false, member, content);
+        Feedback savedFeedback = Feedback.of(FeedbackType.LIKE, false, member, content);
         FeedbackCreateDTO request = new FeedbackCreateDTO(1L, FeedbackType.DISLIKE);
 
         given(feedbackQuery.findContentById(1L)).willReturn(content);
-        given(feedbackQuery.findFeedback(member.getId(), content.getId()))
-                .willReturn(Optional.ofNullable(existing));
+        given(feedbackQuery.findFeedbackByMemberIdAndContentId(member.getId(), content.getId()))
+                .willReturn(Optional.ofNullable(savedFeedback));
 
         // when
         feedbackService.saveFeedbacks(List.of(request), member);
 
         // then
-        assertThat(existing.getFeedbackType()).isEqualTo(FeedbackType.DISLIKE);
+        assertThat(savedFeedback.getFeedbackType()).isEqualTo(FeedbackType.DISLIKE);
         verify(feedbackRepository, times(1)).saveAll(anyList());
     }
 

--- a/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
@@ -77,7 +77,7 @@ public class FeedbackServiceTest {
         // given
         Member member = MemberFixture.member("user@email.com", Role.ROLE_USER);
         Content content = ContentFixture.content("title", "description");
-        ReflectionTestUtils.setField(content, "title", 1L);
+        ReflectionTestUtils.setField(content, "id", 1L);
 
         Feedback existing = Feedback.of(FeedbackType.LIKE, true, member, content);
         assertThat(existing.isDeleted()).isTrue();


### PR DESCRIPTION
## 📝 요약(Summary)
- 피드백을 저장 API의 로직을 수정했습니다.
  - 테스트코드 작성
  1. feedback이 있는지 확인
     if (existing != null)
  2. 없다면 새로 생성
     else 블록에서 Feedback.of(...) 생성
  3. feedback이 있고 + 삭제된 상태
     existing.isDeleted() → 복구 및 type 수정
  4. 있고 + 삭제되지 않은 상태
     updateFeedbackType() 수행
     💜 '30초 만에 원하는 콘텐츠를 찾는다'라는 서비스 목표에 맞게 사용자의 feedback은 현재 시점에 우선순위를 두기로 했습니다.
     💜 따라서 같은 컨텐츠의 경우 최신의 반응(좋아요/싫어요/관심없음)이 저장됩니다.


## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
혹시라도 로직에 문제가 있거나 더 나은 로직이 있다면 언제든지 말씀해주세요~!

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
