### PR TITLE
feat/UDT-111-설문조사-저장-요청-DTO-콘텐츠-필드-추가

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/dto/response/ContentRecommendationResponse.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/response/ContentRecommendationResponse.java
@@ -18,4 +18,5 @@ public record ContentRecommendationResponse(
         List<String> casts,
         List<String> platforms
 ) {
+
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentMetadataRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentMetadataRepository.java
@@ -4,10 +4,14 @@ import com.example.udtbe.domain.content.entity.ContentMetadata;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ContentMetadataRepository extends JpaRepository<ContentMetadata, Long> {
 
     Optional<ContentMetadata> findByContent_Id(Long contentId);
 
     List<ContentMetadata> findByIsDeletedFalse();
+
+    @Query("select cm.id from ContentMetadata cm where cm.content.id = :contentId")
+    Optional<Long> findIdByContent_Id(Long contentId);
 }

--- a/src/main/java/com/example/udtbe/domain/content/repository/CuratedContentQueryDSLImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/CuratedContentQueryDSLImpl.java
@@ -1,19 +1,18 @@
 package com.example.udtbe.domain.content.repository;
 
+import static com.example.udtbe.domain.content.entity.QContent.content;
+import static com.example.udtbe.domain.content.entity.QCuratedContent.curatedContent;
+
 import com.example.udtbe.domain.member.dto.response.MemberCuratedContentGetResponse;
 import com.example.udtbe.domain.member.dto.response.QMemberCuratedContentGetResponse;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Objects;
-
-import static com.example.udtbe.domain.content.entity.QContent.content;
-import static com.example.udtbe.domain.content.entity.QCuratedContent.curatedContent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/example/udtbe/domain/survey/dto/SurveyMapper.java
+++ b/src/main/java/com/example/udtbe/domain/survey/dto/SurveyMapper.java
@@ -14,12 +14,12 @@ import lombok.NoArgsConstructor;
 
 public class SurveyMapper {
 
-    public static Survey toEntity(SurveyCreateRequest request, Member member) {
-        // TODO : 2차 MVP Contents 변경
+    public static Survey toEntity(SurveyCreateRequest request, Member member,
+            List<String> contentMetaDataIds) {
         return Survey.of(
                 PlatformType.toPlatformTypes(request.platforms()),
                 GenreType.toGenreTypes(request.genres()),
-                List.of(""),
+                contentMetaDataIds,
                 false,
                 member
         );

--- a/src/main/java/com/example/udtbe/domain/survey/dto/request/SurveyCreateRequest.java
+++ b/src/main/java/com/example/udtbe/domain/survey/dto/request/SurveyCreateRequest.java
@@ -11,7 +11,9 @@ public record SurveyCreateRequest(
 
         @NotNull(message = "선호 장르는 필수 값입니다.")
         @Size(min = 1, max = 3, message = "선호 장르는 최소 1개 이상 최대 3개 이하입니다.")
-        List<String> genres
+        List<String> genres,
+
+        List<Long> contentIds
 ) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/example/udtbe/domain/survey/repository/SurveyRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
     boolean existsByMember(Member member);
+
     Optional<Survey> findByMemberId(Long memberId);
 
 }

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyQuery.java
@@ -1,5 +1,7 @@
 package com.example.udtbe.domain.survey.service;
 
+import com.example.udtbe.domain.content.exception.ContentErrorCode;
+import com.example.udtbe.domain.content.repository.ContentMetadataRepository;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.domain.survey.exception.SurveyErrorCode;
@@ -14,6 +16,8 @@ public class SurveyQuery {
 
     private final SurveyRepository surveyRepository;
 
+    private final ContentMetadataRepository contentMetadataRepository;
+
     public boolean existsByMember(Member member) {
         return surveyRepository.existsByMember(member);
     }
@@ -23,7 +27,14 @@ public class SurveyQuery {
     }
 
     public Survey findSurveyByMemberId(Long memberId) {
-        return surveyRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new RestApiException(SurveyErrorCode.SURVEY_NOT_FOUND));
+        return surveyRepository.findByMemberId(memberId).orElseThrow(
+                () -> new RestApiException(SurveyErrorCode.SURVEY_NOT_FOUND)
+        );
+    }
+
+    public Long findContentMetadataId(Long contentId) {
+        return contentMetadataRepository.findIdByContent_Id(contentId).orElseThrow(
+                () -> new RestApiException(ContentErrorCode.CONTENT_METADATA_NOT_FOUND)
+        );
     }
 }

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
@@ -10,6 +10,8 @@ import com.example.udtbe.domain.survey.exception.SurveyErrorCode;
 import com.example.udtbe.global.exception.RestApiException;
 import com.example.udtbe.global.token.cookie.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +30,12 @@ public class SurveyService {
             throw new RestApiException(SurveyErrorCode.SURVEY_ALREADY_EXISTS_FOR_MEMBER);
         }
 
-        Survey survey = SurveyMapper.toEntity(request, member);
+        List<String> contentMetaDataIds = new ArrayList<>();
+        for (Long contentId : request.contentIds()) {
+            contentMetaDataIds.add(String.valueOf(surveyQuery.findContentMetadataId(contentId)));
+        }
+
+        Survey survey = SurveyMapper.toEntity(request, member, contentMetaDataIds);
         surveyQuery.save(survey);
 
         member.updateRole(ROLE_USER);

--- a/src/test/java/com/example/udtbe/common/fixture/SurveyFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/SurveyFixture.java
@@ -4,6 +4,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.entity.Survey;
+import java.util.Collections;
 import java.util.List;
 import lombok.NoArgsConstructor;
 
@@ -15,7 +16,7 @@ public class SurveyFixture {
         return Survey.of(
                 platformTypes,
                 genreTypes,
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -37,7 +38,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of("NETFLIX", "WATCHA"),
                 List.of("ACTION", "THRILLER"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -47,7 +48,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of("DISNEY_PLUS", "NETFLIX"),
                 List.of("SF", "FANTASY"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -57,7 +58,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of("NETFLIX"),
                 List.of("ACTION", "DRAMA"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -67,7 +68,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of("DISNEY_PLUS"),
                 List.of("ACTION", "ADVENTURE"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -77,7 +78,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of("NETFLIX", "WATCHA", "TVING"),
                 List.of("MUSICAL", "ROMANCE"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -87,7 +88,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of("NETFLIX", "WATCHA"),
                 List.of("HORROR", "THRILLER", "MYSTERY"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -97,7 +98,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of("DISNEY_PLUS", "NETFLIX"),
                 List.of("ANIMATION", "ADVENTURE", "FAMILY"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );
@@ -107,7 +108,7 @@ public class SurveyFixture {
         return Survey.of(
                 List.of(), // 빈 플랫폼 리스트
                 List.of("ACTION"),
-                List.of(""),
+                Collections.emptyList(),
                 false,
                 member
         );

--- a/src/test/java/com/example/udtbe/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/udtbe/member/controller/MemberControllerTest.java
@@ -13,6 +13,7 @@ import com.example.udtbe.domain.member.repository.MemberRepository;
 import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
 import com.example.udtbe.domain.survey.repository.SurveyRepository;
 import com.example.udtbe.global.exception.code.EnumErrorCode;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -40,8 +41,13 @@ class MemberControllerTest extends ApiSupport {
         // given
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디");
+        List<Long> contentIds = Collections.emptyList();
 
-        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(
+                platforms,
+                genres,
+                contentIds
+        );
 
         mockMvc.perform(post("/api/survey")
                 .content(toJson(surveyCreateRequest))
@@ -71,8 +77,13 @@ class MemberControllerTest extends ApiSupport {
         // given
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디");
+        List<Long> contentIds = Collections.emptyList();
 
-        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(
+                platforms,
+                genres,
+                contentIds
+        );
 
         mockMvc.perform(post("/api/survey")
                 .content(toJson(surveyCreateRequest))
@@ -101,8 +112,13 @@ class MemberControllerTest extends ApiSupport {
     void updateZeroGenre() throws Exception {
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디");
+        List<Long> contentIds = Collections.emptyList();
 
-        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(
+                platforms,
+                genres,
+                contentIds
+        );
 
         mockMvc.perform(post("/api/survey")
                 .content(toJson(surveyCreateRequest))
@@ -130,8 +146,13 @@ class MemberControllerTest extends ApiSupport {
         // given
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디");
+        List<Long> contentIds = Collections.emptyList();
 
-        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(
+                platforms,
+                genres,
+                contentIds
+        );
 
         mockMvc.perform(post("/api/survey")
                 .content(toJson(surveyCreateRequest))
@@ -161,8 +182,13 @@ class MemberControllerTest extends ApiSupport {
         // given
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디");
+        List<Long> contentIds = Collections.emptyList();
 
-        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest surveyCreateRequest = new SurveyCreateRequest(
+                platforms,
+                genres,
+                contentIds
+        );
 
         mockMvc.perform(post("/api/survey")
                 .content(toJson(surveyCreateRequest))

--- a/src/test/java/com/example/udtbe/survey/controller/SurveyControllerTest.java
+++ b/src/test/java/com/example/udtbe/survey/controller/SurveyControllerTest.java
@@ -5,7 +5,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentMetadataFixture;
 import com.example.udtbe.common.support.ApiSupport;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.repository.ContentMetadataRepository;
+import com.example.udtbe.domain.content.repository.ContentRepository;
 import com.example.udtbe.domain.member.repository.MemberRepository;
 import com.example.udtbe.domain.survey.controller.SurveyController;
 import com.example.udtbe.domain.survey.dto.SurveyMapper;
@@ -29,6 +35,12 @@ class SurveyControllerTest extends ApiSupport {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    ContentRepository contentRepository;
+
+    @Autowired
+    ContentMetadataRepository contentMetadataRepository;
+
     @AfterEach
     void tearDown() {
         surveyRepository.deleteAll();
@@ -39,10 +51,14 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void createSurvey() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        contentMetadataRepository.save(ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디", "범죄");
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -57,12 +73,19 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void throwExceptionIfSurveyAlreadyExistsForMember() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        ContentMetadata savedContentMetadata = contentMetadataRepository.save(
+                ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디", "범죄");
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
-        surveyRepository.save(SurveyMapper.toEntity(request, loginTempMember));
+        surveyRepository.save(SurveyMapper.toEntity(
+                request, loginTempMember, List.of(String.valueOf(savedContentMetadata.getId()))
+        ));
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -79,10 +102,14 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void throwExceptionIfSurveyPlatformIsNull() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        contentMetadataRepository.save(ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = null;
         List<String> genres = List.of("코미디", "범죄");
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -99,10 +126,14 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void throwExceptionIfSurveyPlatformCountIsLessThanOne() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        contentMetadataRepository.save(ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = Collections.emptyList();
         List<String> genres = List.of("코미디", "범죄");
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -119,12 +150,16 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void throwExceptionIfSurveyPlatformCountExceedsSeven() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        contentMetadataRepository.save(ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = List.of(
                 "넷플릭스", "디즈니+", "티빙", "쿠팡플레이", "웨이브", "왓챠", "Apple TV", "유튜브"
         );
         List<String> genres = List.of("코미디", "범죄");
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -141,10 +176,14 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void throwExceptionIfSurveyGenreIsNull() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        contentMetadataRepository.save(ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = null;
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -161,10 +200,14 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void throwExceptionIfSurveyGenreCountIsLessThanOne() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        contentMetadataRepository.save(ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = Collections.emptyList();
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -181,10 +224,14 @@ class SurveyControllerTest extends ApiSupport {
     @Test
     void throwExceptionIfSurveyGenreCountExceedsThree() throws Exception {
         // given
+        Content savedContent = contentRepository.save(ContentFixture.content("드라마", "드라마입니다."));
+        contentMetadataRepository.save(ContentMetadataFixture.dramaMetadata(savedContent));
+
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디", "범죄", "액션", "뮤지컬");
+        List<Long> contentIds = List.of(savedContent.getId());
 
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
 
         // when  // then
         mockMvc.perform(post("/api/survey")
@@ -195,5 +242,24 @@ class SurveyControllerTest extends ApiSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("404"))
                 .andExpect(jsonPath("$.message").value("선호 장르는 최소 1개 이상 최대 3개 이하입니다."));
+    }
+
+    @DisplayName("설문조사 시 보신 콘텐츠 선택하지 않을 수 있다.")
+    @Test
+    void createSurveyWithoutWatchedContents() throws Exception {
+        // given
+        List<String> platforms = List.of("넷플릭스", "디즈니+");
+        List<String> genres = List.of("코미디", "범죄");
+        List<Long> contentIds = Collections.emptyList();
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentIds);
+
+        // when  // then
+        mockMvc.perform(post("/api/survey")
+                        .content(toJson(request))
+                        .contentType(APPLICATION_JSON)
+                        .cookie(accessTokenOfTempMember)
+                )
+                .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/example/udtbe/survey/service/SurveyServiceTest.java
+++ b/src/test/java/com/example/udtbe/survey/service/SurveyServiceTest.java
@@ -19,6 +19,7 @@ import com.example.udtbe.domain.survey.service.SurveyService;
 import com.example.udtbe.global.exception.RestApiException;
 import com.example.udtbe.global.token.cookie.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,8 @@ class SurveyServiceTest {
         Member member = MemberFixture.member(email, ROLE_GUEST);
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디", "범죄");
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        List<Long> contentId = Collections.emptyList();
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentId);
 
         given(surveyQuery.existsByMember(member)).willReturn(Boolean.FALSE);
         given(surveyQuery.save(any(Survey.class))).willReturn(null);
@@ -76,10 +78,12 @@ class SurveyServiceTest {
         Member member = MemberFixture.member(email, ROLE_GUEST);
         List<String> platforms = List.of("넷플릭스", "디즈니+");
         List<String> genres = List.of("코미디", "범죄");
-        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres);
+        List<Long> contentId = Collections.emptyList();
+
+        SurveyCreateRequest request = new SurveyCreateRequest(platforms, genres, contentId);
 
         given(surveyQuery.existsByMember(member)).willReturn(Boolean.TRUE);
-        
+
         // when  // then
         assertThatThrownBy(() -> surveyService.createSurvey(request, member, response))
                 .isInstanceOf(RestApiException.class)


### PR DESCRIPTION
## 📝 요약(Summary)

- 설문조사 저장 API
  - 본 콘텐츠 설문조사 필드 추가
  - 추후 추천 알고리즘에서 편리하게 사용할 수 있또록 콘텐츠 Id 리스트 값이 아닌 콘텐츠 메타데이터Id 리스트 값으로 변경해서 저장
- 설문조사 저장 API Request DTO 필드 추가로 인한 기존 테스트 로직 리팩토링

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- 본 콘텐츠 설문조사 필드 값 중 하나라도 존재하지 않은 콘텐츠 ID 값이 있다면, 전체 롤백이 되도록 설계했습니다.
- 만약, 이 로직보다 존재하는 값만 저장시키도록 변경이 필요할까요?? 이 경우, IN 절을 통해 최적화 가능하지만 전체적인 비즈니스 흐름이 달라집니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분
