### PR TITLE
Feat/udt 158 추천캐시 관리전략 개선

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
@@ -5,10 +5,8 @@ import com.example.udtbe.domain.content.dto.response.ContentRecommendationRespon
 import com.example.udtbe.domain.content.service.ContentRecommendationService;
 import com.example.udtbe.domain.content.service.ContentService;
 import com.example.udtbe.domain.member.entity.Member;
-import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.apache.lucene.queryparser.classic.ParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,7 +23,7 @@ public class RecommendContentController implements RecommendContentControllerApi
     @Override
     public ResponseEntity<List<ContentRecommendationResponse>> getRecommendations(
             @AuthenticationPrincipal Member member,
-            @RequestParam(defaultValue = "10") int limit) throws IOException, ParseException {
+            @RequestParam(defaultValue = "10") int limit) {
         List<ContentRecommendationResponse> recommendations = contentRecommendationService.recommendContents(
                 member,
                 limit);
@@ -35,7 +33,7 @@ public class RecommendContentController implements RecommendContentControllerApi
     @Override
     public ResponseEntity<List<ContentRecommendationResponse>> getCurated(
             @AuthenticationPrincipal Member member,
-            @RequestParam(defaultValue = "6") int limit) throws IOException, ParseException {
+            @RequestParam(defaultValue = "6") int limit) {
         List<ContentRecommendationResponse> recommendations = contentRecommendationService.recommendCuratedContents(
                 member, limit);
         return ResponseEntity.ok(recommendations);

--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentController.java
@@ -5,8 +5,10 @@ import com.example.udtbe.domain.content.dto.response.ContentRecommendationRespon
 import com.example.udtbe.domain.content.service.ContentRecommendationService;
 import com.example.udtbe.domain.content.service.ContentService;
 import com.example.udtbe.domain.member.entity.Member;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.apache.lucene.queryparser.classic.ParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,21 +25,19 @@ public class RecommendContentController implements RecommendContentControllerApi
     @Override
     public ResponseEntity<List<ContentRecommendationResponse>> getRecommendations(
             @AuthenticationPrincipal Member member,
-            @RequestParam(defaultValue = "10") int limit) {
+            @RequestParam(defaultValue = "10") int limit) throws IOException, ParseException {
         List<ContentRecommendationResponse> recommendations = contentRecommendationService.recommendContents(
                 member,
                 limit);
-
         return ResponseEntity.ok(recommendations);
     }
 
     @Override
     public ResponseEntity<List<ContentRecommendationResponse>> getCurated(
             @AuthenticationPrincipal Member member,
-            @RequestParam(defaultValue = "6") int limit) {
+            @RequestParam(defaultValue = "6") int limit) throws IOException, ParseException {
         List<ContentRecommendationResponse> recommendations = contentRecommendationService.recommendCuratedContents(
                 member, limit);
-
         return ResponseEntity.ok(recommendations);
     }
 

--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
@@ -8,9 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.io.IOException;
 import java.util.List;
-import org.apache.lucene.queryparser.classic.ParseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +41,7 @@ public interface RecommendContentControllerApiSpec {
                     example = "10"
             )
             @RequestParam(defaultValue = "10") int limit
-    ) throws IOException, ParseException;
+    );
 
     @Operation(
             summary = "엄선된 콘텐츠 추천 API",
@@ -64,7 +62,7 @@ public interface RecommendContentControllerApiSpec {
                     example = "6"
             )
             @RequestParam(defaultValue = "6") int limit
-    ) throws IOException, ParseException;
+    );
 
     @Operation(summary = "엄선된 콘텐츠 저장 API", description = "엄선된 콘텐츠들을 저장한다.")
     @ApiResponse(useReturnTypeSchema = true)

--- a/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/RecommendContentControllerApiSpec.java
@@ -8,7 +8,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import java.util.List;
+import org.apache.lucene.queryparser.classic.ParseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,7 +43,7 @@ public interface RecommendContentControllerApiSpec {
                     example = "10"
             )
             @RequestParam(defaultValue = "10") int limit
