### PR TITLE
feat/UDT-204-관리자-감독-다건-등록-API

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
@@ -5,12 +5,14 @@ import com.example.udtbe.domain.admin.dto.request.AdminCastsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentGetsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetDetailResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentUpdateResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminDirectorsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.global.dto.CursorPageResponse;
@@ -86,5 +88,13 @@ public class AdminController implements AdminControllerApiSpec {
         CursorPageResponse<AdminCastsGetResponse> response =
                 adminService.getCasts(adminCastsGetRequest);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @Override
+    public ResponseEntity<AdminDirectorsRegisterResponse> registerDirectors(
+            AdminDirectorsRegisterRequest adminDirectorsRegisterRequest) {
+        AdminDirectorsRegisterResponse adminCastsRegisterRequest = adminService.registerDirectors(
+                adminDirectorsRegisterRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(adminCastsRegisterRequest);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
@@ -5,12 +5,14 @@ import com.example.udtbe.domain.admin.dto.request.AdminCastsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentGetsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetDetailResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentUpdateResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminDirectorsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -85,7 +87,7 @@ public interface AdminControllerApiSpec {
     ResponseEntity<AdminMemberInfoGetResponse> getMemberFeedbackInfo(
             @PathVariable(name = "userId") Long userId
     );
-  
+
     @Operation(summary = "출연진 다건 등록", description = "새로운 출연진들을 다건 등록한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "등록된 출연진 contentId 목록 반환"),
@@ -102,6 +104,15 @@ public interface AdminControllerApiSpec {
     @GetMapping("/api/admin/casts")
     ResponseEntity<CursorPageResponse<AdminCastsGetResponse>> getCasts(
             @Valid @ModelAttribute AdminCastsGetRequest adminCastsGetRequest
+    );
+
+    @Operation(summary = "감독 다건 등록", description = "새로운 감독들을 다건 등록한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "등록된 감독 DirectorId 목록 반환"),
+    })
+    @PostMapping("/api/admin/directors")
+    ResponseEntity<AdminDirectorsRegisterResponse> registerDirectors(
+            @Valid @RequestBody AdminDirectorsRegisterRequest adminDirectorsRegisterRequest
     );
 }
 

--- a/src/main/java/com/example/udtbe/domain/admin/dto/common/AdminDirectorDTO.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/common/AdminDirectorDTO.java
@@ -1,0 +1,12 @@
+package com.example.udtbe.domain.admin.dto.common;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminDirectorDTO(
+        @NotBlank(message = "감독 이름은 필수입니다.")
+        String directorName,
+        @NotBlank(message = "감독 사진 주소은 필수입니다.")
+        String directorImageUrl
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminDirectorsRegisterRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminDirectorsRegisterRequest.java
@@ -1,0 +1,18 @@
+package com.example.udtbe.domain.admin.dto.request;
+
+import com.example.udtbe.domain.admin.dto.common.AdminDirectorDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record AdminDirectorsRegisterRequest(
+        @NotNull(message = "감독 정보는 필수입니다.")
+        @Size(max = 30, message = "감독은 최대 30명까지 등록할 수 있습니다.")
+        @Valid
+        @JsonProperty("directors")
+        List<AdminDirectorDTO> adminDirectorDTOS
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminDirectorsRegisterResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminDirectorsRegisterResponse.java
@@ -1,0 +1,10 @@
+package com.example.udtbe.domain.admin.dto.response;
+
+import java.util.List;
+
+public record AdminDirectorsRegisterResponse(
+
+        List<Long> directorIds
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -98,4 +98,8 @@ public class AdminQuery {
             AdminCastsGetRequest adminCastsGetRequest) {
         return castRepository.getCasts(adminCastsGetRequest);
     }
+
+    public List<Director> saveAllDirectors(List<Director> directors) {
+        return directorRepository.saveAll(directors);
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -9,14 +9,17 @@ import com.example.udtbe.domain.admin.dto.request.AdminCastsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentGetsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetDetailResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentUpdateResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminDirectorsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.content.dto.CastMapper;
+import com.example.udtbe.domain.content.dto.DirectorMapper;
 import com.example.udtbe.domain.content.entity.Cast;
 import com.example.udtbe.domain.content.entity.Category;
 import com.example.udtbe.domain.content.entity.Content;
@@ -268,7 +271,7 @@ public class AdminService {
                 detail
         );
     }
-  
+
     @Transactional
     public AdminCastsRegisterResponse registerCasts(
             AdminCastsRegisterRequest adminCastsRegisterRequest) {
@@ -290,5 +293,23 @@ public class AdminService {
     public CursorPageResponse<AdminCastsGetResponse> getCasts(
             AdminCastsGetRequest adminCastsGetRequest) {
         return adminQuery.getCasts(adminCastsGetRequest);
+    }
+
+    public AdminDirectorsRegisterResponse registerDirectors(
+            AdminDirectorsRegisterRequest adminDirectorsRegisterRequest) {
+
+        List<Director> directors = new ArrayList<>();
+        adminDirectorsRegisterRequest.adminDirectorDTOS().stream()
+                .forEach(adminDirectorDTO -> directors.add(DirectorMapper.toDirector(
+                                adminDirectorDTO.directorName(),
+                                adminDirectorDTO.directorImageUrl()
+                        ))
+                );
+
+        List<Long> savedDirectors = adminQuery.saveAllDirectors(directors).stream()
+                .map(Director::getId)
+                .toList();
+
+        return new AdminDirectorsRegisterResponse(savedDirectors);
     }
 }

--- a/src/main/java/com/example/udtbe/domain/content/dto/DirectorMapper.java
+++ b/src/main/java/com/example/udtbe/domain/content/dto/DirectorMapper.java
@@ -1,0 +1,14 @@
+package com.example.udtbe.domain.content.dto;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.example.udtbe.domain.content.entity.Director;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class DirectorMapper {
+
+    public static Director toDirector(String directorName, String directorImageUrl) {
+        return Director.of(directorName, directorImageUrl);
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/entity/Director.java
+++ b/src/main/java/com/example/udtbe/domain/content/entity/Director.java
@@ -47,4 +47,12 @@ public class Director extends TimeBaseEntity {
                 .isDeleted(false)
                 .build();
     }
+
+    public static Director of(String directorName, String directorImageUrl) {
+        return Director.builder()
+                .directorName(directorName)
+                .directorImageUrl(directorImageUrl)
+                .isDeleted(false)
+                .build();
+    }
 }

--- a/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
@@ -17,14 +17,17 @@ import static org.mockito.Mockito.verify;
 import com.example.udtbe.common.fixture.MemberFixture;
 import com.example.udtbe.domain.admin.dto.common.AdminCastDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
+import com.example.udtbe.domain.admin.dto.common.AdminDirectorDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminCastsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentGetsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetDetailResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentGetResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminDirectorsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.admin.service.AdminQuery;
 import com.example.udtbe.domain.admin.service.AdminService;
@@ -528,7 +531,7 @@ public class AdminServiceTest {
         then(memberQuery).should().findMemberById(memberId);
         then(feedbackStatisticsQuery).should().findByMemberOrThrow(memberId);
     }
-  
+
     @DisplayName("여러 명의 출연진을 한번에 저장한다.")
     @Test
     void registerCasts() {
@@ -560,6 +563,42 @@ public class AdminServiceTest {
                         cast1.getId(),
                         cast2.getId(),
                         cast3.getId()
+                )
+        );
+    }
+
+    @DisplayName("여러 명의 감독을 한번에 저장한다.")
+    @Test
+    void registerDirectors() {
+        // given
+        final AdminDirectorDTO adminDirectorDTO1 = new AdminDirectorDTO("봉준호", "봉준호.image.com");
+        final AdminDirectorDTO adminDirectorDTO2 = new AdminDirectorDTO("박찬욱", "박찬욱.image.com");
+        final AdminDirectorDTO adminDirectorDTO3 = new AdminDirectorDTO("류승완", "류승완.image.com");
+        AdminDirectorsRegisterRequest request = new AdminDirectorsRegisterRequest(
+                List.of(adminDirectorDTO1, adminDirectorDTO2, adminDirectorDTO3)
+        );
+
+        Director director1 = mock(Director.class);
+        Director director2 = mock(Director.class);
+        Director director3 = mock(Director.class);
+
+        given(director1.getId()).willReturn(1L);
+        given(director2.getId()).willReturn(2L);
+        given(director3.getId()).willReturn(3L);
+
+        given(adminQuery.saveAllDirectors(any(List.class)))
+                .willReturn(List.of(director1, director2, director3));
+
+        // when
+        AdminDirectorsRegisterResponse response = adminService.registerDirectors(request);
+
+        // then
+        assertAll(
+                () -> verify(adminQuery).saveAllDirectors(any(List.class)),
+                () -> assertThat(response.directorIds()).containsExactly(
+                        director1.getId(),
+                        director2.getId(),
+                        director3.getId()
                 )
         );
     }


### PR DESCRIPTION
## 📝 요약(Summary)

- 관리자 감독 다건 등록 API 구현
 - 이전에 구현한 관리자 출연진 다건 등록 API와 동일하게 구현/테스트 되었습니다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
