### PR TITLE
fix/UDT-113-관리자-OTT-콘텐츠-조회-시-장르-중복-오류

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
@@ -103,10 +103,12 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
                                 list(genre.genreType.stringValue())
                         )
                 ));
+
         categories = categories.stream()
                 .map(c -> new AdminCategoryDTO(
                         CategoryType.from(c.categoryType()).getType(),
                         c.genres().stream()
+                                .distinct()
                                 .map(g -> GenreType.from(g).getType()).toList()
                 )).toList();
 


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
관리자 페이지에서 콘텐츠 조회 시 join으로 인해 장르가 중복되어서 나오는 오류 해결

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