-    );
+    ) throws IOException, ParseException;
 
     @Operation(
             summary = "엄선된 콘텐츠 추천 API",
@@ -62,7 +64,7 @@ public interface RecommendContentControllerApiSpec {
                     example = "6"
             )
             @RequestParam(defaultValue = "6") int limit
-    );
+    ) throws IOException, ParseException;
 
     @Operation(summary = "엄선된 콘텐츠 저장 API", description = "엄선된 콘텐츠들을 저장한다.")
     @ApiResponse(useReturnTypeSchema = true)

--- a/src/main/java/com/example/udtbe/domain/content/dto/ContentRecommendationMapper.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/ContentRecommendationMapper.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.PRIVATE;
 import com.example.udtbe.domain.content.dto.response.ContentRecommendationResponse;
 import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.ContentPlatform;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,11 @@ public class ContentRecommendationMapper {
                         : Collections.emptyList(),
                 metadata.getCastTag() != null ? metadata.getCastTag() : Collections.emptyList(),
                 metadata.getPlatformTag() != null ? metadata.getPlatformTag()
-                        : Collections.emptyList()
+                        : Collections.emptyList(),
+                content.getContentPlatforms() != null ? content.getContentPlatforms().stream()
+                        .map(ContentPlatform::getWatchUrl)
+                        .filter(Objects::nonNull)
+                        .toList() : Collections.emptyList()
         );
     }
 
@@ -76,7 +81,11 @@ public class ContentRecommendationMapper {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
-                Collections.emptyList()
+                Collections.emptyList(),
+                content.getContentPlatforms() != null ? content.getContentPlatforms().stream()
+                        .map(contentPlatform -> contentPlatform.getWatchUrl())
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()) : Collections.emptyList()
         );
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/response/ContentRecommendationResponse.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/response/ContentRecommendationResponse.java
@@ -16,7 +16,8 @@ public record ContentRecommendationResponse(
         List<String> genres,
         List<String> directors,
         List<String> casts,
-        List<String> platforms
+        List<String> platforms,
+        List<String> watchUrls
 ) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/content/exception/RecommendContentErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/content/exception/RecommendContentErrorCode.java
@@ -17,6 +17,10 @@ public enum RecommendContentErrorCode implements ErrorCode {
     POPULAR_CONTENT_RETRIEVAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "인기 콘텐츠 조회에 실패했습니다."),
     INVALID_LIMIT_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 limit 파라미터입니다."),
     RECOMMENDATION_GENERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "추천 생성에 실패했습니다."),
+    CACHE_ACCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "캐시 접근에 실패했습니다."),
+    LUCENE_INDEX_NOT_BUILT(HttpStatus.INTERNAL_SERVER_ERROR, "검색 인덱스가 구축되지 않았습니다."),
+    LUCENE_SEARCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "검색 실행에 실패했습니다."),
+    DATABASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 연결에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/udtbe/domain/content/exception/RecommendContentErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/content/exception/RecommendContentErrorCode.java
@@ -21,6 +21,8 @@ public enum RecommendContentErrorCode implements ErrorCode {
     LUCENE_INDEX_NOT_BUILT(HttpStatus.INTERNAL_SERVER_ERROR, "검색 인덱스가 구축되지 않았습니다."),
     LUCENE_SEARCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "검색 실행에 실패했습니다."),
     DATABASE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 연결에 실패했습니다."),
+    LUCENE_SEARCH_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Lucene 검색 중 입출력 오류가 발생했습니다."),
+    LUCENE_SEARCH_PARSE_ERROR(HttpStatus.BAD_REQUEST, "Lucene 검색 쿼리 파싱에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationQuery.java
@@ -48,8 +48,11 @@ public class ContentRecommendationQuery {
                             metadata -> metadata.getContent().getId(),
                             metadata -> metadata
                     ));
