### PR TITLE
feat/UDT-216 콘텐츠 등록 수정 삭제 배치 및 스케줄러 자동 재시도

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -414,7 +414,7 @@ public class AdminService {
     }
 
     public AdminContentCategoryMetricResponse getContentCategoryMetric() {
-      return adminQuery.getContentCategoryMetric();
+        return adminQuery.getContentCategoryMetric();
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
+++ b/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
@@ -52,6 +52,7 @@ public class BatchConfig {
     private static final String REGISTER_STEP_READER = "contentRegisterReader";
     private static final String UPDATE_STEP_READER = "contentUpdateReader";
     private static final String DELETE_STEP_READER = "contentDeleteReader";
+    private static final int RETRY_LIMIT = 3;
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
@@ -99,6 +100,8 @@ public class BatchConfig {
                 .reader(contentRegisterReader())
                 .processor(contentRegisterProcessor())
                 .writer(contentRegisterWriter())
+                .faultTolerant()
+                .retryLimit(RETRY_LIMIT)
                 .listener(stepStatsListener)
                 .build();
     }
@@ -112,6 +115,8 @@ public class BatchConfig {
                 .reader(contentUpdateReader())
                 .processor(contentUpdateProcessor())
                 .writer(contentUpdateWriter())
+                .faultTolerant()
+                .retryLimit(RETRY_LIMIT)
                 .listener(stepStatsListener)
                 .build();
     }
@@ -125,6 +130,8 @@ public class BatchConfig {
                 .reader(contentDeleteReader())
                 .processor(contentDeleteProcessor())
                 .writer(contentDeleteWriter())
+                .faultTolerant()
+                .retryLimit(RETRY_LIMIT)
                 .listener(stepStatsListener)
                 .build();
     }

--- a/src/main/java/com/example/udtbe/domain/batch/exception/BatchErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/batch/exception/BatchErrorCode.java
@@ -10,7 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum BatchErrorCode implements ErrorCode {
 
     CURSOR_BAD_REQUEST(HttpStatus.BAD_REQUEST, "올바른 커서를 입력해주세요."),
-    ADMIN_CONTENT_JOB_METRIC(HttpStatus.NOT_FOUND, "배치 집계를 찾을 수 없습니다.");
+    ADMIN_CONTENT_JOB_METRIC(HttpStatus.NOT_FOUND, "배치 집계를 찾을 수 없습니다."),
+    BATCH_ALREADY_RUNNING(HttpStatus.CONFLICT, "해당 배치 작업이 이미 실행 중입니다."),
+    BATCH_RESTART_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "배치 작업 재시작에 실패했습니다."),
+    BATCH_ALREADY_COMPLETED(HttpStatus.CONFLICT, "해당 배치 인스턴스가 이미 완료되어 재실행할 수 없습니다."),
+    BATCH_INVALID_PARAMETERS(HttpStatus.BAD_REQUEST, "배치 작업에 잘못된 파라미터가 전달되었습니다."),
+    SCHEDULER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "스케줄러를 실행할 수 없습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/example/udtbe/batch/scheduler/AdminSchedulerTest.java
+++ b/src/test/java/com/example/udtbe/batch/scheduler/AdminSchedulerTest.java
@@ -1,25 +1,89 @@
 package com.example.udtbe.batch.scheduler;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
 import com.example.udtbe.domain.batch.scheduler.AdminScheduler;
 import com.example.udtbe.domain.content.service.LuceneIndexService;
+import com.example.udtbe.global.exception.RestApiException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ContextConfiguration;
 
 @ExtendWith(MockitoExtension.class)
+@EnableRetry
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@ContextConfiguration(classes = {AdminScheduler.class})
 class AdminSchedulerTest {
 
     @Mock
     private LuceneIndexService luceneIndexService;
 
+    @Mock
+    private JobLauncher jobLauncher;
+
+    @Mock
+    private Job contentBatchJob;
+
     @InjectMocks
     private AdminScheduler adminScheduler;
+
+    @Test
+    @DisplayName("성공적으로 잡을 실행한다")
+    void launchesTheJobSuccessfully() throws Exception {
+        // given
+        given(jobLauncher.run(any(Job.class), any(JobParameters.class)))
+                .willReturn(new JobExecution(1L));
+
+        // when
+        adminScheduler.runContentBatchJob();
+
+        // then
+        verify(jobLauncher).run(any(Job.class), any(JobParameters.class));
+    }
+
+    @Test
+    @DisplayName("이미 잡이 실행 중일 경우 예외를 던진다")
+    void throwsExceptionWhenJobIsAlreadyRunning() throws Exception {
+        // given
+        given(jobLauncher.run(any(Job.class), any(JobParameters.class)))
+                .willThrow(new JobExecutionAlreadyRunningException("Job is already running"));
+
+        // when & then
+        assertThrows(RestApiException.class, () -> {
+            adminScheduler.runContentBatchJob();
+        });
+        verify(jobLauncher).run(any(Job.class), any(JobParameters.class));
+    }
+
+    @Test
+    @DisplayName("잘못된 배치 작업 파라미터일 경우 예외를 던진다")
+    void throwsExceptionForInvalidJobParameters() throws Exception {
+        // given
+        given(jobLauncher.run(any(Job.class), any(JobParameters.class)))
+                .willThrow(new JobParametersInvalidException("Invalid job parameters"));
+
+        // when & then
+        assertThrows(RestApiException.class, () -> {
+            adminScheduler.runContentBatchJob();
+        });
+        verify(jobLauncher).run(any(Job.class), any(JobParameters.class));
+    }
 
     @Test
     @DisplayName("루씬 인덱스 리빌드 재시도 메서드가 정상 작동한다")


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

콘텐츠 등록 수정 삭제 배치 및 스케줄러 자동 재시도 로직 구현

- spring batch의 step마다 최대 3번 재시도
- 배치 scheduler에서 다음의 예외가 아닌 예외발생 시 스케줄러 최대 3번 재시도
```java
BATCH_ALREADY_RUNNING(HttpStatus.CONFLICT, "해당 배치 작업이 이미 실행 중입니다."),
BATCH_RESTART_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "배치 작업 재시작에 실패했습니다."),
BATCH_ALREADY_COMPLETED(HttpStatus.CONFLICT, "해당 배치 인스턴스가 이미 완료되어 재실행할 수 없습니다."),
BATCH_INVALID_PARAMETERS(HttpStatus.BAD_REQUEST, "배치 작업에 잘못된 파라미터가 전달되었습니다."),
```

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
