### PR TITLE
feat/UDT-132-Redis-Config-수정

### DIFF
--- a/src/main/java/com/example/udtbe/global/config/RedisConfig.java
+++ b/src/main/java/com/example/udtbe/global/config/RedisConfig.java
@@ -1,10 +1,13 @@
 package com.example.udtbe.global.config;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -21,15 +24,30 @@ public class RedisConfig {
     @Value("${spring.data.redis.password}")
     private String password;
 
+    @Value("${spring.data.redis.ssl.enabled:false}")
+    private boolean sslEnabled;
+
+    @Value("${spring.data.redis.timeout:5000}")
+    private long timeout;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
         config.setHostName(host);
         config.setPort(port);
-        if (!password.isEmpty()) {
+        if (password != null && !password.isEmpty()) {
             config.setPassword(password);
         }
-        return new LettuceConnectionFactory(config);
+
+        LettuceClientConfigurationBuilder lettuceConfigBuilder = LettuceClientConfiguration.builder()
+                .commandTimeout(Duration.ofMillis(timeout));
+
+        if (sslEnabled) {
+            lettuceConfigBuilder.useSsl()
+                    .disablePeerVerification();
+        }
+
+        return new LettuceConnectionFactory(config, lettuceConfigBuilder.build());
     }
 
     @Bean

--- a/src/test/java/com/example/udtbe/common/config/TestRedisConfig.java
+++ b/src/test/java/com/example/udtbe/common/config/TestRedisConfig.java
@@ -1,0 +1,34 @@
+package com.example.udtbe.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@TestConfiguration
+@Profile("test")
+public class TestRedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/test/java/com/example/udtbe/common/support/ApiSupport.java
+++ b/src/test/java/com/example/udtbe/common/support/ApiSupport.java
@@ -1,5 +1,6 @@
 package com.example.udtbe.common.support;
 
+import com.example.udtbe.common.config.TestRedisConfig;
 import com.example.udtbe.common.fixture.MemberFixture;
 import com.example.udtbe.domain.auth.service.AuthQuery;
 import com.example.udtbe.domain.member.entity.Member;
@@ -17,9 +18,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
+@Import(TestRedisConfig.class)
 @AutoConfigureMockMvc
 public abstract class ApiSupport extends TestContainerSupport {
 


### PR DESCRIPTION
## 📝 요약(Summary)

- Prod Server Redis Connection Fail로 인한 Redis Config 수정
  - SSL, TimeOut 등 추가
  - TestContainer 환경 유지를 위한 Test용 RedisConfig 추가
  - ApiSupport.class에 Test용 RedisConfig `@Import`를 이용한 주입

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