+        } catch (OutOfMemoryError e) {
+            log.error("!!!메모리 부족으로 ContentMetadata 캐시 생성 실패 - OOM!!! ", e);
+            throw new RestApiException(RecommendContentErrorCode.CONTENT_METADATA_CACHE_ERROR);
         } catch (Exception e) {
-            log.error("ContentMetadata 캐시 생성 실패: {}", e.getMessage(), e);
+            log.warn("ContentMetadata 캐시 생성 실패: {}", e.getMessage(), e);
             throw new RestApiException(RecommendContentErrorCode.CONTENT_METADATA_CACHE_ERROR);
         }
     }
@@ -61,7 +64,7 @@ public class ContentRecommendationQuery {
         try {
             return feedbackRepository.findByMemberIdAndIsDeletedFalse(memberId);
         } catch (Exception e) {
-            log.error("피드백 조회 실패: memberId={}, error={}", memberId, e.getMessage(), e);
+            log.warn("피드백 조회 실패: memberId={}, error={}", memberId, e.getMessage(), e);
             throw new RestApiException(RecommendContentErrorCode.FEEDBACK_RETRIEVAL_ERROR);
         }
     }
@@ -76,39 +79,8 @@ public class ContentRecommendationQuery {
         try {
             return contentRepository.findAllById(contentIds);
         } catch (Exception e) {
-            log.error("컨텐츠 조회 실패: error={}", e.getMessage(), e);
+            log.warn("컨텐츠 조회 실패: error={}", e.getMessage(), e);
             throw new RestApiException(RecommendContentErrorCode.CONTENT_BATCH_RETRIEVAL_ERROR);
-        }
-    }
-
-    /**
-     * 인기 컨텐츠 메타데이터 조회 (최신순)
-     */
-    public List<ContentMetadata> findPopularContentMetadata(int limit) {
-        if (limit <= 0) {
-            throw new RestApiException(RecommendContentErrorCode.INVALID_LIMIT_PARAMETER);
-        }
-        try {
-            return contentMetadataRepository.findByIsDeletedFalse()
-                    .stream()
-                    .sorted((m1, m2) -> m2.getCreatedAt().compareTo(m1.getCreatedAt()))
-                    .limit(limit)
-                    .toList();
-        } catch (Exception e) {
-            log.error("인기 컨텐츠 메타데이터 조회 실패: error={}", e.getMessage(), e);
-            throw new RestApiException(RecommendContentErrorCode.POPULAR_CONTENT_RETRIEVAL_ERROR);
-        }
-    }
-
-    /**
-     * 삭제되지 않은 모든 ContentMetadata 조회
-     */
-    public List<ContentMetadata> findAllContentMetadata() {
-        try {
-            return contentMetadataRepository.findByIsDeletedFalse();
-        } catch (Exception e) {
-            log.error("모든 ContentMetadata 조회 실패: error={}", e.getMessage(), e);
-            throw new RestApiException(RecommendContentErrorCode.CONTENT_METADATA_CACHE_ERROR);
         }
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationQuery.java
@@ -49,10 +49,10 @@ public class ContentRecommendationQuery {
                             metadata -> metadata
                     ));
         } catch (OutOfMemoryError e) {
-            log.error("!!!메모리 부족으로 ContentMetadata 캐시 생성 실패 - OOM!!! ", e);
+            log.error("!!!메모리 부족으로 ContentMetadata 캐시 생성 실패 - OOM!!! \n {}", e.getMessage());
             throw new RestApiException(RecommendContentErrorCode.CONTENT_METADATA_CACHE_ERROR);
         } catch (Exception e) {
-            log.warn("ContentMetadata 캐시 생성 실패: {}", e.getMessage(), e);
+            log.warn("ContentMetadata 캐시 생성 실패: {}", e.getMessage());
             throw new RestApiException(RecommendContentErrorCode.CONTENT_METADATA_CACHE_ERROR);
         }
     }
