### PR TITLE
Fix/UDT-118 목록 조회시 데이터가 없을때 500에러 발생 수정

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/repository/CuratedContentQueryDSLImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/CuratedContentQueryDSLImpl.java
@@ -9,6 +9,7 @@ import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -31,11 +32,16 @@ public class CuratedContentQueryDSLImpl implements CuratedContentQueryDSL {
                                 content.title,
                                 content.posterUrl
                         )
-                ).from(curatedContent).fetchJoin()
+                ).from(curatedContent)
+                .join(curatedContent.content, content)
                 .where(baseFilter(member).and(cursorFilter(cursor)))
                 .orderBy(curatedContent.id.desc())
                 .limit(size + 1)
                 .fetch();
+
+        if (curatedContentGetResponses == null) {
+            curatedContentGetResponses = Collections.emptyList();
+        }
 
         boolean hasNext = isNext(curatedContentGetResponses.size(), size);
 

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -12,6 +12,7 @@ import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import com.example.udtbe.global.exception.RestApiException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +58,9 @@ public class FeedbackService {
     public CursorPageResponse<FeedbackContentDTO> getFeedbackList(FeedbackContentGetRequest request,
             Member member) {
         List<Feedback> feedbacks = feedbackQuery.getFeedbacksByCursor(member, request);
+        if (feedbacks == null) {
+            feedbacks = Collections.emptyList();
+        }
 
         boolean hasNext = feedbacks.size() > request.size();
         List<Feedback> limited = hasNext ? feedbacks.subList(0, request.size()) : feedbacks;


### PR DESCRIPTION
## 📝 요약(Summary)
피드백 목록 조회와 엄선된 콘텐츠 목록 조회 API에서 조회할 데이터가 없을때 500에러가 발생하던 것을 빈 List를 반환하도록 수정했습니다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
