### PR TITLE
feat/UDT-161-온보딩-유저-확인용-헤더-추가

### DIFF
--- a/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/example/udtbe/domain/survey/service/SurveyService.java
@@ -46,5 +46,8 @@ public class SurveyService {
         authQuery.save(member);
 
         cookieUtil.deleteCookie(response);
+
+        response.setHeader("Access-Control-Expose-Headers", "X-New-User");
+        response.setHeader("X-New-User", "true");
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

- 신규 회원 설문조사 완료 후 온보딩 페이지 이동을 위해서, 설문조사 저장 성공 후 신규 회원임을 나타내는 커스텀 헤더 추가

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