@@ -64,7 +64,7 @@ public class ContentRecommendationQuery {
         try {
             return feedbackRepository.findByMemberIdAndIsDeletedFalse(memberId);
         } catch (Exception e) {
-            log.warn("피드백 조회 실패: memberId={}, error={}", memberId, e.getMessage(), e);
+            log.warn("피드백 조회 실패: memberId={}, error={}", memberId, e.getMessage());
             throw new RestApiException(RecommendContentErrorCode.FEEDBACK_RETRIEVAL_ERROR);
         }
     }
@@ -79,7 +79,7 @@ public class ContentRecommendationQuery {
         try {
             return contentRepository.findAllById(contentIds);
         } catch (Exception e) {
-            log.warn("컨텐츠 조회 실패: error={}", e.getMessage(), e);
+            log.warn("컨텐츠 조회 실패: error={}", e.getMessage());
             throw new RestApiException(RecommendContentErrorCode.CONTENT_BATCH_RETRIEVAL_ERROR);
         }
     }

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
@@ -2,7 +2,9 @@ package com.example.udtbe.domain.content.service;
 
 import com.example.udtbe.domain.content.entity.ContentMetadata;
 import com.example.udtbe.domain.content.event.IndexRebuildCompleteEvent;
+import com.example.udtbe.domain.content.exception.RecommendContentErrorCode;
 import com.example.udtbe.domain.content.repository.ContentMetadataRepository;
+import com.example.udtbe.global.exception.RestApiException;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +52,7 @@ public class LuceneIndexService {
             eventPublisher.publishEvent(
                     IndexRebuildCompleteEvent.of(this, successCount, buildTime));
         } catch (Exception e) {
-            log.error("Lucene 인덱스 빌드 실패", e);
+            throw new RestApiException(RecommendContentErrorCode.LUCENE_INDEX_NOT_BUILT);
         }
     }
 

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
@@ -37,6 +37,13 @@ public class LuceneSearchService {
                     analyzer);
 
             return searcher.search(query, limit * 10);
+        } catch (IOException e) {
+            log.error("Lucene 검색 실행 중 파일 시스템 오류: platformIds={}, genres={}, error={}", 
+                     platformFilteredContentIds.size(), userGenres, e.getMessage(), e);
+            throw e;
+        } catch (ParseException e) {
+            log.warn("검색 쿼리 파싱 실패: genres={}, error={}", userGenres, e.getMessage(), e);
+            throw e;
         }
     }
 
@@ -52,6 +59,13 @@ public class LuceneSearchService {
                     feedbackGenres, analyzer);
 
             return searcher.search(query, limit * 2);
