### PR TITLE
UDT-240 feat: 실패, 재시도 로깅 및 전략 개선

### DIFF
--- a/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
+++ b/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
@@ -10,12 +10,15 @@ import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
 import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
+import com.example.udtbe.domain.batch.lisener.BatchSkipListener;
 import com.example.udtbe.domain.batch.lisener.StepStatsListener;
 import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
+import com.example.udtbe.global.exception.RestApiException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.JobScope;
@@ -35,11 +38,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.StringUtils;
 
 @Configuration
 @EnableConfigurationProperties(BatchProperties.class)
+@Slf4j
 @RequiredArgsConstructor
 public class BatchConfig {
 
@@ -50,6 +55,7 @@ public class BatchConfig {
     public static final String FEEDBACK_STEP = "feedbackStep";
     private static final int CHUNK_SIZE = 5;
     private static final int RETRY_LIMIT = 3;
+    private static final int SKIP_LIMIT = 200;
 
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
@@ -59,7 +65,7 @@ public class BatchConfig {
     private final AdminContentRegisterJobRepository adminContentRegisterJobRepository;
     private final AdminContentDeleteJobRepository adminContentDeleteJobRepository;
     private final StepStatsListener stepStatsListener;
-
+    private final BatchSkipListener batchSkipListener;
 
     @Bean
     @ConditionalOnMissingBean
@@ -75,7 +81,6 @@ public class BatchConfig {
         }
         return runner;
     }
-
 
     @Bean
     public Job contentBatchJob() {
@@ -94,11 +99,14 @@ public class BatchConfig {
                         transactionManager)
                 .reader(contentRegisterReader())
                 .processor(contentRegisterProcessor())
-                .faultTolerant()
-                .retryLimit(RETRY_LIMIT)
-                .retry(Exception.class)
                 .writer(contentRegisterWriter())
+                .faultTolerant()
+                .skip(RestApiException.class)
+                .skipLimit(SKIP_LIMIT)
+                .retry(TransientDataAccessException.class)
+                .retryLimit(RETRY_LIMIT)
                 .listener(stepStatsListener)
+                .listener(batchSkipListener)
                 .build();
     }
 
@@ -106,15 +114,17 @@ public class BatchConfig {
     @JobScope
     public Step contentUpdateStep() {
         return new StepBuilder(UPDATE_STEP, jobRepository)
-                .<AdminContentUpdateJob, AdminContentUpdateJob>chunk(CHUNK_SIZE,
-                        transactionManager)
+                .<AdminContentUpdateJob, AdminContentUpdateJob>chunk(CHUNK_SIZE, transactionManager)
                 .reader(contentUpdateReader())
                 .processor(contentUpdateProcessor())
                 .writer(contentUpdateWriter())
                 .faultTolerant()
+                .skip(RestApiException.class)
+                .skipLimit(SKIP_LIMIT)
+                .retry(TransientDataAccessException.class)
                 .retryLimit(RETRY_LIMIT)
-                .retry(Exception.class)
                 .listener(stepStatsListener)
+                .listener(batchSkipListener)
                 .build();
     }
 
@@ -122,90 +132,89 @@ public class BatchConfig {
     @JobScope
     public Step contentDeleteStep() {
         return new StepBuilder(DELETE_STEP, jobRepository)
-                .<AdminContentDeleteJob, AdminContentDeleteJob>chunk(CHUNK_SIZE,
-                        transactionManager)
+                .<AdminContentDeleteJob, AdminContentDeleteJob>chunk(CHUNK_SIZE, transactionManager)
                 .reader(contentDeleteReader())
                 .processor(contentDeleteProcessor())
                 .writer(contentDeleteWriter())
                 .faultTolerant()
+                .skip(RestApiException.class)
+                .skipLimit(SKIP_LIMIT)
+                .retry(TransientDataAccessException.class)
                 .retryLimit(RETRY_LIMIT)
-                .retry(Exception.class)
                 .listener(stepStatsListener)
+                .listener(batchSkipListener)
                 .build();
     }
 
     @Bean
     @StepScope
     public ListItemReader<AdminContentRegisterJob> contentRegisterReader() {
-        List<AdminContentRegisterJob> pendingJobs = adminContentRegisterJobRepository.findByStatus(
-                BatchStatus.PENDING);
+        List<AdminContentRegisterJob> pendingJobs = adminContentRegisterJobRepository.findByStatusIn(
+                List.of(BatchStatus.PENDING, BatchStatus.FAILED, BatchStatus.RETRYING));
         return new ListItemReader<>(pendingJobs);
     }
 
     @Bean
     @StepScope
     public ListItemReader<AdminContentUpdateJob> contentUpdateReader() {
-        List<AdminContentUpdateJob> pendingJobs = adminContentUpdateJobRepository.findByStatus(
-                BatchStatus.PENDING);
+        List<AdminContentUpdateJob> pendingJobs = adminContentUpdateJobRepository.findByStatusIn(
+                List.of(BatchStatus.PENDING, BatchStatus.FAILED, BatchStatus.RETRYING));
         return new ListItemReader<>(pendingJobs);
     }
 
     @Bean
     @StepScope
     public ListItemReader<AdminContentDeleteJob> contentDeleteReader() {
-        List<AdminContentDeleteJob> pendingJobs = adminContentDeleteJobRepository.findByStatus(
-                BatchStatus.PENDING);
+        List<AdminContentDeleteJob> pendingJobs = adminContentDeleteJobRepository.findByStatusIn(
+                List.of(BatchStatus.PENDING, BatchStatus.FAILED, BatchStatus.RETRYING));
         return new ListItemReader<>(pendingJobs);
     }
 
     @Bean
     @StepScope
     public ItemProcessor<AdminContentRegisterJob, AdminContentRegisterJob> contentRegisterProcessor() {
-        return request -> {
-            request.changeStatus(BatchStatus.PROCESSING);
-            return request;
-        };
+        return item -> item;
     }
 
     @Bean
     @StepScope
     public ItemProcessor<AdminContentUpdateJob, AdminContentUpdateJob> contentUpdateProcessor() {
-        return request -> {
-            request.changeStatus(BatchStatus.PROCESSING);
-            return request;
-        };
+        return item -> item;
     }
 
     @Bean
     @StepScope
     public ItemProcessor<AdminContentDeleteJob, AdminContentDeleteJob> contentDeleteProcessor() {
-        return request -> {
-            request.changeStatus(BatchStatus.PROCESSING);
-            return request;
-        };
+        return item -> item;
     }
 
     @Bean
     @StepScope
     public ItemWriter<AdminContentRegisterJob> contentRegisterWriter() {
         return items -> {
-            items.forEach(item -> {
-
+            for (AdminContentRegisterJob item : items) {
                 try {
+                    item.changeStatus(BatchStatus.PROCESSING);
+                    adminContentRegisterJobRepository.save(item);
+
                     AdminContentRegisterRequest request = AdminContentMapper.toContentRegisterRequest(
                             item);
                     adminQuery.validRegisterAndUpdateContent(request.categories(),
-                            request.platforms(), request.casts(), request.directors());
+                            request.platforms(),
+                            request.casts(), request.directors());
                     adminService.registerContent(request);
+
                     item.changeStatus(BatchStatus.COMPLETED);
                     item.finish();
                     adminContentRegisterJobRepository.save(item);
                 } catch (Exception e) {
                     item.changeStatus(BatchStatus.FAILED);
-                    item.finish();
+                    item.setError("REGISTER_ERROR", e.getMessage());
+                    item.incrementRetryCount();
                     adminContentRegisterJobRepository.save(item);
+                    throw e;
                 }
-            });
+            }
         };
     }
 
@@ -213,23 +222,30 @@ public class BatchConfig {
     @StepScope
     public ItemWriter<AdminContentUpdateJob> contentUpdateWriter() {
         return items -> {
-            items.forEach(item -> {
+            for (AdminContentUpdateJob item : items) {
                 try {
+                    item.changeStatus(BatchStatus.PROCESSING);
+                    adminContentUpdateJobRepository.save(item);
+
                     AdminContentUpdateRequest request = AdminContentMapper.toContentUpdateRequest(
                             item);
                     adminQuery.validContentByContentId(item.getContentId());
                     adminQuery.validRegisterAndUpdateContent(request.categories(),
-                            request.platforms(), request.casts(), request.directors());
+                            request.platforms(),
+                            request.casts(), request.directors());
                     adminService.updateContent(item.getContentId(), request);
+
                     item.changeStatus(BatchStatus.COMPLETED);
                     item.finish();
                     adminContentUpdateJobRepository.save(item);
                 } catch (Exception e) {
                     item.changeStatus(BatchStatus.FAILED);
-                    item.finish();
+                    item.setError("UPDATE_ERROR", e.getMessage());
+                    item.incrementRetryCount();
                     adminContentUpdateJobRepository.save(item);
+                    throw e;
                 }
-            });
+            }
         };
     }
 
@@ -237,20 +253,25 @@ public class BatchConfig {
     @StepScope
     public ItemWriter<AdminContentDeleteJob> contentDeleteWriter() {
         return items -> {
-            items.forEach(item -> {
+            for (AdminContentDeleteJob item : items) {
                 try {
+                    item.changeStatus(BatchStatus.PROCESSING);
+                    adminContentDeleteJobRepository.save(item);
+
                     adminQuery.validContentByContentId(item.getContentId());
                     adminService.deleteContent(item.getContentId());
+
                     item.changeStatus(BatchStatus.COMPLETED);
                     item.finish();
                     adminContentDeleteJobRepository.save(item);
                 } catch (Exception e) {
                     item.changeStatus(BatchStatus.FAILED);
-                    item.finish();
+                    item.setError("DELETE_ERROR", e.getMessage());
+                    item.incrementRetryCount();
                     adminContentDeleteJobRepository.save(item);
+                    throw e;
                 }
-            });
+            }
         };
     }
 }
-

--- a/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
+++ b/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
@@ -53,7 +53,7 @@ public class BatchConfig {
     public static final String UPDATE_STEP = "contentUpdateStep";
     public static final String DELETE_STEP = "contentDeleteStep";
     public static final String FEEDBACK_STEP = "feedbackStep";
-    private static final int CHUNK_SIZE = 5;
+    private static final int CHUNK_SIZE = 100;
     private static final int RETRY_LIMIT = 3;
     private static final int SKIP_LIMIT = 200;
 

--- a/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentDeleteJob.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentDeleteJob.java
@@ -40,6 +40,13 @@ public class AdminContentDeleteJob extends TimeBaseEntity {
 
     private Long contentId;
 
+    private String errorCode;
+
+    private String errorMessage;
+
+    private Integer retryCount = 0;
+
+    private Integer skipCount = 0;
 
     @Builder(access = PRIVATE)
     private AdminContentDeleteJob(BatchStatus status, LocalDateTime scheduledAt, Long memberId,
@@ -48,6 +55,8 @@ public class AdminContentDeleteJob extends TimeBaseEntity {
         this.scheduledAt = scheduledAt;
         this.memberId = memberId;
         this.contentId = contentId;
+        this.retryCount = 0;
+        this.skipCount = 0;
     }
 
     public static AdminContentDeleteJob of(BatchStatus status, Long memberId, Long contentId) {
@@ -63,6 +72,26 @@ public class AdminContentDeleteJob extends TimeBaseEntity {
         this.status = status;
     }
 
+    public void setError(String errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount = (this.retryCount == null ? 0 : this.retryCount) + 1;
+    }
+
+    public void resetRetryCount() {
+        this.retryCount = 0;
+    }
+
+    public void incrementSkipCount() {
+        this.skipCount = (this.skipCount == null ? 0 : this.skipCount) + 1;
+    }
+
+    public void resetSkipCount() {
+        this.skipCount = 0;
+    }
 
     private static LocalDateTime getScheduledAt() {
         return TimeUtil.getScheduledAt();

--- a/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentRegisterJob.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentRegisterJob.java
@@ -86,6 +86,14 @@ public class AdminContentRegisterJob extends TimeBaseEntity {
     @Column(name = "countries")
     private List<String> countries;
 
+    private String errorCode;
+
+    private String errorMessage;
+
+    private Integer retryCount = 0;
+
+    private Integer skipCount = 0;
+
     @Builder(access = PRIVATE)
     private AdminContentRegisterJob(BatchStatus status, Long memberId,
             LocalDateTime scheduledAt,
@@ -112,6 +120,8 @@ public class AdminContentRegisterJob extends TimeBaseEntity {
         this.directors = directors;
         this.casts = casts;
         this.countries = countries;
+        this.retryCount = 0;
+        this.skipCount = 0;
     }
 
     public static AdminContentRegisterJob of(BatchStatus batchStepStatus, Long memberId,
@@ -142,6 +152,27 @@ public class AdminContentRegisterJob extends TimeBaseEntity {
 
     public void changeStatus(BatchStatus status) {
         this.status = status;
+    }
+
+    public void setError(String errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount = (this.retryCount == null ? 0 : this.retryCount) + 1;
+    }
+
+    public void resetRetryCount() {
+        this.retryCount = 0;
+    }
+
+    public void incrementSkipCount() {
+        this.skipCount = (this.skipCount == null ? 0 : this.skipCount) + 1;
+    }
+
+    public void resetSkipCount() {
+        this.skipCount = 0;
     }
 
     private static LocalDateTime getScheduledAt() {

--- a/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentUpdateJob.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentUpdateJob.java
@@ -88,6 +88,14 @@ public class AdminContentUpdateJob extends TimeBaseEntity {
     @Column(name = "countries")
     private List<String> countries;
 
+    private String errorCode;
+
+    private String errorMessage;
+
+    private Integer retryCount = 0;
+
+    private Integer skipCount = 0;
+
     @Builder(access = PRIVATE)
     private AdminContentUpdateJob(BatchStatus status, LocalDateTime scheduledAt,
             Long memberId,
@@ -114,6 +122,8 @@ public class AdminContentUpdateJob extends TimeBaseEntity {
         this.directors = directors;
         this.casts = casts;
         this.countries = countries;
+        this.retryCount = 0;
+        this.skipCount = 0;
     }
 
     public static AdminContentUpdateJob of(BatchStatus status, Long memberId,
@@ -147,6 +157,27 @@ public class AdminContentUpdateJob extends TimeBaseEntity {
 
     public void changeStatus(BatchStatus status) {
         this.status = status;
+    }
+
+    public void setError(String errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount = (this.retryCount == null ? 0 : this.retryCount) + 1;
+    }
+
+    public void resetRetryCount() {
+        this.retryCount = 0;
+    }
+
+    public void incrementSkipCount() {
+        this.skipCount = (this.skipCount == null ? 0 : this.skipCount) + 1;
+    }
+
+    public void resetSkipCount() {
+        this.skipCount = 0;
     }
 
     private static LocalDateTime getScheduledAt() {

--- a/src/main/java/com/example/udtbe/domain/batch/entity/enums/BatchStatus.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/enums/BatchStatus.java
@@ -5,7 +5,7 @@ import com.example.udtbe.global.exception.code.EnumErrorCode;
 import java.util.Arrays;
 
 public enum BatchStatus {
-    PENDING, PROCESSING, COMPLETED, FAILED;
+    PENDING, PROCESSING, COMPLETED, FAILED, SKIPPED, RETRYING;
 
     public static BatchStatus from(String value) {
         return Arrays.stream(values())

--- a/src/main/java/com/example/udtbe/domain/batch/exception/BatchErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/batch/exception/BatchErrorCode.java
@@ -1,6 +1,8 @@
 package com.example.udtbe.domain.batch.exception;
 
+import com.example.udtbe.domain.content.exception.ContentErrorCode;
 import com.example.udtbe.global.exception.ErrorCode;
+import com.example.udtbe.global.exception.RestApiException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,9 +17,107 @@ public enum BatchErrorCode implements ErrorCode {
     BATCH_RESTART_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "배치 작업 재시작에 실패했습니다."),
     BATCH_ALREADY_COMPLETED(HttpStatus.CONFLICT, "해당 배치 인스턴스가 이미 완료되어 재실행할 수 없습니다."),
     BATCH_INVALID_PARAMETERS(HttpStatus.BAD_REQUEST, "배치 작업에 잘못된 파라미터가 전달되었습니다."),
-    SCHEDULER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "스케줄러를 실행할 수 없습니다.");
+    SCHEDULER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "스케줄러를 실행할 수 없습니다."),
+    
+    // Skip 대상 에러 (비즈니스 로직 에러)
+    BUSINESS_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "비즈니스 유효성 검증 실패"),
+    CONTENT_NOT_FOUND_SKIP(HttpStatus.NOT_FOUND, "콘텐츠를 찾을 수 없음 (스킵)"),
+    INVALID_DATA_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 데이터 형식"),
+    CATEGORY_NOT_FOUND_SKIP(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없음 (스킵)"),
+    PLATFORM_NOT_FOUND_SKIP(HttpStatus.NOT_FOUND, "플랫폼을 찾을 수 없음 (스킵)"),
+    CAST_NOT_FOUND_SKIP(HttpStatus.NOT_FOUND, "캐스트를 찾을 수 없음 (스킵)"),
+    DIRECTOR_NOT_FOUND_SKIP(HttpStatus.NOT_FOUND, "감독을 찾을 수 없음 (스킵)"),
+    DUPLICATE_CONTENT(HttpStatus.CONFLICT, "중복된 콘텐츠 (스킵)"),
+    
+    // Retry 대상 에러 (인프라/일시적 에러)
+    DATABASE_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "데이터베이스 연결 실패 (재시도)"),
+    DATABASE_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "데이터베이스 타임아웃 (재시도)"),
+    EXTERNAL_API_TIMEOUT(HttpStatus.SERVICE_UNAVAILABLE, "외부 API 타임아웃 (재시도)"),
+    NETWORK_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "네트워크 오류 (재시도)"),
+    TEMPORARY_SYSTEM_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "일시적 시스템 오류 (재시도)"),
+    LOCK_ACQUISITION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "락 획득 실패 (재시도)"),
+    
+    // 재시작 필요 에러 (심각한 시스템 에러)  
+    SYSTEM_OUT_OF_MEMORY(HttpStatus.INTERNAL_SERVER_ERROR, "시스템 메모리 부족 (재시작 필요)"),
+    DISK_SPACE_FULL(HttpStatus.INTERNAL_SERVER_ERROR, "디스크 공간 부족 (재시작 필요)"),
+    SYSTEM_SHUTDOWN(HttpStatus.INTERNAL_SERVER_ERROR, "시스템 종료 (재시작 필요)"),
+    CRITICAL_SYSTEM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "심각한 시스템 오류 (재시작 필요)");
 
 
     private final HttpStatus httpStatus;
     private final String message;
+    
+    public boolean isSkippable() {
+        return this.ordinal() >= BUSINESS_VALIDATION_FAILED.ordinal() 
+               && this.ordinal() <= DUPLICATE_CONTENT.ordinal();
+    }
+    
+    public boolean isRetryable() {
+        return this.ordinal() >= DATABASE_CONNECTION_FAILED.ordinal() 
+               && this.ordinal() <= LOCK_ACQUISITION_FAILED.ordinal();
+    }
+    
+    public boolean requiresRestart() {
+        return this.ordinal() >= SYSTEM_OUT_OF_MEMORY.ordinal();
+    }
+    
+    public static BatchErrorCode fromException(Exception e) {
+        String message = e.getMessage();
+        String className = e.getClass().getSimpleName();
+        
+        // RestApiException의 ContentErrorCode 매핑
+        if (e instanceof RestApiException) {
+            RestApiException restApiException = (RestApiException) e;
+            ErrorCode errorCode = restApiException.getErrorCode();
+            
+            if (errorCode == ContentErrorCode.CONTENT_NOT_FOUND) {
+                return CONTENT_NOT_FOUND_SKIP;
+            }
+            if (errorCode == ContentErrorCode.CATEGORY_NOT_FOUND || errorCode == ContentErrorCode.GENRE_NOT_FOUND) {
+                return CATEGORY_NOT_FOUND_SKIP;
+            }
+            if (errorCode == ContentErrorCode.PLATFORM_NOT_FOUND) {
+                return PLATFORM_NOT_FOUND_SKIP;
+            }
+            if (errorCode == ContentErrorCode.CAST_NOT_FOUND) {
+                return CAST_NOT_FOUND_SKIP;
+            }
+            if (errorCode == ContentErrorCode.DIRECTOR_NOT_FOUND) {
+                return DIRECTOR_NOT_FOUND_SKIP;
+            }
+            if (errorCode == ContentErrorCode.ALREADY_CURATED_CONTENT) {
+                return DUPLICATE_CONTENT;
+            }
+            
+            // 기타 비즈니스 에러
+            return BUSINESS_VALIDATION_FAILED;
+        }
+        
+        // 일반적인 에러 매핑
+        if (message != null && message.contains("not found")) {
+            return CONTENT_NOT_FOUND_SKIP;
+        }
+        if (message != null && message.contains("duplicate")) {
+            return DUPLICATE_CONTENT;
+        }
+        
+        // 인프라 에러 매핑
+        if (className.contains("Timeout") || message != null && message.contains("timeout")) {
+            return DATABASE_TIMEOUT;
+        }
+        if (className.contains("Connection") || message != null && message.contains("connection")) {
+            return DATABASE_CONNECTION_FAILED;
+        }
+        if (className.contains("Network") || message != null && message.contains("network")) {
+            return NETWORK_ERROR;
+        }
+        
+        // 시스템 에러 매핑
+        if (className.contains("OutOfMemory") || message != null && message.contains("memory")) {
+            return SYSTEM_OUT_OF_MEMORY;
+        }
+        
+        // 기본값
+        return TEMPORARY_SYSTEM_ERROR;
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/batch/lisener/BatchSkipListener.java
+++ b/src/main/java/com/example/udtbe/domain/batch/lisener/BatchSkipListener.java
@@ -1,0 +1,56 @@
+package com.example.udtbe.domain.batch.lisener;
+
+import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
+import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
+import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
+import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
+import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
+import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
+import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.SkipListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BatchSkipListener implements SkipListener<Object, Object> {
+
+    private final AdminContentRegisterJobRepository adminContentRegisterJobRepository;
+    private final AdminContentUpdateJobRepository adminContentUpdateJobRepository;
+    private final AdminContentDeleteJobRepository adminContentDeleteJobRepository;
+
+    @Override
+    public void onSkipInWrite(Object item, Throwable t) {
+        log.error("🚨 SKIP LISTENER CALLED - onSkipInWrite: item={}, exception={}", item,
+                t.getMessage());
+
+        if (item instanceof AdminContentRegisterJob registerJob) {
+            registerJob.changeStatus(BatchStatus.FAILED);
+            adminContentRegisterJobRepository.save(registerJob);
+        } else if (item instanceof AdminContentUpdateJob updateJob) {
+            updateJob.changeStatus(BatchStatus.FAILED);
+            adminContentUpdateJobRepository.save(updateJob);
+        } else if (item instanceof AdminContentDeleteJob deleteJob) {
+            deleteJob.changeStatus(BatchStatus.FAILED);
+            adminContentDeleteJobRepository.save(deleteJob);
+        }
+    }
+
+    @Override
+    public void onSkipInProcess(Object item, Throwable t) {
+        log.warn("Item skipped in process phase: {}, reason: {}", item, t.getMessage());
+
+        if (item instanceof AdminContentRegisterJob registerJob) {
+            registerJob.changeStatus(BatchStatus.FAILED);
+            adminContentRegisterJobRepository.save(registerJob);
+        } else if (item instanceof AdminContentUpdateJob updateJob) {
+            updateJob.changeStatus(BatchStatus.FAILED);
+            adminContentUpdateJobRepository.save(updateJob);
+        } else if (item instanceof AdminContentDeleteJob deleteJob) {
+            deleteJob.changeStatus(BatchStatus.FAILED);
+            adminContentDeleteJobRepository.save(deleteJob);
+        }
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/batch/lisener/StepStatsListener.java
+++ b/src/main/java/com/example/udtbe/domain/batch/lisener/StepStatsListener.java
@@ -5,7 +5,9 @@ import com.example.udtbe.domain.batch.config.BatchConfig;
 import com.example.udtbe.domain.batch.entity.BatchJobMetric;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobStatus;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
+import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
@@ -13,38 +15,40 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class StepStatsListener implements StepExecutionListener {
 
     private final AdminService adminService;
 
     @Override
-    public ExitStatus afterStep(StepExecution stepExecution) {
-        BatchJobType batchJobType = BatchJobType.REGISTER;
-        BatchJobStatus batchJobStatus = BatchJobStatus.NOOP;
+    public void beforeStep(StepExecution stepExecution) {
+        log.info("===== Step 시작: {} =====", stepExecution.getStepName());
+        log.info("Job ID: {}, Job Instance ID: {}",
+                stepExecution.getJobExecutionId(),
+                stepExecution.getJobExecution().getJobInstance().getId());
+    }
 
-        if (stepExecution.getStepName().equals(BatchConfig.REGISTER_STEP)) {
-            batchJobType = BatchJobType.REGISTER;
-        } else if (stepExecution.getStepName().equals(BatchConfig.UPDATE_STEP)) {
-            batchJobType = BatchJobType.UPDATE;
-        } else if (stepExecution.getStepName().equals(BatchConfig.DELETE_STEP)) {
-            batchJobType = BatchJobType.DELETE;
-        } else if (stepExecution.getStepName().equals(BatchConfig.FEEDBACK_STEP)) {
-            batchJobType = BatchJobType.FEEDBACK;
-        }
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        BatchJobType batchJobType = determineBatchJobType(stepExecution.getStepName());
 
         long totalRead = stepExecution.getReadCount();
         long totalWrite = stepExecution.getWriteCount();
         long totalSkip = stepExecution.getSkipCount();
+        long processCount = stepExecution.getProcessSkipCount();
+        long readSkip = stepExecution.getReadSkipCount();
+        long writeSkip = stepExecution.getWriteSkipCount();
+        long rollbackCount = stepExecution.getRollbackCount();
+        long commitCount = stepExecution.getCommitCount();
 
-        if (totalRead == 0) {
-            batchJobStatus = BatchJobStatus.NOOP;
-        } else if (totalWrite < 0 || totalSkip > 0) {
-            batchJobStatus = BatchJobStatus.PARTIAL_COMPLETED;
-        } else if (totalSkip == 0) {
-            batchJobStatus = BatchJobStatus.COMPLETED;
-        } else if (totalWrite == 0) {
-            batchJobStatus = BatchJobStatus.FAILED;
-        }
+        // 상세 통계 로깅
+        logDetailedStats(stepExecution, totalRead, totalWrite, totalSkip,
+                processCount, readSkip, writeSkip, rollbackCount, commitCount);
+
+        BatchJobStatus batchJobStatus = determineBatchJobStatus(totalRead, totalWrite, totalSkip);
+
+        // 에러 정보 로깅
+        logFailureExceptions(stepExecution);
 
         BatchJobMetric metric = BatchJobMetric.of(
                 stepExecution.getJobExecutionId(),
@@ -58,6 +62,72 @@ public class StepStatsListener implements StepExecutionListener {
         );
 
         adminService.updateMetric(metric);
+
+        log.info("===== Step 완료: {} =====", stepExecution.getStepName());
         return stepExecution.getExitStatus();
+    }
+
+    private BatchJobType determineBatchJobType(String stepName) {
+        if (stepName.equals(BatchConfig.REGISTER_STEP)) {
+            return BatchJobType.REGISTER;
+        } else if (stepName.equals(BatchConfig.UPDATE_STEP)) {
+            return BatchJobType.UPDATE;
+        } else if (stepName.equals(BatchConfig.DELETE_STEP)) {
+            return BatchJobType.DELETE;
+        }
+        return BatchJobType.REGISTER; // 기본값
+    }
+
+    private BatchJobStatus determineBatchJobStatus(long totalRead, long totalWrite,
+            long totalSkip) {
+        if (totalRead == 0) {
+            return BatchJobStatus.NOOP;
+        } else if (totalWrite < 0 || totalSkip > 0) {
+            return BatchJobStatus.PARTIAL_COMPLETED;
+        } else if (totalSkip == 0) {
+            return BatchJobStatus.COMPLETED;
+        } else if (totalWrite == 0) {
+            return BatchJobStatus.FAILED;
+        }
+        return BatchJobStatus.PARTIAL_COMPLETED; // 기본값
+    }
+
+    private void logDetailedStats(StepExecution stepExecution, long totalRead, long totalWrite,
+            long totalSkip, long processCount, long readSkip, long writeSkip,
+            long rollbackCount, long commitCount) {
+
+        log.info(" Step 실행 통계 - {}", stepExecution.getStepName());
+        log.info("  ├─ 읽기: {} 건", totalRead);
+        log.info("  ├─ 쓰기: {} 건", totalWrite);
+        log.info("  ├─ 전체 스킵: {} 건", totalSkip);
+        log.info("  ├─ 처리 스킵: {} 건", processCount);
+        log.info("  ├─ 읽기 스킵: {} 건", readSkip);
+        log.info("  ├─ 쓰기 스킵: {} 건", writeSkip);
+        log.info("  ├─ 롤백: {} 회", rollbackCount);
+        log.info("  ├─ 커밋: {} 회", commitCount);
+        long executionTime =
+                stepExecution.getEndTime() != null && stepExecution.getStartTime() != null
+                        ? ChronoUnit.MILLIS.between(stepExecution.getStartTime(),
+                        stepExecution.getEndTime())
+                        : 0L;
+        log.info("  ├─ 실행 시간: {}ms", executionTime);
+        log.info("  └─ 종료 상태: {}", stepExecution.getExitStatus().getExitCode());
+
+        // 성공률 계산
+        if (totalRead > 0) {
+            double successRate = ((double) totalWrite / totalRead) * 100;
+            double skipRate = ((double) totalSkip / totalRead) * 100;
+            log.info("배치 성공률: {}%, 스킵률: {}%", String.format("%.2f", successRate),
+                    String.format("%.2f", skipRate));
+        }
+    }
+
+    private void logFailureExceptions(StepExecution stepExecution) {
+        if (!stepExecution.getFailureExceptions().isEmpty()) {
+            log.error("!!Step 실행 중 발생한 예외들!!:");
+            stepExecution.getFailureExceptions().forEach(ex ->
+                    log.error("  └─ {}: {}", ex.getClass().getSimpleName(), ex.getMessage())
+            );
+        }
     }
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentDeleteJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentDeleteJobRepository.java
@@ -10,4 +10,6 @@ public interface AdminContentDeleteJobRepository extends
 
 
     List<AdminContentDeleteJob> findByStatus(BatchStatus status);
+    
+    List<AdminContentDeleteJob> findByStatusIn(List<BatchStatus> statuses);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentJobRepositoryImpl.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentJobRepositoryImpl.java
@@ -13,11 +13,13 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
+@Slf4j
 public class AdminContentJobRepositoryImpl implements AdminContentJobRepositoryCustom {
 
     @PersistenceContext
@@ -51,15 +53,15 @@ public class AdminContentJobRepositoryImpl implements AdminContentJobRepositoryC
         }
 
         String sql = """
-                SELECT id, status, member_id, created_at, update_at, finished_at, job_type
+                SELECT id, status, member_id, created_at, updated_at, finished_at, job_type
                 FROM (
-                    SELECT admin_content_register_job_id AS id, status, member_id, created_at, update_at, finished_at, 'REGISTER' AS job_type
+                    SELECT admin_content_register_job_id AS id, status, member_id, created_at, updated_at, finished_at, 'REGISTER' AS job_type
                     FROM admin_content_register_job
                     UNION ALL
-                    SELECT admin_content_update_job_id AS id, status, member_id, created_at, update_at, finished_at, 'UPDATE' AS job_type
+                    SELECT admin_content_update_job_id AS id, status, member_id, created_at, updated_at, finished_at, 'UPDATE' AS job_type
                     FROM admin_content_update_job
                     UNION ALL
-                    SELECT admin_content_delete_job_id AS id, status, member_id, created_at, update_at, finished_at, 'DELETE' AS job_type
+                    SELECT admin_content_delete_job_id AS id, status, member_id, created_at, updated_at, finished_at, 'DELETE' AS job_type
                     FROM admin_content_delete_job
                 ) AS jobs
                 WHERE (

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentRegisterJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentRegisterJobRepository.java
@@ -11,4 +11,6 @@ public interface AdminContentRegisterJobRepository extends
 
 
     List<AdminContentRegisterJob> findByStatus(BatchStatus status);
+    
+    List<AdminContentRegisterJob> findByStatusIn(List<BatchStatus> statuses);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentUpdateJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentUpdateJobRepository.java
@@ -11,4 +11,6 @@ public interface AdminContentUpdateJobRepository extends
 
 
     List<AdminContentUpdateJob> findByStatus(BatchStatus status);
+    
+    List<AdminContentUpdateJob> findByStatusIn(List<BatchStatus> statuses);
 }


### PR DESCRIPTION
## 📝 요약(Summary)
Spring Batch 배치 시스템의 실패 처리 및 재시도 전략을 개선했습니다.

**주요 변경사항:**
- **Skip/Retry 전략 도입**: RestApiException은 Skip, TransientDataAccessException은 Retry로 분류하여 처리
- **실패 추적 강화**: Job 엔티티에 errorCode, errorMessage, retryCount, skipCount 필드 추가로 상세한 실패 정보 

수집
- **BatchSkipListener 추가**: Skip 발생 시 로깅 및 상태 업데이트 자동화
- **StepStatsListener 개선**: 성공률, 스킵률, 상세 실행 통계를 포함한 배치 모니터링 강화
- **BatchStatus 확장**: SKIPPED, RETRYING 상태 추가로 더 정교한 상태 관리
- **실패/재시도 Job 재처리**: Reader에서 FAILED, RETRYING 상태의 Job도 함께 읽어와 재처리 가능

**기술적 선택 이유:**
- **ListItemReader 사용**: JpaPagingReader의 페이징 건너뛰기 문제 해결 (status 변경으로 인한 데이터셋 크기 변화)
- **Writer에서 예외 재throw**: Spring Batch의 Skip/Retry 메커니즘이 정상 작동하도록 함

## 💬 공유사항 to 리뷰어
**중점 검토 부분:**
1. **예외 분류 전략**: RestApiException → Skip, TransientDataAccessException → Retry로 구분한 것이 적절한지
2. **ListItemReader 사용**: 메모리 사용량 관점에서 문제없는 수준인지 (현재 데이터 규모 고려)
3. **BatchSkipListener 구현**: Skip 시 상태 업데이트 로직이 적절한지
4. **에러 추적 필드**: errorCode, errorMessage, retryCount 등의 필드명과 구조

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 15분

**추가 검토 포인트:**
- BatchSkipListener의 onSkipInWrite/onSkipInProcess 구현
- StepStatsListener의 상세 통계 로깅 로직
- 새로 추가된 BatchStatus(SKIPPED, RETRYING) 활용도