### PR TITLE
fix/UDT-157-token-filter-blacklist-verify-bug

### DIFF
--- a/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
@@ -54,10 +54,11 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         String accessToken = cookieUtil.getCookieValue(request);
 
         if (tokenProvider.validateToken(accessToken, new Date())) {
-            // accessToken logout 여부 확인
             if (tokenProvider.verifyBlackList(accessToken)) {
-                saveAuthentication(accessToken);
+                filterChain.doFilter(request, response);
             }
+
+            saveAuthentication(accessToken);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
+++ b/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
@@ -36,7 +36,7 @@ import org.springframework.util.StringUtils;
 public class TokenProvider {
 
     private static final String ROLE_KEY = "ROLE";
-    private static final String[] BLACKLIST = new String[]{"false", "delete"};
+    private static final String[] BLACKLIST = new String[]{"black_list_token"};
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 90L;
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L;
 

--- a/src/test/java/com/example/udtbe/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/udtbe/auth/service/AuthServiceTest.java
@@ -80,8 +80,7 @@ class AuthServiceTest {
         given(tokenProvider.validateToken(anyString(), any(Date.class))).willReturn(true);
         given(tokenProvider.getAuthentication(anyString())).willReturn(authentication);
         given(tokenProvider.getExpiration(anyString(), any(Date.class))).willReturn(fiveMinutes);
-        given(redisUtil.getValues(anyString())).willReturn("refresh");
-        given(redisUtil.getValues(anyString())).willReturn("delete");
+        given(redisUtil.getValues(anyString())).willReturn("black_list_token");
 
         willDoNothing().given(redisUtil).setValues(anyString(), anyString(), any(Duration.class));
 


### PR DESCRIPTION
## 📝 요약(Summary)

- 로그아웃 블랙리스트 검증 실패
  - Token Filter 내부 블랙리스트 검증 후 블랙리스트라면 인증 객체 저장 하도록 하는 로직 수정
- 로그아웃 시 AT 블랙리스트 Key 값 변경 및 간단한 리팩토링

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
