### PR TITLE
fix/UDT-165-요일별-콘텐츠-중복-조회-버그

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryImpl.java
@@ -336,7 +336,7 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
             WeeklyRecommendationRequest request, List<GenreType> genreTypes) {
 
         List<WeeklyRecommendedContentsResponse> items = queryFactory
-                .select(new QWeeklyRecommendedContentsResponse(content))
+                .selectDistinct(new QWeeklyRecommendedContentsResponse(content))
                 .from(content)
                 .leftJoin(content.contentGenres, contentGenre)
                 .leftJoin(contentGenre.genre, genre)


### PR DESCRIPTION
## 📝 요약(Summary)

- 요일별 콘텐츠 조회 시 중복 콘텐츠가 조회되는 버그 해결
  - QueryDSL 로직을 Select() -> SelectDistinct()로 변경

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 3분