+        } catch (IOException e) {
+            log.error("Lucene 엄선된 추천 검색 중 파일 시스템 오류: platformIds={}, feedbackGenres={}, error={}", 
+                     platformFilteredContentIds.size(), feedbackGenres, e.getMessage(), e);
+            throw e;
+        } catch (ParseException e) {
+            log.warn("엄선된 추천 쿼리 파싱 실패: feedbackGenres={}, error={}", feedbackGenres, e.getMessage(), e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/example/udtbe/domain/content/util/MemberRecommendationCache.java
+++ b/src/main/java/com/example/udtbe/domain/content/util/MemberRecommendationCache.java
@@ -30,7 +30,7 @@ public class MemberRecommendationCache {
     }
 
     public boolean shouldRefresh() {
-        return getConsumptionRate() >= 0.7;
+        return getConsumptionRate() >= 0.7 || isExpiredByMinutes(5);
     }
 
     public List<ContentRecommendationDTO> getNext() {
@@ -57,5 +57,9 @@ public class MemberRecommendationCache {
 
     public boolean isExpired(int hoursToExpire) {
         return createdAt.plusHours(hoursToExpire).isBefore(LocalDateTime.now());
+    }
+
+    public boolean isExpiredByMinutes(int minutesToExpire) {
+        return createdAt.plusMinutes(minutesToExpire).isBefore(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/util/RecommendationCacheManager.java
+++ b/src/main/java/com/example/udtbe/domain/content/util/RecommendationCacheManager.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 public class RecommendationCacheManager {
 
     private final ConcurrentHashMap<Long, MemberRecommendationCache> memberCaches = new ConcurrentHashMap<>();
-    private static final int EXPIRATION_HOURS = 24;
+    private static final int EXPIRATION_HOURS = 12;
 
     public MemberRecommendationCache getCache(Long memberId) {
         MemberRecommendationCache cache = memberCaches.get(memberId);

--- a/src/main/java/com/example/udtbe/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/udtbe/global/exception/GlobalExceptionHandler.java
@@ -43,6 +43,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(errorCode);
     }
 
+    @ExceptionHandler({java.io.IOException.class})
+    public ResponseEntity<Object> handleIOException(java.io.IOException e) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        putLogContext(errorCode);
+        return handleExceptionInternal(errorCode, " - 검색 엔진 접근 중 오류가 발생했습니다.");
+    }
+
+    @ExceptionHandler({org.apache.lucene.queryparser.classic.ParseException.class})
+    public ResponseEntity<Object> handleParseException(
+            org.apache.lucene.queryparser.classic.ParseException e) {
+        ErrorCode errorCode = INVALID_PARAMETER;
+        putLogContext(errorCode);
+        return handleExceptionInternal(errorCode, " - 검색 조건 처리 중 오류가 발생했습니다.");
+    }
+
     @ExceptionHandler({Exception.class})
     public ResponseEntity<Object> handleAllException(Exception ex) {
         ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -26,6 +26,7 @@ import com.example.udtbe.domain.content.util.RecommendationCacheManager;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.entity.enums.Role;
 import com.example.udtbe.domain.survey.entity.Survey;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
@@ -92,7 +94,7 @@ class ContentRecommendationServiceTest {
 
     @Test
     @DisplayName("캐시 히트 - 기존 캐시에서 다음 배치 반환")
-    void shouldReturnCachedRecommendations_WhenCacheHit() {
+    void shouldReturnCachedRecommendations_WhenCacheHit() throws IOException, ParseException {
         // given - 유효한 캐시 존재
         List<ContentRecommendationDTO> cachedRecommendations = List.of(
                 new ContentRecommendationDTO(1L, 5.0f),


### PR DESCRIPTION
## 📝 요약
UDT-158 추천 알고리즘 개선 작업:
- 콘텐츠 시청 링크(`watchUrl`) 추가
- 에러 및 경고 로그 최적화
- 캐시 5분 단위 갱신
- 최신 20개 피드백 기반 콘텐츠 추천 개선
- `IOException`, `ParseException` 처리 추가
- Lucene 검색 및 캐시 관리 최적화

## 📸 스크린샷 (선택)
(코드 변경만 있으므로 생략)

## 💬 리뷰어에게
- **추천 API**: `RecommendContentController`에서 `IOException`, `ParseException` 처리 추가
- **watchUrl**: `ContentRecommendationResponse`에 시청 링크 추가로 UX 개선
- **캐시**: 만료 시간 24시간 → 12시간, 5분 단위 갱신 추가
- **피드백**: 최신 20개 피드백으로 장르 선호도 계산
- **에러**: `GlobalExceptionHandler`에 검색 예외 처리 추가, 로그 `error` → `warn` 변경
- **테스트**: 캐시 히트 테스트에 예외 처리 검증 추가

**리뷰 포인트**:
- `watchUrls`로 응답 크기 증가, 성능 확인 필요
- **피드백**: 최신 20개 피드백으로 장르 선호도 계산
- 5분 캐시 갱신 주기 적절성 검토
- Lucene 예외 처리 로직 점검

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 완료

## 🤔 예상 리뷰 시간
10분
