### PR TITLE
refator/UDT-152-기존-Error-Log-레벨-다운-및-각종-로그-관련-변경

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/service/ContentQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentQuery.java
@@ -78,7 +78,8 @@ public class ContentQuery {
         return curatedContentRepository.findByMemberIdAndContentId(memberId, contentId);
     }
 
-    public List<CuratedContent> findCuratedContentsByMemberIdAndContentIds(Long memberId, List<Long> contentIds) {
+    public List<CuratedContent> findCuratedContentsByMemberIdAndContentIds(Long memberId,
+            List<Long> contentIds) {
         return curatedContentRepository.findByMemberIdAndContentIdIn(memberId, contentIds);
     }
 

--- a/src/main/java/com/example/udtbe/global/log/ApiTraceAspect.java
+++ b/src/main/java/com/example/udtbe/global/log/ApiTraceAspect.java
@@ -39,7 +39,9 @@ public class ApiTraceAspect {
     public void controllerPointcut() {
     }
 
-    @Pointcut("execution(* com.example.udtbe..service..*(..))")
+    @Pointcut("execution(* com.example.udtbe..service..*(..)) && " +
+            "!within(com.example.udtbe.global.security.service..*) && " +
+            "!within(com.example.udtbe.global.token.service..*)")
     public void servicePointcut() {
     }
 

--- a/src/main/java/com/example/udtbe/global/log/ApiTraceAspect.java
+++ b/src/main/java/com/example/udtbe/global/log/ApiTraceAspect.java
@@ -53,15 +53,16 @@ public class ApiTraceAspect {
     public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
         long start = System.currentTimeMillis();
 
-        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String fullClassName = joinPoint.getSignature().getDeclaringTypeName();
+        String simpleClassName = fullClassName.substring(fullClassName.lastIndexOf('.') + 1);
         String methodName = getMethodName(joinPoint);
-        log.info("[START] {}.{}()", className, methodName);
+        log.info("[START] {}.{}()", simpleClassName, methodName);
         try {
             return joinPoint.proceed();
         } finally {
             long end = System.currentTimeMillis();
             long timeMs = end - start;
-            log.info("[END] {}.{}() ===> {}ms", className, methodName, timeMs);
+            log.info("[END] {}.{}() ===> {}ms", simpleClassName, methodName, timeMs);
         }
     }
 

--- a/src/main/java/com/example/udtbe/global/log/MDCMemberTrace.java
+++ b/src/main/java/com/example/udtbe/global/log/MDCMemberTrace.java
@@ -1,8 +1,6 @@
 package com.example.udtbe.global.log;
 
-import com.example.udtbe.domain.auth.service.AuthQuery;
 import com.example.udtbe.domain.member.entity.Member;
-import com.example.udtbe.global.security.dto.CustomOauth2User;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -10,7 +8,6 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import java.util.Objects;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -20,40 +17,25 @@ import org.springframework.stereotype.Component;
 
 @Order(Ordered.LOWEST_PRECEDENCE)
 @Component
-@RequiredArgsConstructor
 class MDCMemberTrace implements Filter {
-
-    private final AuthQuery authQuery;
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
         try {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (Objects.nonNull(authentication) && authentication.isAuthenticated()) {
-                Object principal = authentication.getPrincipal();
-                Long memberId = null;
-
-                if (principal instanceof Member member) {
-                    memberId = member.getId();
-                } else if (principal instanceof CustomOauth2User oauth2User) {
-                    try {
-                        String email = oauth2User.getEmail();
-                        Member member = authQuery.getMemberByEmail(email);
-                        memberId = member.getId();
-                    } catch (Exception e) {
-                        // OAuth2 사용자 조회 실패 시 로그만 남기고 계속 진행
-                        // 로깅을 위한 필터이므로 예외가 발생해도 요청 처리를 중단하지 않음
-                    }
-                }
-
-                if (memberId != null) {
-                    MDC.put("memberId", String.valueOf(memberId));
-                }
-            }
+            putMemberIdToMDC(authentication);
             chain.doFilter(request, response);
         } finally {
             MDC.clear();
+        }
+    }
+
+    private static void putMemberIdToMDC(Authentication authentication) {
+        if (Objects.nonNull(authentication) && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof Member member) {
+            Long memberId = member.getId();
+            MDC.put("memberId", String.valueOf(memberId));
         }
     }
 }

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomAccessDeniedHandler.java
@@ -31,28 +31,27 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             AccessDeniedException accessDeniedException) throws IOException {
         // 현재 인증된 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        log.error(authentication.getName());
         // 사용자 권한에 따라 다른 응답 제공
         if (!Objects.isNull(accessDeniedException)) {
             if (!matchAuthenticationFromRole(authentication, ROLE_USER)) {
                 // ROLE_USER 권한이 없는 경우
-                log.info(SecurityErrorCode.FORBIDDEN_USER.getMessage());
+                log.warn(SecurityErrorCode.FORBIDDEN_USER.getMessage());
                 setUpResponse(response, SecurityErrorCode.FORBIDDEN_USER);
             } else if (!matchAuthenticationFromRole(authentication, ROLE_GUEST)) {
                 // ROLE_GUEST 권한이 없는 경우
-                log.info(SecurityErrorCode.FORBIDDEN_GUEST.getMessage());
+                log.warn(SecurityErrorCode.FORBIDDEN_GUEST.getMessage());
                 setUpResponse(response, SecurityErrorCode.FORBIDDEN_GUEST);
             } else if (!matchAuthenticationFromRole(authentication, ROLE_ADMIN)) {
                 // ROLE_GUEST 권한이 없는 경우
-                log.info(SecurityErrorCode.FORBIDDEN_GUEST.getMessage());
+                log.warn(SecurityErrorCode.FORBIDDEN_GUEST.getMessage());
                 setUpResponse(response, SecurityErrorCode.FORBIDDEN_ADMIN);
             } else {
                 // 기타 권한이 없는 경우
-                log.info(SecurityErrorCode.FORBIDDEN_MISMATCH.getMessage());
+                log.warn(SecurityErrorCode.FORBIDDEN_MISMATCH.getMessage());
                 setUpResponse(response, SecurityErrorCode.FORBIDDEN_MISMATCH);
             }
         } else {
-            log.info(SecurityErrorCode.FORBIDDEN_MISMATCH.getMessage());
+            log.warn(SecurityErrorCode.FORBIDDEN_MISMATCH.getMessage());
             setUpResponse(response, SecurityErrorCode.FORBIDDEN_MISMATCH);
         }
     }

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -21,7 +21,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException {
 
-        log.error("비인가 사용자 요청 -> 예외 발생 : {}", authException.getMessage());
+        log.warn("비인가 사용자 요청 -> 예외 발생 : {}", authException.getMessage());
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
         response.setContentType("application/json");

--- a/src/main/java/com/example/udtbe/global/security/handler/CustomOauth2FailureHandler.java
+++ b/src/main/java/com/example/udtbe/global/security/handler/CustomOauth2FailureHandler.java
@@ -15,7 +15,7 @@ public class CustomOauth2FailureHandler implements AuthenticationFailureHandler 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException exception) throws IOException {
-        log.error("소셜 로그인 실패", exception);
+        log.warn("소셜 로그인 실패", exception);
         response.sendError(HttpServletResponse.SC_BAD_REQUEST, "소셜 로그인에 실패하였습니다.");
     }
 }

