### PR TITLE
Feat/udt 223 콘텐츠 등록 수정 삭제 배치 삭제

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
@@ -180,4 +180,10 @@ public class AdminController implements AdminControllerApiSpec {
         adminAuthService.signin(request, response);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+    @Override
+    public ResponseEntity<Void> deleteInvalidBatchJobs() {
+        adminService.deleteInvalidBatchJobs();
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
 }

--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
@@ -36,6 +36,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -199,5 +200,13 @@ public interface AdminControllerApiSpec {
     @PostMapping("/api/admin/signin")
     ResponseEntity<Void> signin(@RequestBody @Valid AdminSinginRequest request,
             HttpServletResponse response);
+
+
+    @Operation(summary = "INVALID 상태 배치 작업 전체 삭제", description = "모든 INVALID 상태의 배치 작업(등록/수정/삭제)을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제된 작업 건수 정보 반환"),
+    })
+    @DeleteMapping("/api/admin/batch/invalid")
+    ResponseEntity<Void> deleteInvalidBatchJobs();
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -15,17 +15,12 @@ import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
 import com.example.udtbe.domain.batch.entity.BatchJobMetric;
-import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import com.example.udtbe.domain.batch.exception.BatchErrorCode;
 import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
 import com.example.udtbe.domain.batch.repository.BatchJobMetricRepository;
-import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
-import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
-import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
-import com.example.udtbe.domain.batch.repository.JobMetricRepository;
 import com.example.udtbe.domain.content.entity.Cast;
 import com.example.udtbe.domain.content.entity.Category;
 import com.example.udtbe.domain.content.entity.Content;
