### PR TITLE
fix/UDT-227-감독-출연진-이름-기반-조회-cursor-파싱-버그

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminCastsGetRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminCastsGetRequest.java
@@ -1,5 +1,6 @@
 package com.example.udtbe.domain.admin.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -14,6 +15,7 @@ public record AdminCastsGetRequest(
         Integer size
 ) {
 
+    @Schema(hidden = true)
     public int getSizeOrDefault() {
         return Objects.nonNull(size) ? size : 10;
     }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminDirectorsGetRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminDirectorsGetRequest.java
@@ -1,5 +1,6 @@
 package com.example.udtbe.domain.admin.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -14,6 +15,7 @@ public record AdminDirectorsGetRequest(
         Integer size
 ) {
 
+    @Schema(hidden = true)
     public int getSizeOrDefault() {
         return Objects.nonNull(size) ? size : 10;
     }

--- a/src/main/java/com/example/udtbe/domain/content/repository/CastQueryDSLImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/CastQueryDSLImpl.java
@@ -56,6 +56,7 @@ public class CastQueryDSLImpl implements CastQueryDSL {
 
     private BooleanExpression cursorFilter(String cursorId) {
         return Optional.ofNullable(cursorId)
+                .filter(StringUtils::hasText)
                 .map(Long::valueOf)
                 .map(cast.id::gt)
                 .orElse(null);

--- a/src/main/java/com/example/udtbe/domain/content/repository/DirectorQueryDSLImpl.java
+++ b/src/main/java/com/example/udtbe/domain/content/repository/DirectorQueryDSLImpl.java
@@ -57,6 +57,7 @@ public class DirectorQueryDSLImpl implements DirectorQueryDSL {
 
     private BooleanExpression cursorFilter(String cursorId) {
         return Optional.ofNullable(cursorId)
+                .filter(StringUtils::hasText)
                 .map(Long::valueOf)
                 .map(director.id::gt)
                 .orElse(null);


### PR DESCRIPTION
## 📝 요약(Summary)

- 감독/출연진 이름 기반 조회 API Cursor 파싱 버그 해결
  - 첫 조회(Cursor == null)일 때 `Long.valueOf`가 수행되어 오류 발생 -> `.filter(StringUtils::hasText)` 조건을 앞단에 추가하여 해결
- 감독/출연진 이름 기반 조회 API CustomSizeGetter Swagger Schema hidden 처리

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
