### PR TITLE
fix/UDT-187 어드민 콘텐츠 필터링 목록 조회 문제

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminContentGetsRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminContentGetsRequest.java
@@ -1,10 +1,12 @@
 package com.example.udtbe.domain.admin.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record AdminContentGetsRequest(
-        Long cursor,
-        @NotNull
+        String cursor,
+        @NotNull(message = "커서 사이즈는 필수 값 입니다.")
+        @Min(value = 1, message = "커서 사이즈는 1 이상입니다.")
         int size,
         String categoryType
 ) {

--- a/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryCustom.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/ContentRepositoryCustom.java
@@ -16,7 +16,7 @@ public interface ContentRepositoryCustom {
 
     AdminContentGetDetailResponse getAdminContentDetails(Long contentId);
 
-    CursorPageResponse<AdminContentGetResponse> getsAdminContents(Long cursor, int size,
+    CursorPageResponse<AdminContentGetResponse> getsAdminContents(String cursor, int size,
             String categoryType);
 
     CursorPageResponse<ContentsGetResponse> getContents(ContentsGetRequest request);

--- a/src/test/java/com/example/udtbe/admin/repository/AdminContentRepositoryTest.java
+++ b/src/test/java/com/example/udtbe/admin/repository/AdminContentRepositoryTest.java
@@ -130,6 +130,12 @@ public class AdminContentRepositoryTest extends DataJpaSupport {
                 .containsExactly(
                         IntStream.range(0, size).mapToObj(i -> lastId - i).toArray(Long[]::new));
         assertThat(page.hasNext()).isTrue();
-        assertThat(page.nextCursor()).isEqualTo(String.valueOf(lastId - size + 1));
+
+        AdminContentGetResponse lastItemOnPage = dtos.get(dtos.size() - 1);
+        Long lastItemIdOnPage = lastItemOnPage.contentId();
+        String[] cursorParts = page.nextCursor().split("\\|");
+
+        assertThat(cursorParts).hasSize(2);
+        assertThat(cursorParts[0]).isEqualTo(String.valueOf(lastItemIdOnPage));
     }
 }

--- a/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
@@ -365,7 +365,8 @@ public class AdminServiceTest {
         CursorPageResponse<AdminContentGetResponse> page = new CursorPageResponse<>(
                 List.of(adminContentGetResponse1, adminContentGetResponse), "4", true);
 
-        AdminContentGetsRequest adminContentGetsRequest = new AdminContentGetsRequest(5L, 2, null);
+        AdminContentGetsRequest adminContentGetsRequest = new AdminContentGetsRequest(
+                "5|2025-07-30", 2, null);
 
         given(contentRepository.getsAdminContents(
                 adminContentGetsRequest.cursor(),
@@ -405,7 +406,8 @@ public class AdminServiceTest {
         CursorPageResponse<AdminContentGetResponse> page = new CursorPageResponse<>(
                 List.of(adminContentGetResponse2, adminContentGetResponse1), "4", true);
 
-        AdminContentGetsRequest adminContentGetsRequest = new AdminContentGetsRequest(5L, 2, "드라마");
+        AdminContentGetsRequest adminContentGetsRequest = new AdminContentGetsRequest(
+                "5|2025-07-05", 2, "드라마");
 
         given(contentRepository.getsAdminContents(
                 adminContentGetsRequest.cursor(),


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 상황: 관리자 페이지에서 콘텐츠 목록 조회 시 일부 항목이 중복되거나 누락되는 문제가 있었습니다.

- 문제: 기존에는 `contentId`만을 커서로 사용하고 `openDate` 기준으로 정렬하였으나, 커서와 정렬 기준이 일치하지 않아 정확한 페이지네이션이 이루어지지 않았습니다.

- 해결: `openDate`와 `contentId`를 복합 커서로 사용하여 정렬 기준과 일치하도록 로직을 수정하였습니다. 이로써 중복 및 누락 현상이 해결되었습니다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