--- a/src/main/java/com/example/udtbe/global/token/filter/TokenExceptionFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenExceptionFilter.java
@@ -25,14 +25,7 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (Exception e) {
 
-            log.error("JWT 검증 실패로 인한 예외 발생 : {}", e.getMessage());
-            log.error("Exception type: {}", e.getClass().getName());
-            log.error("Stack trace: ", e);  // 전체 스택트레이스 출력
-
-            // 원인이 ClassCastException인지 확인
-            if (e instanceof ClassCastException) {
-                log.error("ClassCastException 발생!");
-            }
+            log.warn("JWT 검증 실패로 인한 예외 발생 : {}", e.getMessage());
 
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);  // 401 Unauthorized
             response.setContentType("application/json");

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -84,7 +84,7 @@
       </filter>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
       <appender-ref ref="Console"/>
       <appender-ref ref="InfoFile"/>
       <appender-ref ref="WarnFile"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,12 +5,12 @@
   <springProperty name="LOG_PATH" source="LOG_PATH" defaultValue="./logs"/>
   <property name="MDC_PATTERN"
     value="%X{requestId:-N/A} | %X{memberId:-anonymous} | %X{status:-} | %X{errorCode:-}"/>
-  <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} | ${MDC_PATTERN} - %msg%n
+  <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} | ${MDC_PATTERN} - %msg%n
   </pattern>
   <property name="CONSOLE_LOG_PATTERN"
     value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
   <property name="LOG_FILE_PATTERN"
-    value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} | ${MDC_PATTERN} - %msg%n"/>
+    value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %class{1} | ${MDC_PATTERN} - %msg%n"/>
 
   <!-- ============ [local, dev] 프로파일용 ============ -->
   <springProfile name="local,dev">
@@ -21,7 +21,12 @@
         <fileNamePattern>${LOG_PATH}/json.%d{yyyy-MM-dd}.log</fileNamePattern>
         <maxHistory>14</maxHistory>
       </rollingPolicy>
-      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <includeMdcKeyName>requestId</includeMdcKeyName>
+        <includeMdcKeyName>memberId</includeMdcKeyName>
+        <includeMdcKeyName>status</includeMdcKeyName>
+        <includeMdcKeyName>errorCode</includeMdcKeyName>
+      </encoder>
     </appender>
 
     <!-- 콘솔 로그 -->
@@ -115,7 +120,12 @@
         <fileNamePattern>${LOG_PATH}/json.%d{yyyy-MM-dd}.log</fileNamePattern>
         <maxHistory>30</maxHistory>
       </rollingPolicy>
-      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <includeMdcKeyName>requestId</includeMdcKeyName>
+        <includeMdcKeyName>memberId</includeMdcKeyName>
+        <includeMdcKeyName>status</includeMdcKeyName>
+        <includeMdcKeyName>errorCode</includeMdcKeyName>
+      </encoder>
     </appender>
 
     <appender name="InfoFile" class="ch.qos.logback.core.rolling.RollingFileAppender">


### PR DESCRIPTION
## 📝 요약(Summary)

### 애플리케이션
- Log Level 변경
  - Security 관련 Slf4j Level `error` -> `warn`으로 변경  * 과도한 error 로그로 모니터링 어려움
- MDCMemberTrace 리팩토링
  - Anonymous 인증 객체 CastClassException으로 인해 변경된 구조 리팩토링
- Logback-spring.xml
  - 로그 형식 변경
  - Local, Dev 환경 Root Level Debug -> INFO 변경  * 시각적 어령무
- AOP Log
  - Class Name 간소화(패키지 구조 제거)
  - Security 관련 Service 클래스 servicePointcut 제외

### 인프라
- FileBeat
  - Log 라인 단위 설정
  - 30초 마다 전송되도록 설정

## 📸스크린샷 (선택)

<img width="218" height="87" alt="image" src="https://github.com/user-attachments/assets/d4f57e26-9a40-4697-ad4c-ece13e89da5c" />

- 인프라 FileBeat 적용

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분