@@ -69,9 +64,6 @@ public class AdminQuery {
     private final AdminContentUpdateJobRepository adminContentUpdateJobRepository;
     private final AdminContentDeleteJobRepository adminContentDeleteJobRepository;
     private final AdminRepository adminRepository;
-    private final AdminContentRegisterJobRepository adminContentRegisterJobRepository;
-    private final AdminContentUpdateJobRepository adminContentUpdateJobRepository;
-    private final AdminContentDeleteJobRepository adminContentDeleteJobRepository;
 
 
     public void validContentByContentId(Long contentId) {

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -13,7 +13,11 @@ import com.example.udtbe.domain.admin.entity.Admin;
 import com.example.udtbe.domain.admin.repository.AdminRepository;
 import com.example.udtbe.domain.batch.entity.BatchJobMetric;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
+import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import com.example.udtbe.domain.batch.exception.BatchErrorCode;
+import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
+import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
+import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
 import com.example.udtbe.domain.batch.repository.JobMetricRepository;
 import com.example.udtbe.domain.content.entity.Cast;
 import com.example.udtbe.domain.content.entity.Category;
@@ -55,6 +59,9 @@ public class AdminQuery {
     private final CountryRepository countryRepository;
     private final JobMetricRepository jobMetricRepository;
     private final AdminRepository adminRepository;
+    private final AdminContentRegisterJobRepository adminContentRegisterJobRepository;
+    private final AdminContentUpdateJobRepository adminContentUpdateJobRepository;
+    private final AdminContentDeleteJobRepository adminContentDeleteJobRepository;
 
 
     public void validContentByContentId(Long contentId) {
@@ -213,6 +220,16 @@ public class AdminQuery {
     public Admin getAdmin(String email) {
         return adminRepository.findByEmail(email)
                 .orElseThrow(() -> new RestApiException(ADMIN_NOT_FOUND));
+    }
+
+    public void deleteInvalidBatchJobs() {
+        try {
+            adminContentRegisterJobRepository.deleteByStatus(BatchStatus.INVALID);
+            adminContentUpdateJobRepository.deleteByStatus(BatchStatus.INVALID);
+            adminContentDeleteJobRepository.deleteByStatus(BatchStatus.INVALID);
+        } catch (Exception e) {
+            throw new RestApiException(BatchErrorCode.BATCH_DELETE_FAILED);
+        }
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -453,4 +453,9 @@ public class AdminService {
         return adminQuery.getContentCategoryMetric();
     }
 
+    @Transactional
+    public void deleteInvalidBatchJobs() {
+        adminQuery.deleteInvalidBatchJobs();
+    }
+
 }

--- a/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
+++ b/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
@@ -11,6 +11,7 @@ import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
 import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import com.example.udtbe.domain.batch.listener.BatchSkipListener;
+import com.example.udtbe.domain.batch.listener.JobCompletionListener;
 import com.example.udtbe.domain.batch.listener.StepStatsListener;
 import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
@@ -83,11 +84,12 @@ public class BatchConfig {
     }
 
     @Bean
-    public Job contentBatchJob() {
+    public Job contentBatchJob(JobCompletionListener jobCompletionListener) {
         return new JobBuilder(CONTENT_BATCH_JOB, jobRepository)
                 .start(contentRegisterStep())
                 .next(contentUpdateStep())
                 .next(contentDeleteStep())
+                .listener(jobCompletionListener)
                 .build();
     }
 

--- a/src/main/java/com/example/udtbe/domain/batch/exception/BatchErrorCode.java
+++ b/src/main/java/com/example/udtbe/domain/batch/exception/BatchErrorCode.java
@@ -16,6 +16,7 @@ public enum BatchErrorCode implements ErrorCode {
     BATCH_ALREADY_COMPLETED(HttpStatus.CONFLICT, "해당 배치 인스턴스가 이미 완료되어 재실행할 수 없습니다."),
     BATCH_INVALID_PARAMETERS(HttpStatus.BAD_REQUEST, "배치 작업에 잘못된 파라미터가 전달되었습니다."),
     SCHEDULER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "스케줄러를 실행할 수 없습니다."),
+    BATCH_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "배치 작업 삭제에 실패했습니다."),
 
     // Skip 대상 에러 (비즈니스 로직 에러)
     BUSINESS_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "비즈니스 유효성 검증 실패"),

--- a/src/main/java/com/example/udtbe/domain/batch/listener/BatchJobCompleteListener.java
+++ b/src/main/java/com/example/udtbe/domain/batch/listener/BatchJobCompleteListener.java
@@ -18,13 +18,10 @@ public class BatchJobCompleteListener {
     private final ApplicationEventPublisher eventPublisher;
     private final AdminScheduler adminScheduler;
 
-    /**
-     * 배치 완료 이벤트 처리 - 새벽 4시 배치 완료시 루씬 인덱스 리빌드 실행
-     */
     @EventListener
     @Async
     public void handleBatchComplete(BatchJobCompleteEvent event) {
-        log.info("📨 배치 완료 이벤트 수신: {} (상태: {}, 시간: {})",
+        log.info("배치 완료 이벤트 수신: {} (상태: {}, 시간: {})",
                 event.getJobName(), event.getStatus(), event.getCompletedAt());
 
         if (event.isDailyBatch() && event.isSuccessful()) {
@@ -36,28 +33,21 @@ public class BatchJobCompleteListener {
         }
     }
 
-    /**
-     * 루씬 인덱스 리빌드 실행
-     */
     private void performLuceneRebuild(BatchJobCompleteEvent batchEvent) {
         try {
             long startTime = System.currentTimeMillis();
 
             adminScheduler.rebuildLuceneIndexWithRetry();
 
-            // 임시로 시뮬레이션
-            Thread.sleep(1000); // 리빌드 시뮬레이션
-            int indexedCount = batchEvent.getTotalProcessedCount(); // 배치에서 처리된 건수 사용
-
             long buildTime = System.currentTimeMillis() - startTime;
+            int indexedCount = batchEvent.getTotalProcessedCount();
 
-            // 기존 IndexRebuildCompleteEvent 발행
             IndexRebuildCompleteEvent rebuildEvent = IndexRebuildCompleteEvent.of(
                     this, indexedCount, buildTime);
 
             eventPublisher.publishEvent(rebuildEvent);
 
-            log.info("✅ 루씬 인덱스 리빌드 완료 - 인덱싱: {} 건, 소요시간: {}ms",
+            log.info("루씬 인덱스 리빌드 완료 - 인덱싱: {} 건, 소요시간: {}ms",
                     indexedCount, buildTime);
 
         } catch (Exception e) {

--- a/src/main/java/com/example/udtbe/domain/batch/listener/JobCompletionListener.java
+++ b/src/main/java/com/example/udtbe/domain/batch/listener/JobCompletionListener.java
@@ -1,0 +1,22 @@
+package com.example.udtbe.domain.batch.listener;
+
+import com.example.udtbe.domain.batch.util.BatchRetryProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JobCompletionListener implements JobExecutionListener {
+
+    private final BatchRetryProcessor batchRetryProcessor;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        batchRetryProcessor.resetSystemFailure();
+        log.info("배치 작업 완료 서버 에러 리셋");
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentDeleteJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentDeleteJobRepository.java
@@ -12,4 +12,6 @@ public interface AdminContentDeleteJobRepository extends
     List<AdminContentDeleteJob> findByStatus(BatchStatus status);
     
     List<AdminContentDeleteJob> findByStatusIn(List<BatchStatus> statuses);
+    
+    void deleteByStatus(BatchStatus status);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentRegisterJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentRegisterJobRepository.java
@@ -13,4 +13,6 @@ public interface AdminContentRegisterJobRepository extends
     List<AdminContentRegisterJob> findByStatus(BatchStatus status);
     
     List<AdminContentRegisterJob> findByStatusIn(List<BatchStatus> statuses);
+    
+    void deleteByStatus(BatchStatus status);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentUpdateJobRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentUpdateJobRepository.java
@@ -13,4 +13,6 @@ public interface AdminContentUpdateJobRepository extends
     List<AdminContentUpdateJob> findByStatus(BatchStatus status);
     
     List<AdminContentUpdateJob> findByStatusIn(List<BatchStatus> statuses);
+    
+    void deleteByStatus(BatchStatus status);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/util/BatchRetryProcessor.java
+++ b/src/main/java/com/example/udtbe/domain/batch/util/BatchRetryProcessor.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class BatchRetryProcessor {
 
-    private static final int RETRY_LIMIT = 3; // 상수로 정의
+    private static final int RETRY_LIMIT = 3;
 
     private final StepStatsListener stepStatsListener;
     private final ThreadLocal<AtomicBoolean> systemFailureDetected = ThreadLocal.withInitial(

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneIndexService.java
@@ -92,13 +92,12 @@ public class LuceneIndexService {
         doc.add(new StringField("contentId", contentId.toString(), Field.Store.YES));
         doc.add(new TextField("title", metadata.getTitle(), Field.Store.YES));
 
-        // List<String> 타입의 태그들을 쉼표로 구분된 문자열로 변환
         String platformTag = metadata.getPlatformTag() != null ?
                 String.join(",", metadata.getPlatformTag()) : "";
         String genreTag = metadata.getGenreTag() != null ?
                 String.join(",", metadata.getGenreTag()) : "";
-        String directorTag = metadata.getDirectorTag() != null ?
-                String.join(",", metadata.getDirectorTag()) : "";
+//        String directorTag = metadata.getDirectorTag() != null ?
+//                String.join(",", metadata.getDirectorTag()) : "";
         String rating = metadata.getRating() != null ? metadata.getRating() : "";
 
         doc.add(new TextField("platformTag", platformTag, Field.Store.YES));

--- a/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/LuceneSearchService.java
@@ -88,7 +88,6 @@ public class LuceneSearchService {
                     String escapedGenre = QueryParser.escape(feedbackGenre);
                     QueryParser genreParser = new QueryParser("genreTag", analyzer);
                     Query genreQuery = genreParser.parse(escapedGenre);
-                    // 피드백 기반 장르에 더 높은 우선순위 부여
                     mainQueryBuilder.add(genreQuery, BooleanClause.Occur.SHOULD);
                     log.trace("피드백 기반 장르 추가: {}", feedbackGenre);
                 }
@@ -99,7 +98,6 @@ public class LuceneSearchService {
 
     }
 
-    //구독중인 플랫폼의 컨텐츠들, 좋아하는 장르(우선순위)를 기준으로 쿼리를 생성
     private BooleanQuery buildRecommendationQuery(List<Long> platformFilteredContentIds,
             List<String> memberGenres, Analyzer analyzer) throws ParseException {
 


### PR DESCRIPTION
## 📝 요약(Summary)
INVALID 상태의 배치 작업들을 일괄 삭제하는 API를 추가했습니다.

데이터베이스에 누적된 INVALID 상태 배치 작업(등록/수정/삭제)을 관리자가 정리할 수 있도록 `DELETE /api/admin/batch/invalid` 엔드포인트를 구현했습니다.

## 📸스크린샷 (선택)
N/A

## 💬 공유사항 to 리뷰어
**중점 검토 부분:**
- 담당 프론트엔드와의 협의를 통해 정상작동시, ok / 에러 발생시, 에러 코드를 내보내기로 했습니다~
- 3개 테이블 삭제 시 트랜잭션 처리가 적절한지
- `catch (Exception e)`로 모든 예외를 `BATCH_DELETE_FAILED`로 변환하는 것이 적절한지
-
## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분