### PR TITLE
Feat/udt 166 추천 알고리즘 설문조사 콘텐츠 반영

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -133,7 +133,8 @@ public class ContentRecommendationService {
         List<ContentRecommendationDTO> recommendations = processLuceneScoring(
                 topDocs, koreanMemberGenres, null, member, metadataCache, false, contentTag);
 
-        return buildRegularRecommendationResponse(recommendations, limit, metadataCache, member.getId());
+        return buildRegularRecommendationResponse(recommendations, limit, metadataCache,
+                member.getId());
     }
 
     private List<ContentRecommendationDTO> processLuceneScoring(
@@ -197,9 +198,9 @@ public class ContentRecommendationService {
                 .collect(Collectors.toList());
 
         if (preferredGenres.isEmpty()) {
-            List<Feedback> allFeedbacks = contentRecommendationQuery.findFeedbacksByMemberId(
+            List<Feedback> feedbacks = contentRecommendationQuery.findFeedbacksByMemberId(
                     member.getId());
-            preferredGenres = extractFallbackGenresFromRecentLikes(allFeedbacks, metadataCache);
+            preferredGenres = extractFallbackGenresFromRecentLikes(feedbacks, metadataCache);
             log.info("선호 장르가 없어 최근 좋아요 기반 장르 사용: {}", preferredGenres);
         } else {
             log.info("추출된 선호 장르: {}", preferredGenres);
@@ -325,9 +326,9 @@ public class ContentRecommendationService {
         }
 
         List<Feedback> targetFeedbacks;
-        targetFeedbacks = recentFeedbackLimit.map(integer -> feedbacks.stream()
+        targetFeedbacks = recentFeedbackLimit.map(limit -> feedbacks.stream()
                 .sorted((f1, f2) -> f2.getUpdatedAt().compareTo(f1.getUpdatedAt()))
-                .limit(integer)
+                .limit(limit)
                 .toList()).orElse(feedbacks);
 
         for (Feedback feedback : targetFeedbacks) {
@@ -358,9 +359,9 @@ public class ContentRecommendationService {
     }
 
 
-    private List<String> extractFallbackGenresFromRecentLikes(List<Feedback> allFeedbacks,
+    private List<String> extractFallbackGenresFromRecentLikes(List<Feedback> feedbacks,
             Map<Long, ContentMetadata> metadataCache) {
-        return allFeedbacks.stream()
+        return feedbacks.stream()
                 .filter(f -> !f.isDeleted() && f.getFeedbackType() == FeedbackType.LIKE)
                 .sorted((f1, f2) -> f2.getCreatedAt().compareTo(f1.getCreatedAt()))
                 .limit(20)

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -37,6 +37,7 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -224,7 +225,7 @@ public class ContentRecommendationService {
 
         Set<Long> contentIds = new HashSet<>();
         for (String koreanPlatformTag : koreanPlatformTags) {
-            if (koreanPlatformTag != null && !koreanPlatformTag.trim().isEmpty()) {
+            if (StringUtils.hasText(koreanPlatformTag)) {
                 for (Map.Entry<Long, ContentMetadata> entry : metadataCache.entrySet()) {
                     ContentMetadata metadata = entry.getValue();
                     if (metadata.getPlatformTag() != null &&
@@ -245,7 +246,7 @@ public class ContentRecommendationService {
 
         float boost = 0.0f;
         for (String memberGenre : memberGenres) {
-            if (memberGenre != null && !memberGenre.trim().isEmpty()) {
+            if (StringUtils.hasText(memberGenre)) {
                 String targetGenre = memberGenre.trim();
                 if (docGenres.contains(targetGenre)) {
                     boost += 1.0f;
@@ -293,7 +294,7 @@ public class ContentRecommendationService {
             ContentMetadata metadata = metadataCache.get(contentId);
             if (metadata != null && metadata.getGenreTag() != null) {
                 for (String genre : metadata.getGenreTag()) {
-                    if (genre != null && !genre.trim().isEmpty()) {
+                    if (StringUtils.hasText(genre)) {
                         genre = genre.trim();
                         genreScores.put(genre, genreScores.getOrDefault(genre, 0.0f) + 1.0f);
                     }
@@ -344,7 +345,7 @@ public class ContentRecommendationService {
                     };
 
                     for (String genre : metadata.getGenreTag()) {
-                        if (genre != null && !genre.trim().isEmpty()) {
+                        if (StringUtils.hasText(genre)) {
                             genre = genre.trim();
                             float oldScore = genreScores.getOrDefault(genre, 0.0f);
                             float newScore = oldScore + score;

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -17,6 +17,7 @@ import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.global.exception.RestApiException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -67,8 +68,8 @@ public class ContentRecommendationService {
                 }
             }
 
-            Survey userSurvey = contentRecommendationQuery.findSurveyByMemberId(member.getId());
-            return executeRecommendationSearch(userSurvey, member, limit, isCurated);
+            Survey memberSurvey = contentRecommendationQuery.findSurveyByMemberId(member.getId());
+            return executeRecommendationSearch(memberSurvey, member, limit, isCurated);
         } catch (IOException e) {
             throw new RestApiException(RecommendContentErrorCode.LUCENE_SEARCH_IO_ERROR);
         } catch (ParseException e) {
@@ -77,36 +78,36 @@ public class ContentRecommendationService {
     }
 
     private List<ContentRecommendationResponse> executeRecommendationSearch(
-            Survey userSurvey, Member member, int limit, boolean isCurated)
+            Survey memberSurvey, Member member, int limit, boolean isCurated)
             throws IOException, ParseException {
 
         // TODO: 모든 ContentMetadata 한 번에 조회하여 캐시 생성 , 추후 메모리 분석 및 성능 개선의 여지가 농후
         Map<Long, ContentMetadata> metadataCache = contentRecommendationQuery.findContentMetadataCache();
         List<Long> platformFilteredContentIds = getPlatformFilteredContentIds(
-                userSurvey.getPlatformTag(), metadataCache);
+                memberSurvey.getPlatformTag(), metadataCache);
 
         if (isCurated) {
-            return executeCuratedRecommendation(userSurvey, member, limit, metadataCache,
+            return executeCuratedRecommendation(memberSurvey, member, limit, metadataCache,
                     platformFilteredContentIds);
         }
 
-        return executeRegularRecommendation(userSurvey, member, limit, metadataCache,
+        return executeRegularRecommendation(memberSurvey, member, limit, metadataCache,
                 platformFilteredContentIds);
     }
 
     private List<ContentRecommendationResponse> executeCuratedRecommendation(
-            Survey userSurvey, Member member, int limit,
+            Survey memberSurvey, Member member, int limit,
             Map<Long, ContentMetadata> metadataCache, List<Long> platformFilteredContentIds)
             throws IOException, ParseException {
 
         List<String> feedbackBasedGenres = extractPreferredGenresFromFeedback(member,
                 metadataCache);
-        List<String> surveyGenres = GenreType.toKoreanTypes(userSurvey.getGenreTag());
+        List<String> surveyGenres = GenreType.toKoreanTypes(memberSurvey.getGenreTag());
         TopDocs topDocs = luceneSearchService.searchCuratedRecommendations(
                 platformFilteredContentIds, feedbackBasedGenres, limit);
 
         List<ContentRecommendationDTO> recommendations = processLuceneScoring(
-                topDocs, feedbackBasedGenres, surveyGenres, member, metadataCache, true);
+                topDocs, feedbackBasedGenres, surveyGenres, member, metadataCache, true, null);
 
         List<ContentRecommendationDTO> sortedRecommendations = recommendations.stream()
                 .sorted((r1, r2) -> Float.compare(r2.score(), r1.score()))
@@ -117,17 +118,20 @@ public class ContentRecommendationService {
     }
 
     private List<ContentRecommendationResponse> executeRegularRecommendation(
-            Survey userSurvey, Member member, int limit,
+            Survey memberSurvey, Member member, int limit,
             Map<Long, ContentMetadata> metadataCache, List<Long> platformFilteredContentIds)
             throws IOException, ParseException {
 
-        List<String> englishUserGenres = userSurvey.getGenreTag();
-        List<String> koreanUserGenres = GenreType.toKoreanTypes(englishUserGenres);
+        List<String> englishMemberGenres = memberSurvey.getGenreTag();
+        List<String> koreanMemberGenres = GenreType.toKoreanTypes(englishMemberGenres);
+        List<Long> contentTag = memberSurvey.getContentTag().stream()
+                .map(Long::valueOf)
+                .toList();
         TopDocs topDocs = luceneSearchService.searchRecommendations(platformFilteredContentIds,
-                koreanUserGenres, limit);
+                koreanMemberGenres, limit);
 
         List<ContentRecommendationDTO> recommendations = processLuceneScoring(
-                topDocs, koreanUserGenres, null, member, metadataCache, false);
+                topDocs, koreanMemberGenres, null, member, metadataCache, false, contentTag);
 
         return buildFinalResponse(recommendations, limit, metadataCache, member.getId(),
                 false);
@@ -135,7 +139,8 @@ public class ContentRecommendationService {
 
     private List<ContentRecommendationDTO> processLuceneScoring(
             TopDocs topDocs, List<String> primaryGenres, List<String> secondaryGenres,
-            Member member, Map<Long, ContentMetadata> metadataCache, boolean isCurated)
+            Member member, Map<Long, ContentMetadata> metadataCache, boolean isCurated,
+            List<Long> contentTagIds)
             throws IOException {
 
         try (DirectoryReader indexReader = luceneIndexService.getIndexReader()) {
@@ -146,23 +151,30 @@ public class ContentRecommendationService {
             Map<String, Float> feedbackScores = calculateGenreFeedbackScores(member, metadataCache,
                     Optional.empty());
 
+            Map<String, Float> contentTagGenreScores = calculateContentTagGenreScores(contentTagIds,
+                    metadataCache);
+
             for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
                 Document doc = searcher.storedFields().document(scoreDoc.doc);
                 Long contentId = Long.valueOf(doc.get("contentId"));
 
+                Set<String> docGenres = parseGenreTags(doc.get("genreTag"));
+
                 float luceneScore = scoreDoc.score * 3.0f;
-                float feedbackScore = calculateGenreFeedbackBoost(doc, feedbackScores);
+                float feedbackScore = calculateGenreFeedbackBoost(docGenres, feedbackScores);
                 float finalScore;
 
                 if (isCurated) {
-                    float feedbackGenreBoost = calculateGenreBoost(doc, primaryGenres);
-                    float surveyGenreBoost = calculateGenreBoost(doc, secondaryGenres);
+                    float feedbackGenreBoost = calculateGenreBoost(docGenres, primaryGenres);
+                    float surveyGenreBoost = calculateGenreBoost(docGenres, secondaryGenres);
                     finalScore =
                             luceneScore + feedbackGenreBoost * 2.0f + surveyGenreBoost
                                     + feedbackScore;
                 } else {
-                    float genreBoost = calculateGenreBoost(doc, primaryGenres);
-                    finalScore = luceneScore + genreBoost * 2.0f + feedbackScore;
+                    float genreBoost = calculateGenreBoost(docGenres, primaryGenres);
+                    float contentTagBoost = calculateContentTagBoost(docGenres,
+                            contentTagGenreScores);
+                    finalScore = luceneScore + genreBoost * 2.0f + feedbackScore + contentTagBoost;
                 }
 
                 recommendations.add(new ContentRecommendationDTO(contentId, finalScore));
@@ -226,44 +238,81 @@ public class ContentRecommendationService {
         return new ArrayList<>(contentIds);
     }
 
-    private float calculateGenreBoost(Document doc, List<String> userGenres) {
-        if (userGenres == null || userGenres.isEmpty()) {
-            return 0.0f;
-        }
-
-        String genreTag = doc.get("genreTag");
-        if (genreTag == null) {
+    private float calculateGenreBoost(Set<String> docGenres, List<String> memberGenres) {
+        if (memberGenres == null || memberGenres.isEmpty() || docGenres.isEmpty()) {
             return 0.0f;
         }
 
         float boost = 0.0f;
-        String[] docGenres = genreTag.split(",");
-        for (String userGenre : userGenres) {
-            if (userGenre != null && !userGenre.trim().isEmpty()) {
-                for (String docGenre : docGenres) {
-                    if (docGenre.trim().equals(userGenre.trim())) {
-                        boost += 1.0f;
-                        break;
-                    }
+        for (String memberGenre : memberGenres) {
+            if (memberGenre != null && !memberGenre.trim().isEmpty()) {
+                String targetGenre = memberGenre.trim();
+                if (docGenres.contains(targetGenre)) {
+                    boost += 1.0f;
                 }
             }
         }
         return boost;
     }
 
-    private float calculateGenreFeedbackBoost(Document doc, Map<String, Float> genreScores) {
-        String docGenreTag = doc.get("genreTag");
-        if (docGenreTag == null) {
+    private float calculateGenreFeedbackBoost(Set<String> docGenres,
+            Map<String, Float> genreScores) {
+        if (docGenres.isEmpty()) {
             return 0.0f;
         }
 
         float boost = 0.0f;
-        String[] docGenres = docGenreTag.split(",");
         for (String genre : docGenres) {
-            genre = genre.trim();
             boost += genreScores.getOrDefault(genre, 0.0f);
         }
         return boost;
+    }
+
+    private float calculateContentTagBoost(Set<String> docGenres,
+            Map<String, Float> contentTagGenreScores) {
+        if (docGenres.isEmpty() || contentTagGenreScores.isEmpty()) {
+            return 0.0f;
+        }
+
+        float boost = 0.0f;
+        for (String docGenre : docGenres) {
+            boost += contentTagGenreScores.getOrDefault(docGenre, 0.0f);
+        }
+        return boost;
+    }
+
+    private Map<String, Float> calculateContentTagGenreScores(List<Long> contentTagIds,
+            Map<Long, ContentMetadata> metadataCache) {
+        Map<String, Float> genreScores = new HashMap<>();
+
+        if (contentTagIds == null || contentTagIds.isEmpty()) {
+            return genreScores;
+        }
+
+        for (Long contentId : contentTagIds) {
+            ContentMetadata metadata = metadataCache.get(contentId);
+            if (metadata != null && metadata.getGenreTag() != null) {
+                for (String genre : metadata.getGenreTag()) {
+                    if (genre != null && !genre.trim().isEmpty()) {
+                        genre = genre.trim();
+                        genreScores.put(genre, genreScores.getOrDefault(genre, 0.0f) + 1.0f);
+                    }
+                }
+            }
+        }
+
+        return genreScores;
+    }
+
+    private Set<String> parseGenreTags(String genreTag) {
+        if (genreTag == null || genreTag.trim().isEmpty()) {
+            return Set.of();
+        }
+
+        return Arrays.stream(genreTag.split(","))
+                .map(String::trim)
+                .filter(genre -> !genre.isEmpty())
+                .collect(Collectors.toSet());
     }
 
     private Map<String, Float> calculateGenreFeedbackScores(Member member,

--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -133,8 +133,7 @@ public class ContentRecommendationService {
         List<ContentRecommendationDTO> recommendations = processLuceneScoring(
                 topDocs, koreanMemberGenres, null, member, metadataCache, false, contentTag);
 
-        return buildFinalResponse(recommendations, limit, metadataCache, member.getId(),
-                false);
+        return buildRegularRecommendationResponse(recommendations, limit, metadataCache, member.getId());
     }
 
     private List<ContentRecommendationDTO> processLuceneScoring(
@@ -388,33 +387,25 @@ public class ContentRecommendationService {
         return buildResponseFromRecommendations(nextBatch, metadataCache);
     }
 
-    private List<ContentRecommendationResponse> buildFinalResponse(
+    private List<ContentRecommendationResponse> buildRegularRecommendationResponse(
             List<ContentRecommendationDTO> recommendations, int limit,
-            Map<Long, ContentMetadata> metadataCache, Long memberId, boolean isCurated) {
+            Map<Long, ContentMetadata> metadataCache, Long memberId) {
 
         List<ContentRecommendationDTO> sortedRecommendations = recommendations.stream()
                 .sorted((r1, r2) -> Float.compare(r2.score(), r1.score()))
                 .toList();
 
-        if (!isCurated) {
-            List<ContentRecommendationDTO> firstBatch = sortedRecommendations.stream()
-                    .limit(limit)
-                    .toList();
-
-            List<ContentRecommendationDTO> remainingRecommendations = sortedRecommendations.stream()
-                    .skip(limit)
-                    .toList();
-
-            cacheManager.putCache(memberId, remainingRecommendations);
-
-            return buildResponseFromRecommendations(firstBatch, metadataCache);
-        }
-
-        List<ContentRecommendationDTO> limitedRecommendations = sortedRecommendations.stream()
+        List<ContentRecommendationDTO> firstBatch = sortedRecommendations.stream()
                 .limit(limit)
                 .toList();
 
-        return buildResponseFromRecommendations(limitedRecommendations, metadataCache);
+        List<ContentRecommendationDTO> remainingRecommendations = sortedRecommendations.stream()
+                .skip(limit)
+                .toList();
+
+        cacheManager.putCache(memberId, remainingRecommendations);
+
+        return buildResponseFromRecommendations(firstBatch, metadataCache);
     }
 
     private List<ContentRecommendationResponse> buildResponseFromRecommendations(

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
@@ -27,22 +27,22 @@ public class LuceneSearchService {
     private final LuceneIndexService luceneIndexService;
 
     public TopDocs searchRecommendations(List<Long> platformFilteredContentIds,
-            List<String> userGenres, int limit) throws IOException, ParseException {
+            List<String> memberGenres, int limit) throws IOException, ParseException {
 
         try (DirectoryReader indexReader = luceneIndexService.getIndexReader()) {
             IndexSearcher searcher = new IndexSearcher(indexReader);
             Analyzer analyzer = luceneIndexService.getAnalyzer();
 
-            BooleanQuery query = buildRecommendationQuery(platformFilteredContentIds, userGenres,
+            BooleanQuery query = buildRecommendationQuery(platformFilteredContentIds, memberGenres,
                     analyzer);
 
             return searcher.search(query, limit * 10);
         } catch (IOException e) {
-            log.error("Lucene 검색 실행 중 파일 시스템 오류: platformIds={}, genres={}, error={}", 
-                     platformFilteredContentIds.size(), userGenres, e.getMessage(), e);
+            log.error("Lucene 검색 실행 중 파일 시스템 오류: platformIds={}, genres={}, error={}",
+                    platformFilteredContentIds.size(), memberGenres, e.getMessage(), e);
             throw e;
         } catch (ParseException e) {
-            log.warn("검색 쿼리 파싱 실패: genres={}, error={}", userGenres, e.getMessage(), e);
+            log.warn("검색 쿼리 파싱 실패: genres={}, error={}", memberGenres, e.getMessage(), e);
             throw e;
         }
     }
@@ -60,11 +60,12 @@ public class LuceneSearchService {
 
             return searcher.search(query, limit * 2);
         } catch (IOException e) {
-            log.error("Lucene 엄선된 추천 검색 중 파일 시스템 오류: platformIds={}, feedbackGenres={}, error={}", 
-                     platformFilteredContentIds.size(), feedbackGenres, e.getMessage(), e);
+            log.error("Lucene 엄선된 추천 검색 중 파일 시스템 오류: platformIds={}, feedbackGenres={}, error={}",
+                    platformFilteredContentIds.size(), feedbackGenres, e.getMessage(), e);
             throw e;
         } catch (ParseException e) {
-            log.warn("엄선된 추천 쿼리 파싱 실패: feedbackGenres={}, error={}", feedbackGenres, e.getMessage(), e);
+            log.warn("엄선된 추천 쿼리 파싱 실패: feedbackGenres={}, error={}", feedbackGenres, e.getMessage(),
+                    e);
             throw e;
         }
     }
@@ -100,7 +101,7 @@ public class LuceneSearchService {
 
     //구독중인 플랫폼의 컨텐츠들, 좋아하는 장르(우선순위)를 기준으로 쿼리를 생성
     private BooleanQuery buildRecommendationQuery(List<Long> platformFilteredContentIds,
-            List<String> userGenres, Analyzer analyzer) throws ParseException {
+            List<String> memberGenres, Analyzer analyzer) throws ParseException {
 
         Builder mainQueryBuilder = new Builder();
 
@@ -111,11 +112,11 @@ public class LuceneSearchService {
         }
         mainQueryBuilder.add(idFilterBuilder.build(), BooleanClause.Occur.MUST);
 
-        if (userGenres != null && !userGenres.isEmpty()) {
+        if (memberGenres != null && !memberGenres.isEmpty()) {
 
-            for (String userGenre : userGenres) {
-                if (userGenre != null && !userGenre.trim().isEmpty()) {
-                    String escapedGenre = QueryParser.escape(userGenre);
+            for (String memberGenre : memberGenres) {
+                if (memberGenre != null && !memberGenre.trim().isEmpty()) {
+                    String escapedGenre = QueryParser.escape(memberGenre);
                     QueryParser genreParser = new QueryParser("genreTag", analyzer);
                     Query genreQuery = genreParser.parse(escapedGenre);
                     mainQueryBuilder.add(genreQuery, BooleanClause.Occur.SHOULD);

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
@@ -39,10 +39,10 @@ public class LuceneSearchService {
             return searcher.search(query, limit * 10);
         } catch (IOException e) {
             log.error("Lucene 검색 실행 중 파일 시스템 오류: platformIds={}, genres={}, error={}",
-                    platformFilteredContentIds.size(), memberGenres, e.getMessage(), e);
+                    platformFilteredContentIds.size(), memberGenres, e.getMessage());
             throw e;
         } catch (ParseException e) {
-            log.warn("검색 쿼리 파싱 실패: genres={}, error={}", memberGenres, e.getMessage(), e);
+            log.warn("검색 쿼리 파싱 실패: genres={}, error={}", memberGenres, e.getMessage());
             throw e;
         }
     }
@@ -61,11 +61,11 @@ public class LuceneSearchService {
             return searcher.search(query, limit * 2);
         } catch (IOException e) {
             log.error("Lucene 엄선된 추천 검색 중 파일 시스템 오류: platformIds={}, feedbackGenres={}, error={}",
-                    platformFilteredContentIds.size(), feedbackGenres, e.getMessage(), e);
+                    platformFilteredContentIds.size(), feedbackGenres, e.getMessage());
             throw e;
         } catch (ParseException e) {
-            log.warn("엄선된 추천 쿼리 파싱 실패: feedbackGenres={}, error={}", feedbackGenres, e.getMessage(),
-                    e);
+            log.warn("엄선된 추천 쿼리 파싱 실패: feedbackGenres={}, error={}", feedbackGenres,
+                    e.getMessage());
             throw e;
         }
     }


### PR DESCRIPTION
## 📝 요약(Summary)
설문조사에서 선택한 콘텐츠 태그를 추천 알고리즘의 스코어 계산에 반영하고, 코드의 일관성을 위해 user → member로 용어를 통일했습니다. 추가로 장르 태그 파싱 로직을 개선하여 성능을 향상시켰습니다.

### 주요 변경사항
1. **콘텐츠 태그 기반 스코어링 추가**: 설문조사에서 선택한 콘텐츠의 장르를 분석하여 추천 점수에 반영
2. **용어 일관성 개선**: 전체 코드베이스에서 user → member로 변수명 통일  
3. **성능 최적화**: 장르 태그 파싱을 Set 기반으로 개선하여 중복 연산 제거
4. **코드 구조 개선**: 불필요한 분기문 제거 및 메서드 분리

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
### 중점적으로 봐주셨으면 하는 부분:
1. **새로운 콘텐츠 태그 스코어링 로직** (`calculateContentTagBoost` 메서드)
   - 설문조사에서 선택한 콘텐츠들의 장르를 기반으로 가중치를 계산하는 로직의 적절성
   - 스코어링 밸런스가 기존 알고리즘과 잘 조화되는지

2. **성능 개선 부분**
   - `parseGenreTags` 메서드에서 Set 사용으로 인한 성능 향상
   - `calculateGenreBoost`에서 String 배열 대신 Set 사용으로 중복 연산 제거

3. **리팩토링 일관성**
   - user → member 변경이 누락된 부분이 있는지 확인

### 논의사항:
- 콘텐츠 태그 스코어의 가중치(현재 1.0f)가 적절한지 의견을 듣고 싶습니다
- `buildRegularRecommendationResponse` 메서드명이 더 적절한 이름이 있을까요?

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분