### PR TITLE
fix/UDT-114-요일별-콘텐츠-목록-조회-테스트-검증-버그

### DIFF
--- a/src/test/java/com/example/udtbe/content/controller/ContentControllerTest.java
+++ b/src/test/java/com/example/udtbe/content/controller/ContentControllerTest.java
@@ -458,7 +458,7 @@ class ContentControllerTest extends ApiSupport {
         initContentGenre(contentGenres, savedContents.get(0), savedGenres.get(19));
         initContentGenre(contentGenres, savedContents.get(1), savedGenres.get(7));
         initContentGenre(contentGenres, savedContents.get(2), savedGenres.get(0));
-        initContentGenre(contentGenres, savedContents.get(3), savedGenres.get(6));
+        initContentGenre(contentGenres, savedContents.get(3), savedGenres.get(5));
         initContentGenre(contentGenres, savedContents.get(4), savedGenres.get(14));
         initContentGenre(contentGenres, savedContents.get(5), savedGenres.get(3));
         initContentGenre(contentGenres, savedContents.get(6), savedGenres.get(9));


### PR DESCRIPTION
## 📝 요약(Summary)

- 요일별 콘텐츠 목록 조회 통합 테스트 오류 수정
  - 화요일 콘텐츠 장르가 잘못된 장르가 매핑되어 검증이 실패하는 오류 수정

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

- 테스트 실시 요일에 따라 검증 로직이 변경되서 자꾸 한번 씩 테스트가 깨지네요.. 테스트는 항상 동일한 결과를 내야하는데 잘못된 테스트 로직을 짠건 아닌가 고민됩니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
