### PR TITLE
feat/UDT-250-백오피스-로그인

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
@@ -9,6 +9,7 @@ import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminMemberListGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentsRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminSinginRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentCategoryMetricResponse;
@@ -24,10 +25,12 @@ import com.example.udtbe.domain.admin.dto.response.AdminMembersGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentMetricGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultResponse;
+import com.example.udtbe.domain.admin.service.AdminAuthService;
 import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.domain.batch.scheduler.AdminScheduler;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -40,6 +43,7 @@ public class AdminController implements AdminControllerApiSpec {
 
     private final AdminService adminService;
     private final AdminScheduler adminScheduler;
+    private final AdminAuthService adminAuthService;
 
     @Override
     public ResponseEntity<AdminContentRegisterResponse> registerContent(Member memeber,
@@ -143,7 +147,7 @@ public class AdminController implements AdminControllerApiSpec {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(adminContentJobGetResponseCursorPageResponse);
     }
-  
+
     @Override
     public ResponseEntity<AdminContentCategoryMetricResponse> getContentCategoryMetric() {
         AdminContentCategoryMetricResponse response = adminService.getContentCategoryMetric();
@@ -163,4 +167,9 @@ public class AdminController implements AdminControllerApiSpec {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Override
+    public ResponseEntity<Void> signin(AdminSinginRequest request, HttpServletResponse response) {
+        adminAuthService.signin(request, response);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
@@ -9,6 +9,7 @@ import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminMemberListGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentsRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminSinginRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentCategoryMetricResponse;
@@ -30,6 +31,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -178,12 +180,18 @@ public interface AdminControllerApiSpec {
     @GetMapping("/api/admin/batch/metrics")
     ResponseEntity<AdminScheduledContentMetricGetResponse> getBatchMetric();
 
-
     @Operation(summary = "콘텐츠 카테고리 지표 조회", description = "콘텐츠 카테고리 별 비율 정보를 가져온다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "콘텐츠 카테고리 별 비율 정보"),
     })
     @GetMapping("/api/admin/metrics/categories")
     ResponseEntity<AdminContentCategoryMetricResponse> getContentCategoryMetric();
-  
+
+    @Operation(summary = "어드민 로그인", description = "백오피스에서 관리자 로그인을 한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "백오피스 관리자 로그인 성공"),
+    })
+    @PostMapping("/api/admin/signin")
+    ResponseEntity<Void> signin(@RequestBody @Valid AdminSinginRequest request,
+            HttpServletResponse response);
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminSinginRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminSinginRequest.java
@@ -1,0 +1,17 @@
+package com.example.udtbe.domain.admin.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record AdminSinginRequest(
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        @Size(min = 7, max = 12, message = "비밀번호는 7자 이상 12자 이하입니다.")
+        String password
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/admin/entity/Admin.java
+++ b/src/main/java/com/example/udtbe/domain/admin/entity/Admin.java
@@ -1,0 +1,76 @@
+package com.example.udtbe.domain.admin.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.example.udtbe.domain.member.entity.enums.Role;
+import com.example.udtbe.global.entity.TimeBaseEntity;
+import com.example.udtbe.global.util.RoleConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "admin")
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Admin extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "admin_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Convert(converter = RoleConverter.class)
+    @Column(name = "role", nullable = false)
+    private Role role;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    @Builder(access = PRIVATE)
+    private Admin(String email, String password, String name, Role role,
+            LocalDateTime lastLoginAt, boolean isDeleted) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.role = role;
+        this.lastLoginAt = lastLoginAt;
+        this.isDeleted = false;
+    }
+
+    public static Admin of(String email, String password, String name, Role role,
+            LocalDateTime lastLoginAt) {
+        return Admin.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .role(role)
+                .lastLoginAt(lastLoginAt)
+                .build();
+    }
+
+    public void updateLastLoginAt(LocalDateTime lastLoginAt) {
+        this.lastLoginAt = lastLoginAt;
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/example/udtbe/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,10 @@
+package com.example.udtbe.domain.admin.repository;
+
+import com.example.udtbe.domain.admin.entity.Admin;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByEmail(String email);
+}

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminAuthService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminAuthService.java
@@ -1,0 +1,50 @@
+package com.example.udtbe.domain.admin.service;
+
+import static com.example.udtbe.domain.auth.exception.AuthErrorCode.INVALID_CREDENTIALS;
+
+import com.example.udtbe.domain.admin.dto.request.AdminSinginRequest;
+import com.example.udtbe.domain.admin.entity.Admin;
+import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.security.dto.AuthInfo;
+import com.example.udtbe.global.security.dto.CustomOauth2User;
+import com.example.udtbe.global.token.cookie.CookieUtil;
+import com.example.udtbe.global.token.service.TokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.LocalDateTime;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+    private final AdminQuery adminQuery;
+    private final TokenProvider tokenProvider;
+    private final CookieUtil cookieUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void signin(AdminSinginRequest request, HttpServletResponse response) {
+        Admin findAdmin = adminQuery.getAdmin(request.email());
+
+        if (!passwordEncoder.matches(request.password(), findAdmin.getPassword())) {
+            throw new RestApiException(INVALID_CREDENTIALS);
+        }
+
+        AuthInfo authInfo = AuthInfo.of(
+                findAdmin.getName(), findAdmin.getEmail(), findAdmin.getRole()
+        );
+        CustomOauth2User customOauth2User = new CustomOauth2User(authInfo);
+
+        String accessToken = tokenProvider.generateAccessToken(findAdmin, customOauth2User,
+                new Date());
+        tokenProvider.generateRefreshToken(findAdmin, customOauth2User, new Date());
+
+        findAdmin.updateLastLoginAt(LocalDateTime.now());
+
+        response.addCookie(cookieUtil.createCookie(accessToken));
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -1,5 +1,7 @@
 package com.example.udtbe.domain.admin.service;
 
+import static com.example.udtbe.domain.admin.exception.AdminErrorCode.ADMIN_NOT_FOUND;
+
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminCastsGetRequest;
@@ -7,6 +9,8 @@ import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentCategoryMetricResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminDirectorsGetResponse;
+import com.example.udtbe.domain.admin.entity.Admin;
+import com.example.udtbe.domain.admin.repository.AdminRepository;
 import com.example.udtbe.domain.batch.entity.BatchJobMetric;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.exception.BatchErrorCode;
@@ -50,6 +54,7 @@ public class AdminQuery {
     private final DirectorRepository directorRepository;
     private final CountryRepository countryRepository;
     private final JobMetricRepository jobMetricRepository;
+    private final AdminRepository adminRepository;
 
 
     public void validContentByContentId(Long contentId) {
@@ -203,6 +208,11 @@ public class AdminQuery {
 
     public AdminContentCategoryMetricResponse getContentCategoryMetric() {
         return contentRepository.getContentCategoryMetric();
+    }
+
+    public Admin getAdmin(String email) {
+        return adminRepository.findByEmail(email)
+                .orElseThrow(() -> new RestApiException(ADMIN_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/auth/exception/AuthErrorCode.java
@@ -14,7 +14,7 @@ public enum AuthErrorCode implements ErrorCode {
     FAIL_REISSUE_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 재발급에 실패했습니다."),
     MISSING_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "AT가 존재하지 않습니다."),
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
-    ;
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/udtbe/global/config/SecurityConfig.java
@@ -19,6 +19,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -50,7 +52,9 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(
                         (auth) -> auth
-                                .requestMatchers("/", "/api/auth/reissue/token").permitAll()
+                                .requestMatchers("/",
+                                        "/api/auth/reissue/token",
+                                        "/api/admin/signin").permitAll()
                                 .requestMatchers("/api/survey").hasAnyAuthority(ROLE_GUEST.name())
                                 .requestMatchers("/api/admin/**").hasAnyAuthority(ROLE_ADMIN.name())
                                 .requestMatchers("/api/**")
@@ -118,5 +122,10 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/example/udtbe/global/token/filter/TokenAuthenticationFilter.java
@@ -42,7 +42,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             "/actuator/health",
             "/actuator/prometheus",
             "/actuator/metrics",
-            "/api/auth/reissue/token"
+            "/api/auth/reissue/token",
+            "/api/admin/signin"
     );
     private static final AntPathMatcher pathMatcher = new AntPathMatcher();
     private final TokenProvider tokenProvider;

--- a/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
+++ b/src/main/java/com/example/udtbe/global/token/service/TokenProvider.java
@@ -3,6 +3,7 @@ package com.example.udtbe.global.token.service;
 import static com.example.udtbe.global.token.exception.TokenErrorCode.INVALID_TOKEN;
 import static com.example.udtbe.global.token.exception.TokenErrorCode.MALFORMED_TOKEN;
 
+import com.example.udtbe.domain.admin.entity.Admin;
 import com.example.udtbe.domain.auth.service.AuthQuery;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.exception.RestApiException;
@@ -73,6 +74,31 @@ public class TokenProvider {
 
         return Jwts.builder()
                 .subject(String.valueOf(findMember.getId()))
+                .claim(ROLE_KEY, authorities)
+                .issuedAt(now)
+                .expiration(expiredTime)
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    public String generateAccessToken(Admin admin, CustomOauth2User authentication, Date now) {
+        return generateToken(admin.getId(), authentication, ACCESS_TOKEN_EXPIRE_TIME, now);
+    }
+
+    public void generateRefreshToken(Admin admin, CustomOauth2User authentication, Date now) {
+        String refreshToken = generateToken(admin.getId(), authentication,
+                REFRESH_TOKEN_EXPIRE_TIME, now);
+        redisUtil.setValues("RT:" + authentication.getEmail(), refreshToken,
+                Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
+    }
+
+    private String generateToken(Long id, CustomOauth2User authentication, long tokenExpireTime,
+            Date now) {
+        Date expiredTime = createExpiredDateWithTokenType(now, tokenExpireTime);
+        String authorities = getAuthorities(authentication);
+
+        return Jwts.builder()
+                .subject(String.valueOf(id))
                 .claim(ROLE_KEY, authorities)
                 .issuedAt(now)
                 .expiration(expiredTime)


### PR DESCRIPTION
## 📝 요약(Summary)

- 백오피스 관리자용 로그인 API 구현
  - 순환 참조 문제로 인해 AuthService가 아닌 AdminAuthService에서 비즈니스 로직 구현

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
