### PR TITLE
fix/UDT-238 배치 로직 오류 

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -1,5 +1,7 @@
 package com.example.udtbe.domain.admin.service;
 
+import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
+import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminCastsGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
@@ -48,6 +50,72 @@ public class AdminQuery {
     private final DirectorRepository directorRepository;
     private final CountryRepository countryRepository;
     private final JobMetricRepository jobMetricRepository;
+
+
+    public void validContentByContentId(Long contentId) {
+        Content content = contentRepository.findById(contentId).orElseThrow(()
+                -> new RestApiException(ContentErrorCode.CONTENT_NOT_FOUND)
+        );
+        if (content.isDeleted()) {
+            throw new RestApiException(ContentErrorCode.CONTENT_NOT_FOUND);
+        }
+    }
+
+    public void validRegisterAndUpdateContent(List<AdminCategoryDTO> categoryDTOs,
+            List<AdminPlatformDTO> platformDTOs,
+            List<Long> castIds, List<Long> directorIds) {
+
+        categoryDTOs.forEach(dto -> {
+            CategoryType categoryType = CategoryType.fromByType(dto.categoryType());
+            List<GenreType> genreTypes = dto.genres().stream().map(GenreType::fromByType).toList();
+            validCategoryByCategoryType(categoryType);
+            validGenreByCategoryTypeAndGenreTypes(categoryType, genreTypes);
+        });
+
+        platformDTOs.forEach(dto -> {
+            PlatformType platformType = PlatformType.fromByType(dto.platformType());
+            validPlatformByPlatformType(platformType);
+        });
+
+        castIds.forEach(this::validCastByCastId);
+        directorIds.forEach(this::validDirectorByDirectorId);
+    }
+
+    private void validCategoryByCategoryType(CategoryType categoryType) {
+        if (!categoryRepository.existsCategoryByCategoryType(categoryType)) {
+            throw new RestApiException(ContentErrorCode.CATEGORY_NOT_FOUND);
+        }
+    }
+
+    private void validGenreByCategoryTypeAndGenreTypes(CategoryType categoryType,
+            List<GenreType> genreTypes) {
+        genreTypes.forEach(genreType -> {
+            Category category = categoryRepository.findByCategoryType(categoryType).orElseThrow(()
+                    -> new RestApiException(ContentErrorCode.CATEGORY_NOT_FOUND)
+            );
+            if (!genreRepository.existsGenreByGenreTypeAndCategory(genreType, category)) {
+                throw new RestApiException(ContentErrorCode.GENRE_NOT_FOUND);
+            }
+        });
+    }
+
+    private void validPlatformByPlatformType(PlatformType platformType) {
+        if (!platformRepository.existsPlatformByPlatformType(platformType)) {
+            throw new RestApiException(ContentErrorCode.PLATFORM_NOT_FOUND);
+        }
+    }
+
+    private void validCastByCastId(Long castId) {
+        if (!castRepository.existsById(castId)) {
+            throw new RestApiException(ContentErrorCode.CAST_NOT_FOUND);
+        }
+    }
+
+    private void validDirectorByDirectorId(Long directorId) {
+        if (!directorRepository.existsById(directorId)) {
+            throw new RestApiException(ContentErrorCode.DIRECTOR_NOT_FOUND);
+        }
+    }
 
 
     public Content findContentByContentId(Long contentId) {
@@ -125,7 +193,7 @@ public class AdminQuery {
             AdminDirectorsGetRequest adminDirectorsGetRequest) {
         return directorRepository.getDirectors(adminDirectorsGetRequest);
     }
-  
+
     public BatchJobMetric findAdminContentJobMetric(BatchJobType batchJobType) {
         return jobMetricRepository.findAdminContentJobMetricByType(batchJobType)
                 .orElseThrow(()
@@ -136,5 +204,5 @@ public class AdminQuery {
     public AdminContentCategoryMetricResponse getContentCategoryMetric() {
         return contentRepository.getContentCategoryMetric();
     }
-     
+
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentDeleteJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentDeleteJobRepository.java
@@ -8,5 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AdminContentDeleteJobRepository extends
         JpaRepository<AdminContentDeleteJob, Long> {
 
-    List<AdminContentDeleteJob> findAllByStatus(BatchStatus status);
+
+    List<AdminContentDeleteJob> findByStatus(BatchStatus status);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentRegisterJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentRegisterJobRepository.java
@@ -9,5 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AdminContentRegisterJobRepository extends
         JpaRepository<AdminContentRegisterJob, Long> {
 
-    List<AdminContentRegisterJob> findAllByStatus(BatchStatus status);
+
+    List<AdminContentRegisterJob> findByStatus(BatchStatus status);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentUpdateJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentUpdateJobRepository.java
@@ -9,5 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AdminContentUpdateJobRepository extends
         JpaRepository<AdminContentUpdateJob, Long> {
 
-    List<AdminContentUpdateJob> findAllByStatus(BatchStatus status);
+
+    List<AdminContentUpdateJob> findByStatus(BatchStatus status);
 }


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<img width="262" height="880" alt="image" src="https://github.com/user-attachments/assets/2ea4abf4-80c4-4ee0-84ee-f2a4cb1d2ffa" />


10 청크 단위로 배치를 돌렸지만, 다음 청크가 실행되지 않고, 다다음 청크로 실행되는 문제

JpaPagingReader

1. Reader: status가 PENDING인 데이터를 DB에서 페이지 단위로 조회. (예: 1~5번째 아이템)
2. Processor/Writer: 조회된 아이템들의 status를 PROCESSING을 거쳐 COMPLETED 또는 FAILED로 변경하고 DB에 저장. → Commit
3. Reader (다음 페이지): 다음 페이지를 읽기 위해 다시 status가 PENDING인 데이터를 DB에 요청(6~10번째 아이템을 기대)
4. 문제 발생: 하지만 이전 Chunk에서 처리한 1~5번 아이템은 이미 status가 변경되어 PENDING 상태가 아님. 따라서 Reader가 보는 전체 데이터셋의 크기가 줄어들게 됩니다. 이로 인해 페이징 계산이 어긋나게 되고, 원래 6~10번째 순서였던 아이템들을 건너뛰고 그 이후의 데이터를 읽어오게 된다.

ListReader 로 데이터 가져와 해결, but CG가 많이 차지할 가능성이 있지만, 그 정도의 방대한 데이터를 넣는 것이 아니기 때문에 ListReader사용 → 이점 Offset방식이 아니기 때문에 빠르게 read할 수 있다.

---
<img width="1616" height="582" alt="image" src="https://github.com/user-attachments/assets/eba9b59c-c6ec-4883-8fc0-971aa6cb1edb" />

<img width="1622" height="522" alt="image" src="https://github.com/user-attachments/assets/d26a9469-e462-4414-923a-f2f5c2804821" />


실패한 작업이 그대로 저장이되는 문제 → 트랜잭션이 청크단위로 실행되기 때문에 작업의 write과정이 실행될 때마다 데이터 검증 로직을 추가해 해결!


만약 데이터가 변경되는 도중 서버가 끊기면? → 단위로 트랜잭션이 묶이기 때문에 진행중인 청크만 롤백!

<img width="1504" height="840" alt="image" src="https://github.com/user-attachments/assets/fe1e667b-e3df-4ee8-b7e3-067814ba042c" />

<img width="750" height="426" alt="스크린샷 2025-08-05 오전 12 26 30" src="https://github.com/user-attachments/assets/a3f09b7f-6674-488c-9ded-7d87ab6ab11f" />

39번은 성공하고 40번에서 서버를 강제로 껐음 → 청크 단위 만큼 롤백!

따라서 청크 사이즈를 조절하는 것이 좋아보임!

청크 사이즈가 많을 때: 트랜잭션이 많이 생기지  않아 성능은 좋아 짐 → 하지만, 오류가 나면 재시도 할 작업이 많아짐

청크 사이즈가 적을 때: 트랜잭션이 많이 생겨 속도 저하, 재시도 할 작업 적어짐


## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
