### PR TITLE
Feat/udt 231 topdocs cache rebuild

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -486,4 +486,12 @@ public class ContentRecommendationService {
         log.info("===== 캐싱된 추천 분석 완료 =====");
     }
 
+    public void clearMyRecommendationCache(Member member) {
+        Long memberId = member.getId();
+        boolean hadCache = cacheManager.hasCache(memberId);
+        if (hadCache) {
+            cacheManager.removeMemberCache(memberId);
+        }
+    }
+
 }

--- a/src/main/java/com/example/udtbe/domain/content/util/RecommendationCacheManager.java
+++ b/src/main/java/com/example/udtbe/domain/content/util/RecommendationCacheManager.java
@@ -39,16 +39,11 @@ public class RecommendationCacheManager {
         return cache != null && !cache.isExpired(EXPIRATION_HOURS);
     }
 
-    public void removeCache(Long memberId) {
+    public void removeMemberCache(Long memberId) {
         MemberRecommendationCache removed = memberCaches.remove(memberId);
         if (removed != null) {
             log.info("기본 추천 캐시 제거 완료: memberId={}", memberId);
         }
-    }
-
-    public void removeMemberCaches(Long memberId) {
-        removeCache(memberId);
-        log.info("사용자 캐시 제거 완료: memberId={}", memberId);
     }
 
     public void clearAllCaches() {

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.udtbe.domain.member.controller;
 
 import com.example.udtbe.domain.content.dto.request.CuratedContentListDeleteRequest;
+import com.example.udtbe.domain.content.service.ContentRecommendationService;
 import com.example.udtbe.domain.content.service.ContentService;
 import com.example.udtbe.domain.member.dto.request.MemberCuratedContentGetsRequest;
 import com.example.udtbe.domain.member.dto.request.MemberUpdateGenreRequest;
@@ -23,6 +24,7 @@ public class MemberController implements MemberControllerApiSpec {
 
     private final MemberService memberService;
     private final ContentService contentService;
+    private final ContentRecommendationService contentRecommendationService;
 
     @Override
     public ResponseEntity<MemberInfoResponse> getMemberInfo(Member member) {
@@ -62,6 +64,12 @@ public class MemberController implements MemberControllerApiSpec {
     public ResponseEntity<Void> deleteCuratedContents(CuratedContentListDeleteRequest request,
             Member member) {
         contentService.deleteCuratedContents(member.getId(), request.contentIds());
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> clearMyRecommendationCache(Member member) {
+        contentRecommendationService.clearMyRecommendationCache(member);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
@@ -11,6 +11,7 @@ import com.example.udtbe.domain.member.dto.response.MemberUpdatePlatformResponse
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -64,4 +66,18 @@ public interface MemberControllerApiSpec {
     ResponseEntity<Void> deleteCuratedContents(
             @RequestBody @Valid CuratedContentListDeleteRequest request,
             @AuthenticationPrincipal Member member);
+
+    @Operation(
+            summary = "개인 추천 캐시 클리어 API",
+            description = "내 추천 캐시를 클리어합니다. 다음 추천 요청 시 새로운 데이터로 계산됩니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "추천 캐시 클리어 성공"
+    )
+    @PostMapping("/users/me/recommendations/cache/clear")
+    ResponseEntity<Void> clearMyRecommendationCache(
+            @Parameter(description = "인증된 사용자 정보", required = true)
+            @AuthenticationPrincipal Member member
+    );
 }

--- a/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/member/controller/MemberControllerApiSpec.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -75,7 +74,7 @@ public interface MemberControllerApiSpec {
             responseCode = "200",
             description = "추천 캐시 클리어 성공"
     )
-    @PostMapping("/users/me/recommendations/cache/clear")
+    @DeleteMapping("/users/me/recommendations/cache/clear")
     ResponseEntity<Void> clearMyRecommendationCache(
             @Parameter(description = "인증된 사용자 정보", required = true)
             @AuthenticationPrincipal Member member

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -4,11 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.lenient;
 
 import com.example.udtbe.common.fixture.ContentFixture;
 import com.example.udtbe.common.fixture.ContentMetadataFixture;
@@ -89,7 +89,6 @@ class ContentRecommendationServiceTest {
         //테스트 멤버 기준으로 생성
         testSurvey = createTestSurvey();
 
-        // 캐시 매니저 기본 설정 - 캐시 없음 상태로 초기화 (lenient 설정으로 불필요한 스텁 허용)
         lenient().when(cacheManager.getCache(anyLong())).thenReturn(null);
     }
 

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import com.example.udtbe.common.fixture.ContentFixture;
 import com.example.udtbe.common.fixture.ContentMetadataFixture;
@@ -88,8 +89,8 @@ class ContentRecommendationServiceTest {
         //테스트 멤버 기준으로 생성
         testSurvey = createTestSurvey();
 
-        // 캐시 매니저 기본 설정 - 캐시 없음 상태로 초기화
-        when(cacheManager.getCache(anyLong())).thenReturn(null);
+        // 캐시 매니저 기본 설정 - 캐시 없음 상태로 초기화 (lenient 설정으로 불필요한 스텁 허용)
+        lenient().when(cacheManager.getCache(anyLong())).thenReturn(null);
     }
 
     @Test
@@ -297,5 +298,19 @@ class ContentRecommendationServiceTest {
         // 기본 피드백 데이터 (필요에 따라 각 테스트에서 오버라이드)
         when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
                 .thenReturn(new ArrayList<>());
+    }
+
+    @Test
+    @DisplayName("사용자 추천 캐시 삭제")
+    void shouldClearUserCache_WhenCacheExists() {
+        // given
+        when(cacheManager.hasCache(testMember.getId())).thenReturn(true);
+
+        // when
+        contentRecommendationService.clearMyRecommendationCache(testMember);
+
+        // then
+        verify(cacheManager).hasCache(testMember.getId());
+        verify(cacheManager).removeMemberCache(testMember.getId());
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)
사용자 설문조사 변경 시 개인 추천 캐시를 수동으로 삭제하는 API 추가

**변경사항:**
- `DELETE /users/me/recommendations/cache/clear` API 추가
- 캐시 삭제 로직 및 테스트 구현

**목적:** 설문조사 변경 후 기존 캐시로 인해 새로운 선호도가 반영되지 않는 문제 해결

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.

## 🤔 Review 예상 시간
- 5분