### PR TITLE
refactor/UDT-135-feedback-다중-삭제로-변경

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/controller/FeedbackController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/FeedbackController.java
@@ -3,6 +3,7 @@ package com.example.udtbe.domain.content.controller;
 import com.example.udtbe.domain.content.dto.common.FeedbackContentDTO;
 import com.example.udtbe.domain.content.dto.request.FeedbackContentGetRequest;
 import com.example.udtbe.domain.content.dto.request.FeedbackCreateBulkRequest;
+import com.example.udtbe.domain.content.dto.request.FeedbackListDeleteRequest;
 import com.example.udtbe.domain.content.service.FeedbackService;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
@@ -34,8 +35,8 @@ public class FeedbackController implements FeedbackControllerApiSpec {
     }
 
     @Override
-    public ResponseEntity<Void> deleteFeedback(Long feedbackId, Member member) {
-        feedbackService.deleteFeedback(feedbackId, member);
+    public ResponseEntity<Void> deleteFeedback(FeedbackListDeleteRequest request, Member member) {
+        feedbackService.deleteFeedback(request.feedbackIds(), member);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/controller/FeedbackController.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/FeedbackController.java
@@ -28,7 +28,6 @@ public class FeedbackController implements FeedbackControllerApiSpec {
     @Override
     public ResponseEntity<CursorPageResponse<FeedbackContentDTO>> getFeedbackByCursor(
             FeedbackContentGetRequest request, Member member) {
-        // TODO: 3차 MVP 때 플랫폼별, 장르별 FeedbackSortType 반영
         CursorPageResponse<FeedbackContentDTO> response = feedbackService.getFeedbackList(
                 request, member);
         return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/main/java/com/example/udtbe/domain/content/controller/FeedbackControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/content/controller/FeedbackControllerApiSpec.java
@@ -3,6 +3,7 @@ package com.example.udtbe.domain.content.controller;
 import com.example.udtbe.domain.content.dto.common.FeedbackContentDTO;
 import com.example.udtbe.domain.content.dto.request.FeedbackContentGetRequest;
 import com.example.udtbe.domain.content.dto.request.FeedbackCreateBulkRequest;
+import com.example.udtbe.domain.content.dto.request.FeedbackListDeleteRequest;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,7 +15,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,6 +40,6 @@ public interface FeedbackControllerApiSpec {
     @Operation(summary = "Feedback한 Content 삭제 API", description = "좋아요/싫어요 한 컨텐츠들을 삭제한다.")
     @ApiResponse(useReturnTypeSchema = true)
     @DeleteMapping("/users/me/feedbacks/{feedbackId}")
-    ResponseEntity<Void> deleteFeedback(@PathVariable(name = "feedbackId") Long feedbackId,
+    ResponseEntity<Void> deleteFeedback(@RequestBody @Valid FeedbackListDeleteRequest request,
             @AuthenticationPrincipal Member member);
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/request/FeedbackListDeleteRequest.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/request/FeedbackListDeleteRequest.java
@@ -1,0 +1,13 @@
+package com.example.udtbe.domain.content.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record FeedbackListDeleteRequest(
+        @NotNull(message = "feedbackIds는 필수값입니다.")
+        @NotEmpty(message = "feedbackIds는 최소 1개 이상이어야 합니다.")
+        List<Long> feedbackIds
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/FeedbackRepository.java
@@ -29,4 +29,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long>, Feedb
               c.id ASC
             """)
     List<Content> findTopRankedContents(Pageable pageable);
+
+    List<Feedback> findByMemberIdAndIdIn(Long memberId, List<Long> feedbackIds);
+
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackQuery.java
@@ -39,4 +39,9 @@ public class FeedbackQuery {
     public Optional<Feedback> findFeedbackByMemberIdAndContentId(Long memberId, Long contentId) {
         return feedbackRepository.findFeedbackByMemberIdAndContentId(memberId, contentId);
     }
+
+    public List<Feedback> findFeedbackByIdList(Long memberId,
+            List<Long> feedbackIds) {
+        return feedbackRepository.findByMemberIdAndIdIn(memberId, feedbackIds);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -74,14 +74,15 @@ public class FeedbackService {
     }
 
     @Transactional
-    public void deleteFeedback(Long feedbackId, Member member) {
-        Feedback feedback = feedbackQuery.findFeedbackById(feedbackId);
+    public void deleteFeedback(List<Long> feedbackIds, Member member) {
+        List<Feedback> feedbacks = feedbackQuery.findFeedbackByIdList(member.getId(), feedbackIds);
 
-        if (!feedback.getMember().getId().equals(member.getId())) {
-            throw new RestApiException(FeedbackErrorCode.FEEDBACK_OWNER_MISSMATCH);
-        }
-
-        feedback.switchDeleted();
+        feedbacks.forEach(feedback -> {
+            if (!feedback.getMember().getId().equals(member.getId())) {
+                throw new RestApiException(FeedbackErrorCode.FEEDBACK_OWNER_MISSMATCH);
+            }
+            feedback.switchDeleted();
+        });
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/FeedbackService.java
@@ -6,11 +6,9 @@ import com.example.udtbe.domain.content.dto.common.FeedbackCreateDTO;
 import com.example.udtbe.domain.content.dto.request.FeedbackContentGetRequest;
 import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
-import com.example.udtbe.domain.content.exception.FeedbackErrorCode;
 import com.example.udtbe.domain.content.repository.FeedbackRepository;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
-import com.example.udtbe.global.exception.RestApiException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -76,13 +74,7 @@ public class FeedbackService {
     @Transactional
     public void deleteFeedback(List<Long> feedbackIds, Member member) {
         List<Feedback> feedbacks = feedbackQuery.findFeedbackByIdList(member.getId(), feedbackIds);
-
-        feedbacks.forEach(feedback -> {
-            if (!feedback.getMember().getId().equals(member.getId())) {
-                throw new RestApiException(FeedbackErrorCode.FEEDBACK_OWNER_MISSMATCH);
-            }
-            feedback.switchDeleted();
-        });
+        feedbacks.forEach(Feedback::switchDeleted);
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
@@ -34,7 +34,6 @@ public class MemberController implements MemberControllerApiSpec {
     public ResponseEntity<CursorPageResponse<MemberCuratedContentGetResponse>> getCuratedContents(
             Member member,
             MemberCuratedContentGetsRequest memberCuratedContentGetsRequest) {
-        // TODO: 3차 MVP 때 엄선된 콘텐츠 필터링 반영
         CursorPageResponse<MemberCuratedContentGetResponse> response
                 = memberService.getCuratedContents(memberCuratedContentGetsRequest, member);
         return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/FeedbackServiceTest.java
@@ -164,7 +164,7 @@ public class FeedbackServiceTest {
         assertThat(result.nextCursor()).isEqualTo(feedbacks.get(1).getId());
     }
 
-    @DisplayName("회원은 피드백을 삭제할 수 있다.")
+    @DisplayName("회원은 피드백을 다건 삭제할 수 있다.")
     @Test
     void deleteFeedback() {
         // given
@@ -172,17 +172,21 @@ public class FeedbackServiceTest {
 
         Content content = content("test_content", "description");
 
-        Feedback feedback = Feedback.of(FeedbackType.LIKE, false, member, content);
-
-        ReflectionTestUtils.setField(feedback, "id", 1L);
+        Feedback feedback1 = Feedback.of(FeedbackType.LIKE, false, member, content);
+        Feedback feedback2 = Feedback.of(FeedbackType.LIKE, false, member, content);
+        
         ReflectionTestUtils.setField(member, "id", 10L);
+        List<Long> feedbackIds = List.of(1L, 2L);
+        List<Feedback> feedbacks = List.of(feedback1, feedback2);
 
-        given(feedbackQuery.findFeedbackById(1L)).willReturn(feedback);
+        given(feedbackQuery.findFeedbackByIdList(10L, feedbackIds))
+                .willReturn(feedbacks);
 
         // when
-        feedbackService.deleteFeedback(1L, member);
+        feedbackService.deleteFeedback(feedbackIds, member);
 
         // then
-        assertThat(feedback.isDeleted()).isTrue();
+        assertThat(feedback1.isDeleted()).isTrue();
+        assertThat(feedback2.isDeleted()).isTrue();
     }
 }

--- a/temp.md
+++ b/temp.md
@@ -1,0 +1,295 @@
+<div align="center">
+👥 Team Members
+<img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&height=200&section=header&text=Meet%20Our%20Team&fontSize=50&fontColor=fff" />
+<table>
+<tr>
+<td align="center">
+<a href="https://github.com/dnjstjt1297">
+<img src="https://avatars.githubusercontent.com/dnjstjt1297?s=100" width="100px;" alt="dnjstjt1297"/><br/>
+<b>dnjstjt1297</b><br/>
+김원석
+</a>
+</td>
+<td align="center">
+<a href="https://github.com/dudxo">
+<img src="https://avatars.githubusercontent.com/dudxo?s=100" width="100px;" alt="dudxo"/><br/>
+<b>dudxo</b><br/>
+권영태
+</a>
+</td>
+<td align="center">
+<a href="https://github.com/hjg727">
+<img src="https://avatars.githubusercontent.com/hjg727?s=100" width="100px;" alt="hjg727"/><br/>
+<b>hjg727</b><br/>
+홍정기
+</a>
+</td>
+<td align="center">
+<a href="https://github.com/LGAIN">
+<img src="https://avatars.githubusercontent.com/LGAIN?s=100" width="100px;" alt="LGAIN"/><br/>
+<b>LGAIN</b><br/>
+이가인
+</a>
+</td>
+</tr>
+</table>
+</div>
+
+## 프로젝트 배경
+
+### 문제 인식
+
+> 1. **OTT 콘텐츠 과잉**
+>    - 국내 OTT 시장 규모: 2023년 약 1.4조원.
+>    - 20~30대가 전체 이용자의 80% 이상, 구독 플랫폼 평균 2.8개 보유.
+>    - 방대한 선택지로 ‘무엇을 볼지’ 고민에 평균 10~20분 이상 소모.
+> 2. **통합 추천 서비스 부재**
+>    - 플랫폼별 앱을 오가며 콘텐츠를 검색해야 하는 불편.
+>    - 기존 서비스(예: 키노라이츠)는 최소 10편 평가 후 추천, 실시간 개인화 한계.
+>    - 능동적 피드백 수집의 어려움
+> 3. **‘좋아요/싫어요’ 클릭률 저조, 피드백 데이터 부족.**
+
+### 해결 목표 및 기대 효과
+
+### 스트리밍 성향 파악 및 직관적 UI(릴스)를 통해 OTT 콘텐츠를 추천한다. 이를 통해, 탐색 시간을 30초 내로 단축하여 빠르게 유입과 퇴장을 목표로 한다.
+
+### 세부 목표
+
+> 1. **초기 성향 설정**
+>    - 회원가입 시 OTT 구독 플랫폼·선호 장르 설문.
+> 2. **스와이프 기반 실시간 피드백**
+>    - 릴스형 숏폼 UI, 오른쪽 스와이프 좋아요, 왼쪽 스와이프 싫어요, 아래 관심없음.
+> 3. **구독 플랫폼 통합 추천**
+>    - 구독 중인 OTT 콘텐츠 우선 추천, 미구독 콘텐츠 병행 노출.
+> 4. **마이페이지 피드백 수정**
+>    - 이전 피드백 히스토리 수정 기능 제공, 추천 알고리즘에 반영.
+> 5. **OTT 콘텐츠 필터링해서 보기**
+
+## ERD
+
+## 서비스 요청 흐름도
+
+## 시스템 아키텍처
+
+<img width="996" alt="image" src="https://github.com/user-attachments/assets/877d9fb9-fb1d-4fd7-9bd1-f5e087ec3f39" />
+
+## 기능 소개
+
+### 1️⃣ 로그인
+
+👉 카카오 로그인을 이용해 회원가입 및 로그인을 진행할 수 있다.
+
+<br>
+<img src = "" width="200" height="260"/>
+<img src = "" width="200" height="260"/>
+<br>
+
+### 2️⃣ 설문
+
+👉 처음 가입하는 사용자는 자신이 구독하고 있는 OTT 플랫폼과 선호하는 장르를 추천받을 수 있다.
+
+<br>
+<img src = "" width="300" height="360"/>
+<br>
+
+### 3️⃣ OTT 콘텐츠 추천
+
+👉 사용자는 자신이 선호하는 장르에 기반한 콘텐츠들의 카드를 넘겨 OTT 콘텐츠들을 추천받을 수 있다.<br>
+👉 이때, 추천받은 콘텐츠에 대해 좋아요/싫어요/관심없음 의 피드백을 남길 수 있으며, 이 피드백으로 다음 추천 콘텐츠들이 결정된다.
+
+<br>
+<img src = "" width="200" height="290"/>
+<img src = "" width="200" height="290"/>
+<br>
+<br>
+
+### 4️⃣ 엄선된 콘텐츠 추천
+
+👉 20개의 피드백을 남기면 3개의 엄선된 추천 콘텐츠를 확인할 수 있다.
+👉 각 콘텐츠 카드 우상단의 새로운 추천 콘텐츠를 확인할 수 있다.
+
+<br>
+<img src = "" width="300" height="390"/>
+
+<br>
+
+### 5️⃣ 찾아보기
+
+👉 찾아보기 탭에서 OTT 콘텐츠들을 확인할 수 있다.
+👉 필터링 기능을 통해 OTT / 카테고리 / 장르 / 국가 등으로 콘텐츠들을 필터링할 수 있다.
+👉 요일별 추천 콘텐츠를 확인할 수 있다.
+👉 인기 콘텐츠를 확인할 수 있다.
+
+<br>
+
+<br>
+
+### 6️⃣ 마이페이지
+
+👉 마이페이지에서는 사용자의 정보를 확인할 수 있다.
+👉 사용자는 회원가입 시 작성한 설문의 내용(구독하고 있는 OTT 플랫폼, 선호 장르)를 확인하고, 수정할 수 있다.
+👉 사용자는 자신의 피드백 히스토리를 확인하고, 이전에 남긴 피드백을 수정할 수 있다.
+
+<br>
+<img src = "" width="400" height="230"/>
+<br>
+
+### 7️⃣ 관리자 모드
+
+👉 관리자는 ADMIN 페이지에서 콘텐츠를 등록/수정/삭제할 수 있다.
+
+<br>
+<img src = "" width="400" height="230"/>
+<br>
+
+# Team Rules
+
+## 🌿 브랜치 관리
+
+### 브랜치 구조
+
+- **develop**: 개발용 메인 브랜치
+- **prod**: 배포용 브랜치
+- **feature**: 기능 개발 브랜치
+
+### 브랜치 네이밍 규칙
+
+```
+feat/UDT-22-구현할-기능-기반-네이밍
+fix/UDT-22-고쳐야될-부분-네이밍
+refactor/UDT-22-리팩토링-부분-네이밍
+```
+
+**예시**:
+
+- `feat/UDT-22-회원가입`
+- `feat/UDT-22-1차-추천알고리즘`
+- `fix/UDT-22-회원가입-검증오류`
+- `refactor/UDT-22-dto-record로-변경`
+
+### 개발 플로우
+
+1. develop에서 feature 브랜치 생성
+2. 기능 개발 및 커밋
+3. PR 생성 및 코드 리뷰
+4. develop 브랜치로 머지
+5. 배포 시 develop → prod
+
+## 📝 커밋 컨벤션
+
+### 기본 형식
+
+```
+UDT-[티켓번호] [타입]: [간단한 설명]
+```
+
+### 타입 분류
+
+| 타입       | 설명                      |
+| ---------- | ------------------------- |
+| `feat`     | 새로운 기능 추가          |
+| `fix`      | 버그 수정                 |
+| `refactor` | 리팩토링 (기능 변화 없음) |
+| `hotfix`   | 빠르게 버그 수정          |
+| `docs`     | 문서 수정                 |
+| `test`     | 테스트 코드               |
+| `chore`    | 빌드, 배포 관련           |
+
+**예시**: `UDT-XXX feat: 사용자 인증 기능 구현`
+
+## 🏗️ 패키지 구조
+
+```
+com.example.udtbe/
+├── domain/
+│   ├── admin/
+│   │   ├── controller/
+│   │   ├── dto/
+│   │   ├── exception/
+│   │   └── service/
+│   ├── auth/
+│   ├── content/
+│   ├── file/
+│   ├── member/
+│   └── survey/
+├── global/
+│   ├── config/
+│   ├── dto/
+│   ├── entity/
+│   ├── exception/
+│   ├── log/
+│   ├── security/
+│   ├── token/
+│   └── util/
+└── UdtBeApplication
+```
+
+## 💻 코딩 컨벤션
+
+### API 네이밍
+
+- **엔드포인트**: `/api/users` 형식
+- **컨트롤러 메서드**:
+  - 리스트: `getUsers()`
+  - 단일: `getUser()`
+- **서비스 메서드**: `getUsers()`
+
+### 변수 네이밍
+
+- `findUser` ← `findByUserById()`
+- `savedUser` ← `.save()`
+
+### DTO 네이밍 규칙
+
+- **Record 사용**: `Entity(User)~~Request`, `Entity(User)~~Response`
+- **생성자**: 정적메서드 사용 (`of`, `fromXX`)
+- **참조형 클래스**: `~~DTO` (예: `PlatformDTO`)
+- **커서 페이지네이션**: `CursorPageResponse<~~GetResponse>`
+
+### 인증 처리
+
+```java
+@GetMapping
+public ResponseEntity<?> getUser(@AuthenticationPrincipal Long userId) {
+    // 구현
+}
+```
+
+## ⚙️ 개발 환경 설정
+
+### IntelliJ 설정
+
+#### 1. Google 코드 스타일 적용
+
+- 다운로드: [Google Java Style Guide](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml)
+- Settings → Editor → Code Style → Java → 구성표 가져오기
+- 들여쓰기: 4 4 8 0 고정
+
+#### 2. 자동 포맷팅 설정
+
+- Settings → Tools → Actions on Save
+- ✅ Reformat code
+- ✅ Optimize imports
+
+## 🚀 CI/CD
+
+### 파이프라인 구조
+
+- **develop**: CI/CD (빌드 및 테스트, 배포)
+- **prod**: CD (배포)
+
+## ✅ 개발 원칙
+
+### 레이어 구조
+
+- **Controller** → **Service** → **Repository** 계층 구조 준수
+- 각 레이어의 역할과 책임 명확히 분리
+
+### 의존성 주입
+
+- `@RequiredArgsConstructor` 활용한 생성자 주입 권장
+
+### 테스트
+
+- 비즈니스 로직에 대한 단위 테스트 필수
+- 통합 테스트를 통한 전체 플로우 검증


### PR DESCRIPTION
## 📝 요약(Summary)

기존의 feedback 삭제기능은 1개씩 삭제되는 로직입니다.
엄선된 콘텐츠 삭제와 같이 다건 삭제가 가능하도록 코드를 수정했습니다.
잘못된 부분이 있다면 언제든지 말씀해주시기 바랍니다.

참고: 현재 배포가 완료된 기능이라, 빠르게 적용할 수 있게 프론트 코드도 이미 준비가 되어있습니다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
