### PR TITLE
fix/UDT-129-설문조사-저장-시-회원-ROLE-업데이트-버그

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/entity/Director.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/Director.java
@@ -28,6 +28,9 @@ public class Director extends TimeBaseEntity {
     @Column(name = "director_name", nullable = false)
     private String directorName;
 
+    @Column(name = "director_image_url")
+    private String directorImageUrl;
+
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 

--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
@@ -2,6 +2,7 @@ package com.example.udtbe.domain.survey.service;
 
 import static com.example.udtbe.domain.member.entity.enums.Role.ROLE_USER;
 
+import com.example.udtbe.domain.auth.service.AuthQuery;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.survey.dto.SurveyMapper;
 import com.example.udtbe.domain.survey.dto.request.SurveyCreateRequest;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SurveyService {
 
     private final SurveyQuery surveyQuery;
+    private final AuthQuery authQuery;
     private final CookieUtil cookieUtil;
 
     @Transactional
@@ -39,6 +41,8 @@ public class SurveyService {
         surveyQuery.save(survey);
 
         member.updateRole(ROLE_USER);
+        authQuery.save(member);
+
         cookieUtil.deleteCookie(response);
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

- 설문조사 저장 시 회원 ROLE 업데이트 버그 해결
  - 영속성 컨텍스트에 회원 스냅샷이 존재하지 않아 더티 체킹이 실제로 일어나지 않은 오류
- 데이터 세팅을 위한 Director Image 필드 추가

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 3분
