### PR TITLE
fix/UDT-188-JWT-재발급-401-403-버그-픽스

### DIFF
--- a/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
@@ -50,11 +50,11 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(
                         (auth) -> auth
+                                .requestMatchers("/", "/api/auth/reissue/token").permitAll()
                                 .requestMatchers("/api/survey").hasAnyAuthority(ROLE_GUEST.name())
                                 .requestMatchers("/api/admin/**").hasAnyAuthority(ROLE_ADMIN.name())
                                 .requestMatchers("/api/**")
                                 .hasAnyAuthority(ROLE_USER.name(), ROLE_ADMIN.name())
-                                .requestMatchers("/", "/api/auth/reissue/token").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .oauth2Login(

--- a/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
@@ -41,7 +41,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             "/api/auth/temp-signup",
             "/actuator/health",
             "/actuator/prometheus",
-            "/actuator/metrics"
+            "/actuator/metrics",
+            "/api/auth/reissue/token"
     );
     private static final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final TokenProvider tokenProvider;


### PR DESCRIPTION
## 📝 요약(Summary)

- JWT AT Ressiue API가 인증/인가 필터를 건너뛰지 못하는 문제 해결
  - Security Config authorizeHttpRequests() 정책 순서 변경(포괄적인 정책(`/api/**` 후순위로 변경)
  - TokenFilter SKIP_URL PATH 추가 등록

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 3분
