### PR TITLE
refactor/UDT-180-관리자-콘텐츠-등록-API-수정

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminContentRegisterRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminContentRegisterRequest.java
@@ -1,6 +1,5 @@
 package com.example.udtbe.domain.admin.dto.request;
 
-import com.example.udtbe.domain.admin.dto.common.AdminCastDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
 import jakarta.validation.constraints.Min;
@@ -41,9 +40,9 @@ public record AdminContentRegisterRequest(
 
         List<String> countries,
 
-        List<String> directors,
+        List<Long> directors,
 
-        List<AdminCastDTO> casts,
+        List<Long> casts,
 
         @NotEmpty(message = "플랫폼을 하나 이상 선택해주세요.")
         List<AdminPlatformDTO> platforms

--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminContentUpdateRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminContentUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.example.udtbe.domain.admin.dto.request;
 
-import com.example.udtbe.domain.admin.dto.common.AdminCastDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
 import jakarta.validation.constraints.Min;
@@ -40,9 +39,9 @@ public record AdminContentUpdateRequest(
 
         List<String> countries,
 
-        List<String> directors,
+        List<Long> directors,
 
-        List<AdminCastDTO> casts,
+        List<Long> casts,
 
         @NotEmpty(message = "플랫폼을 하나 이상 선택해주세요.")
         List<AdminPlatformDTO> platforms

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -68,18 +68,6 @@ public class AdminQuery {
         );
     }
 
-    public Cast findOrSaveCast(String castName, String castImageUrl) {
-        return castRepository.findByCastNameAndCastImageUrl(castName, castImageUrl).orElseGet(() ->
-                castRepository.save(Cast.of(castName, castImageUrl))
-        );
-    }
-
-    public Director findOrSaveDirector(String directorName) {
-        return directorRepository.findByDirectorName(directorName).orElseGet(() ->
-                directorRepository.save(Director.of(directorName))
-        );
-    }
-
     public Director findDirector(Long directorId) {
         return directorRepository.findById(directorId).orElseThrow(() ->
                 new RestApiException(ContentErrorCode.DIRECTOR_NOT_FOUND)

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -68,7 +68,7 @@ public class AdminQuery {
         );
     }
 
-    public Director findDirector(Long directorId) {
+    public Director findDirectorByDirectorId(Long directorId) {
         return directorRepository.findById(directorId).orElseThrow(() ->
                 new RestApiException(ContentErrorCode.DIRECTOR_NOT_FOUND)
         );

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -80,9 +80,21 @@ public class AdminQuery {
         );
     }
 
+    public Director findDirector(Long directorId) {
+        return directorRepository.findById(directorId).orElseThrow(() ->
+                new RestApiException(ContentErrorCode.DIRECTOR_NOT_FOUND)
+        );
+    }
+
     public Country findOrSaveCountry(String countryName) {
         return countryRepository.findByCountryName(countryName).orElseGet(() ->
                 countryRepository.save(Country.of(countryName))
+        );
+    }
+
+    public Cast findCastByCastId(Long castId) {
+        return castRepository.findById(castId).orElseThrow(() ->
+                new RestApiException(ContentErrorCode.CAST_NOT_FOUND)
         );
     }
 }

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -1,7 +1,6 @@
 package com.example.udtbe.domain.admin.service;
 
 import com.example.udtbe.domain.admin.dto.AdminContentMapper;
-import com.example.udtbe.domain.admin.dto.common.AdminCastDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminContentGetsRequest;
@@ -149,14 +148,18 @@ public class AdminService {
             ContentCategory.of(content, category);
         });
 
-        request.casts().forEach(dto -> {
-            Cast cast = adminQuery.findOrSaveCast(dto.castName(), dto.castImageUrl());
+        List<String> castTags = new ArrayList<>();
+        request.casts().forEach(castId -> {
+            Cast cast = adminQuery.findCastByCastId(castId);
             ContentCast.of(content, cast);
+            castTags.add(cast.getCastName());
         });
 
-        request.directors().forEach(name -> {
-            Director director = adminQuery.findOrSaveDirector(name);
+        List<String> directorTags = new ArrayList<>();
+        request.directors().forEach(directorId -> {
+            Director director = adminQuery.findDirector(directorId);
             ContentDirector.of(content, director);
+            directorTags.add(director.getDirectorName());
         });
 
         request.countries().forEach(name -> {
@@ -188,9 +191,8 @@ public class AdminService {
                 .distinct().toList();
         List<String> platformTags = request.platforms().stream().map(AdminPlatformDTO::platformType)
                 .toList();
-        List<String> castTags = request.casts().stream().map(AdminCastDTO::castName).toList();
         metadata.update(request.title(), request.rating(), categoryTags, genreTags, platformTags,
-                request.directors(), castTags);
+                directorTags, castTags);
 
         return AdminContentMapper.toContentUpdateResponse(content);
     }

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -38,6 +38,7 @@ import com.example.udtbe.domain.content.repository.ContentPlatformRepository;
 import com.example.udtbe.domain.content.repository.ContentRepository;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import com.example.udtbe.global.log.annotation.LogReturn;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -69,14 +70,18 @@ public class AdminService {
             ContentCategory.of(content, category);
         });
 
-        request.casts().forEach(dto -> {
-            Cast cast = adminQuery.findOrSaveCast(dto.castName(), dto.castImageUrl());
+        List<String> castTags = new ArrayList<>();
+        request.casts().forEach(castId -> {
+            Cast cast = adminQuery.findCastByCastId(castId);
             ContentCast.of(content, cast);
+            castTags.add(cast.getCastName());
         });
 
-        request.directors().forEach(name -> {
-            Director director = adminQuery.findOrSaveDirector(name);
+        List<String> directorTags = new ArrayList<>();
+        request.directors().forEach(directorId -> {
+            Director director = adminQuery.findDirector(directorId);
             ContentDirector.of(content, director);
+            directorTags.add(director.getDirectorName());
         });
 
         request.countries().forEach(name -> {
@@ -107,10 +112,9 @@ public class AdminService {
                 .toList();
         List<String> genreTags = request.categories().stream().flatMap(c -> c.genres().stream())
                 .distinct().toList();
-        List<String> castTags = request.casts().stream().map(AdminCastDTO::castName).toList();
         contentMetadataRepository.save(ContentMetadata.of(
                 content.getTitle(), content.getRating(), categoryTags,
-                genreTags, platformTags, request.directors(), castTags,
+                genreTags, platformTags, directorTags, castTags,
                 content
         ));
 

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -78,7 +78,7 @@ public class AdminService {
 
         List<String> directorTags = new ArrayList<>();
         request.directors().forEach(directorId -> {
-            Director director = adminQuery.findDirector(directorId);
+            Director director = adminQuery.findDirectorByDirectorId(directorId);
             ContentDirector.of(content, director);
             directorTags.add(director.getDirectorName());
         });
@@ -157,7 +157,7 @@ public class AdminService {
 
         List<String> directorTags = new ArrayList<>();
         request.directors().forEach(directorId -> {
-            Director director = adminQuery.findDirector(directorId);
+            Director director = adminQuery.findDirectorByDirectorId(directorId);
             ContentDirector.of(content, director);
             directorTags.add(director.getDirectorName());
         });

--- a/src/main/java/com/example/udtbe/domain/content/entity/Director.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/Director.java
@@ -35,9 +35,10 @@ public class Director extends TimeBaseEntity {
     private boolean isDeleted;
 
     @Builder(access = PRIVATE)
-    private Director(String directorName, boolean isDeleted) {
+    private Director(String directorName, boolean isDeleted, String directorImageUrl) {
         this.directorName = directorName;
         this.isDeleted = isDeleted;
+        this.directorImageUrl = directorImageUrl;
     }
 
     public static Director of(String directorName) {

--- a/src/main/java/com/example/udtbe/domain/content/exception/ContentErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/content/exception/ContentErrorCode.java
@@ -16,6 +16,8 @@ public enum ContentErrorCode implements ErrorCode {
     PLATFORM_NOT_FOUND(HttpStatus.NOT_FOUND, "플랫폼을 찾을 수 없습니다."),
     CURATED_CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "엄선된 추천 콘텐츠를 찾을 수 없습니다."),
     ALREADY_CURATED_CONTENT(HttpStatus.CONFLICT, "이미 저장된 엄선된 콘텐츠입니다."),
+    DIRECTOR_NOT_FOUND(HttpStatus.NOT_FOUND, "감독을 찾을 수 없습니다."),
+    CAST_NOT_FOUND(HttpStatus.NOT_FOUND, "출연진을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/example/udtbe/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/example/udtbe/admin/controller/AdminControllerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.udtbe.common.support.ApiSupport;
-import com.example.udtbe.domain.admin.dto.common.AdminCastDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
@@ -100,8 +99,8 @@ public class AdminControllerTest extends ApiSupport {
                 LocalDateTime.of(2025, 7, 11, 0, 0),
                 100, 1, "전체관람가",
                 List.of(new AdminCategoryDTO("영화", List.of("액션"))),
-                List.of("한국"), List.of("테스트 감독"),
-                List.of(new AdminCastDTO("테스트 배우", "https://cast.jpg")),
+                List.of("한국"), List.of(1L, 2L),
+                List.of(1L, 2L),
                 List.of(new AdminPlatformDTO("넷플릭스", "https://watch"))
         );
     }
@@ -132,8 +131,8 @@ public class AdminControllerTest extends ApiSupport {
                         new AdminCategoryDTO("애니메이션", List.of("키즈")),
                         new AdminCategoryDTO("드라마", List.of("서사/드라마"))
                 ),
-                List.of("한국"), List.of("수정 테스트 감독"),
-                List.of(new AdminCastDTO("수정 테스트 배우", "c1")),
+                List.of("한국"), List.of(1L, 2L),
+                List.of(1L, 2L),
                 List.of(
                         new AdminPlatformDTO("넷플릭스", "w1"),
                         new AdminPlatformDTO("디즈니+", "w2")
@@ -169,8 +168,8 @@ public class AdminControllerTest extends ApiSupport {
                     "p", "b", "t",
                     LocalDateTime.now(), 10, 1, "전체",
                     List.of(new AdminCategoryDTO("영화", List.of("액션"))),
-                    List.of("KR"), List.of("D"),
-                    List.of(new AdminCastDTO("C", "u")),
+                    List.of("KR"), List.of((long) i),
+                    List.of((long) i),
                     List.of(new AdminPlatformDTO("넷플릭스", "u"))
             );
 
@@ -222,8 +221,8 @@ public class AdminControllerTest extends ApiSupport {
                             new AdminCategoryDTO(categoryType, List.of("서사/드라마")),
                             new AdminCategoryDTO("애니메이션", List.of("키즈"))
                     ),
-                    List.of("KR"), List.of("D"),
-                    List.of(new AdminCastDTO("C", "u")),
+                    List.of("KR"), List.of((long) i),
+                    List.of((long) i),
                     List.of(new AdminPlatformDTO("넷플릭스", "u"))
             );
 

--- a/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -99,11 +100,8 @@ public class AdminServiceTest {
                         new AdminCategoryDTO("애니메이션", List.of("키즈"))
                 ),
                 List.of("대한민국"),
-                List.of("테스트 감독"),
-                List.of(
-                        new AdminCastDTO("테스트 배우", "https://cast.image1"),
-                        new AdminCastDTO("테스트 배우2", "https://cast.image2")
-                ),
+                List.of(1L, 2L),
+                List.of(1L, 2L),
                 List.of(
                         new AdminPlatformDTO("넷플릭스", "https://watch1"),
                         new AdminPlatformDTO("왓챠", "https://watch2")
@@ -134,18 +132,8 @@ public class AdminServiceTest {
             }
         }
 
-        List<AdminCastDTO> adminCastDtos = registerRequest.casts();
-        for (AdminCastDTO adminCastDto : adminCastDtos) {
-            given(adminQuery.findOrSaveCast(eq(adminCastDto.castName()),
-                    eq(adminCastDto.castImageUrl())))
-                    .willReturn(mock(Cast.class));
-        }
-
-        for (String directorName : registerRequest.directors()) {
-            given(adminQuery.findOrSaveDirector(
-                    eq(directorName)))
-                    .willReturn(mock(Director.class));
-        }
+        given(adminQuery.findCastByCastId(anyLong())).willReturn(mock(Cast.class));
+        given(adminQuery.findDirectorByDirectorId(anyLong())).willReturn(mock(Director.class));
 
         for (String countryName : registerRequest.countries()) {
             given(adminQuery.findOrSaveCountry(
@@ -181,11 +169,11 @@ public class AdminServiceTest {
                 () -> verify(adminQuery, times(genresSize))
                         .findByGenreTypeAndCategory(any(GenreType.class), any(Category.class)),
 
-                () -> verify(adminQuery, times(adminCastDtos.size()))
-                        .findOrSaveCast(anyString(), anyString()),
+                () -> verify(adminQuery, times(registerRequest.casts().size()))
+                        .findCastByCastId(anyLong()),
 
                 () -> verify(adminQuery, times(registerRequest.directors().size()))
-                        .findOrSaveDirector(anyString()),
+                        .findDirectorByDirectorId(anyLong()),
 
                 () -> verify(adminQuery, times(registerRequest.countries().size()))
                         .findOrSaveCountry(anyString()),
@@ -245,8 +233,8 @@ public class AdminServiceTest {
                 130, 1, "19세 관람가",
                 List.of(new AdminCategoryDTO("애니메이션", List.of("키즈"))),
                 List.of("미국"),
-                List.of("수정 테스트 감독"),
-                List.of(new AdminCastDTO("수정 테스트 배우", "https://new-image")),
+                List.of(1L, 2L),
+                List.of(1L, 2L),
                 List.of(new AdminPlatformDTO("디즈니+", "https://watch"))
         );
 
@@ -263,18 +251,8 @@ public class AdminServiceTest {
             }
         }
 
-        List<AdminCastDTO> adminCastDtos = adminContentUpdateRequest.casts();
-        for (AdminCastDTO adminCastDto : adminCastDtos) {
-            given(adminQuery.findOrSaveCast(eq(adminCastDto.castName()),
-                    eq(adminCastDto.castImageUrl())))
-                    .willReturn(mock(Cast.class));
-        }
-
-        for (String directorName : adminContentUpdateRequest.directors()) {
-            given(adminQuery.findOrSaveDirector(
-                    eq(directorName)))
-                    .willReturn(mock(Director.class));
-        }
+        given(adminQuery.findCastByCastId(anyLong())).willReturn(mock(Cast.class));
+        given(adminQuery.findDirectorByDirectorId(anyLong())).willReturn(mock(Director.class));
 
         for (String countryName : adminContentUpdateRequest.countries()) {
             given(adminQuery.findOrSaveCountry(
@@ -297,8 +275,6 @@ public class AdminServiceTest {
                 .toList();
         List<String> genreTag = adminCategoryDTO.stream().flatMap(dto -> dto.genres().stream())
                 .toList();
-        List<String> castTag = adminCastDtos.stream().map(AdminCastDTO::castName).toList();
-        List<String> directorTag = adminContentUpdateRequest.directors();
         List<String> platformTag = adminPlatformDTOS.stream().map(AdminPlatformDTO::platformType)
                 .toList();
         // then
@@ -322,12 +298,12 @@ public class AdminServiceTest {
                 () -> verify(adminQuery, times(genreSize)).findByGenreTypeAndCategory(
                         any(GenreType.class), any(Category.class)
                 ),
-                () -> verify(adminQuery, times(adminCastDtos.size())).findOrSaveCast(
-                        anyString(), anyString()
+                () -> verify(adminQuery, times(registerRequest.casts().size())).findCastByCastId(
+                        anyLong()
                 ),
                 () -> verify(adminQuery,
-                        times(adminContentUpdateRequest.directors().size())).findOrSaveDirector(
-                        anyString()
+                        times(adminContentUpdateRequest.directors()
+                                .size())).findDirectorByDirectorId(anyLong()
                 ),
                 () -> verify(adminQuery,
                         times(adminContentUpdateRequest.countries().size())).findOrSaveCountry(
@@ -343,8 +319,8 @@ public class AdminServiceTest {
                         eq(categoryTag),
                         eq(genreTag),
                         eq(platformTag),
-                        eq(directorTag),
-                        eq(castTag)
+                        any(List.class),
+                        any(List.class)
                 )
         );
     }

--- a/src/test/resources/data-test.sql
+++ b/src/test/resources/data-test.sql
@@ -56,3 +56,22 @@ VALUES (1, 'NETFLIX', NOW(), NOW(), false),
        (5, 'DISNEY_PLUS', NOW(), NOW(), false),
        (6, 'WATCHA', NOW(), NOW(), false),
        (7, 'APPLE_TV', NOW(), NOW(), false);
+
+
+-- 4) 출연진 데이터 삽입
+INSERT INTO cast (cast_id, cast_name, cast_image_url, is_deleted, created_at, updated_at)
+VALUES (1, '하정우', 'https://example.com/images/ha-jung-woo.jpg', false, NOW(), NOW()),
+       (2, '전도연', 'https://example.com/images/jeon-do-yeon.jpg', false, NOW(), NOW()),
+       (3, '이병헌', 'https://example.com/images/lee-byung-hun.jpg', false, NOW(), NOW()),
+       (4, '김태리', 'https://example.com/images/kim-tae-ri.jpg', false, NOW(), NOW()),
+       (5, '송강호', 'https://example.com/images/song-kang-ho.jpg', false, NOW(), NOW());
+
+
+-- 5) 감독 데이터 삽입
+INSERT INTO director (director_id, director_name, director_image_url, is_deleted, created_at,
+                      updated_at)
+VALUES (1, '봉준호', 'https://example.com/images/bong-joon-ho.jpg', false, NOW(), NOW()),
+       (2, '박찬욱', 'https://example.com/images/park-chan-wook.jpg', false, NOW(), NOW()),
+       (3, '김지운', 'https://example.com/images/kim-jee-woon.jpg', false, NOW(), NOW()),
+       (4, '임상수', 'https://example.com/images/im-sang-soo.jpg', false, NOW(), NOW()),
+       (5, '류승완', 'https://example.com/images/ryoo-seung-wan.jpg', false, NOW(), NOW());


### PR DESCRIPTION
## 📝 요약(Summary)

- 출연진, 감독 조회/등록 API 개발 요구사항에 따른 관리자 콘텐츠 등록/수정 API 리팩토링
  - 관리카 콘텐츠 등록/수정 API 호출 시 기존 `DirectorName`, `AdminCastDTO`가 담긴 Request 를 `List<Long>` 타입의 출연진/감독 ID들이 담긴 Request로 스펙 변경
  - 스펙 및 로직 변경에 따른 `AdminQuery.Class`, `ContentErrorCode`, `AdminControllerTest`, `AdminServiceTest` 추가 | 리팩토링
  - 테스트용 Data SQL 추가

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5~10분
