### PR TITLE
feat/UDT-217 콘텐츠 등록 수정 삭제 배치작업 집계

### DIFF
--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminController.java
@@ -8,6 +8,7 @@ import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminMemberListGetRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentResultGetsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminSinginRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
@@ -27,7 +28,7 @@ import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMembersGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentMetricGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
-import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultGetResponse;
 import com.example.udtbe.domain.admin.service.AdminAuthService;
 import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.domain.batch.scheduler.AdminScheduler;
@@ -35,7 +36,6 @@ import com.example.udtbe.domain.batch.scheduler.FeedbackFullScanScheduler;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -166,8 +166,10 @@ public class AdminController implements AdminControllerApiSpec {
     }
 
     @Override
-    public ResponseEntity<List<AdminScheduledContentResultResponse>> getBatchResults() {
-        List<AdminScheduledContentResultResponse> responses = adminService.getsScheduledResults();
+    public ResponseEntity<CursorPageResponse<AdminScheduledContentResultGetResponse>> getBatchResults(
+            AdminScheduledContentResultGetsRequest request) {
+        CursorPageResponse<AdminScheduledContentResultGetResponse> responses = adminService
+                .getsScheduledResults(request);
         return ResponseEntity.status(HttpStatus.OK).body(responses);
     }
 

--- a/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
+++ b/src/main/java/com/example/udtbe/domain/admin/controller/AdminControllerApiSpec.java
@@ -8,6 +8,7 @@ import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminMemberListGetRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentResultGetsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminSinginRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
@@ -27,7 +28,7 @@ import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMembersGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentMetricGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
-import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultGetResponse;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.global.dto.CursorPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,7 +37,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -173,18 +173,19 @@ public interface AdminControllerApiSpec {
             @Valid @ModelAttribute AdminScheduledContentsRequest adminContentJobGetsRequest
     );
 
-    @Operation(summary = "배치 결과 목록 조회", description = "배치 집계 결과 목록을 조회한다.")
+    @Operation(summary = "배치 별 집계 결과 목록 조회", description = "배치 별 집계 결과 목록을 조회한다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "배치 결과 목록반환"),
+            @ApiResponse(responseCode = "200", description = "배치 별 결과 목록 반환"),
     })
     @GetMapping("/api/admin/batch/results")
-    ResponseEntity<List<AdminScheduledContentResultResponse>> getBatchResults();
+    ResponseEntity<CursorPageResponse<AdminScheduledContentResultGetResponse>> getBatchResults(
+            @Valid @ModelAttribute AdminScheduledContentResultGetsRequest request
+    );
 
-    @Operation(summary = "전체 배치 집계 결과 조회", description = "전체 배치 집계 결과를 조회한다.")
+    @Operation(summary = "전체 배치 작업 집계 결과 조회", description = "전체 배치 작업 집계 결과를 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "전체 배치 집계 조회")
     })
-
     @GetMapping("/api/admin/batch/metrics")
     ResponseEntity<AdminScheduledContentMetricGetResponse> getBatchMetric();
 
@@ -221,6 +222,7 @@ public interface AdminControllerApiSpec {
     ResponseEntity<AdminContentDelJobGetDetailResponse> getBatchDelJobDetails(
             @PathVariable(value = "jobId") Long jobId
     );
+
     @Operation(summary = "어드민 로그인", description = "백오피스에서 관리자 로그인을 한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "백오피스 관리자 로그인 성공"),

--- a/src/main/java/com/example/udtbe/domain/admin/dto/AdminContentMapper.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/AdminContentMapper.java
@@ -3,7 +3,6 @@ package com.example.udtbe.domain.admin.dto;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminMemberGenreFeedbackDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
-import com.example.udtbe.domain.admin.dto.common.BatchJobMetricDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminContentDelJobGetDetailResponse;
@@ -12,6 +11,7 @@ import com.example.udtbe.domain.admin.dto.response.AdminContentRegJobGetDetailRe
 import com.example.udtbe.domain.admin.dto.response.AdminContentRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentUpJobGetDetailResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentUpdateResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultGetResponse;
 import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
@@ -174,6 +174,7 @@ public class AdminContentMapper {
 
         return new AdminContentRegJobGetDetailResponse(
                 job.getBatchJobMetricId(),
+                job.getStatus(),
                 job.getTitle(),
                 job.getDescription(),
                 job.getPosterUrl(),
@@ -202,6 +203,7 @@ public class AdminContentMapper {
 
         return new AdminContentUpJobGetDetailResponse(
                 job.getBatchJobMetricId(),
+                job.getStatus(),
                 job.getContentId(),
                 job.getTitle(),
                 job.getDescription(),
@@ -229,6 +231,7 @@ public class AdminContentMapper {
 
         return new AdminContentDelJobGetDetailResponse(
                 job.getBatchJobMetricId(),
+                job.getStatus(),
                 job.getContentId(),
                 job.getErrorCode(),
                 job.getErrorMessage(),
@@ -246,12 +249,18 @@ public class AdminContentMapper {
         );
     }
 
-    public static BatchJobMetricDTO toBatchJobMetricDTO(BatchJobMetric metric) {
-        return new BatchJobMetricDTO(
+    public static AdminScheduledContentResultGetResponse toAdminScheduledContentResultGetResponse(
+            BatchJobMetric metric) {
+        return new AdminScheduledContentResultGetResponse(
+                metric.getId(),
+                metric.getType(),
+                metric.getStatus(),
                 metric.getTotalRead(),
                 metric.getTotalComplete(),
                 metric.getTotalInvalid(),
-                metric.getTotalFailed()
+                metric.getTotalFailed(),
+                metric.getStartTime(),
+                metric.getEndTime()
         );
     }
 

--- a/src/main/java/com/example/udtbe/domain/admin/dto/AdminContentMapper.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/AdminContentMapper.java
@@ -3,6 +3,7 @@ package com.example.udtbe.domain.admin.dto;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminMemberGenreFeedbackDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
+import com.example.udtbe.domain.admin.dto.common.BatchJobMetricDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminContentDelJobGetDetailResponse;
@@ -14,9 +15,13 @@ import com.example.udtbe.domain.admin.dto.response.AdminContentUpdateResponse;
 import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
+import com.example.udtbe.domain.batch.entity.BatchJobMetric;
+import com.example.udtbe.domain.batch.entity.enums.BatchJobStatus;
+import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.FeedbackStatistics;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +31,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class AdminContentMapper {
 
-    // 배치 관련 mapper 시작
     public static AdminContentRegisterJob toContentRegisterJob(AdminContentRegisterRequest request,
             Long memberId) {
 
@@ -163,26 +167,13 @@ public class AdminContentMapper {
         return new AdminContentDeleteResponse(jobId);
     }
 
-    public static Content toContentEntity(AdminContentRegisterRequest adminContentRegisterRequest) {
-        return Content.of(
-                adminContentRegisterRequest.title(),
-                adminContentRegisterRequest.description(),
-                adminContentRegisterRequest.posterUrl(),
-                adminContentRegisterRequest.backdropUrl(),
-                adminContentRegisterRequest.trailerUrl(),
-                adminContentRegisterRequest.openDate(),
-                adminContentRegisterRequest.runningTime(),
-                adminContentRegisterRequest.episode(),
-                adminContentRegisterRequest.rating()
-        );
-    }
-
     public static AdminContentRegJobGetDetailResponse toAdminContentRegJobDetailResponse(
             AdminContentRegisterJob job) {
         List<AdminCategoryDTO> categoryDTOs = new ArrayList<>(job.getCategories().values());
         List<AdminPlatformDTO> platformDTOs = new ArrayList<>(job.getPlatforms().values());
 
         return new AdminContentRegJobGetDetailResponse(
+                job.getBatchJobMetricId(),
                 job.getTitle(),
                 job.getDescription(),
                 job.getPosterUrl(),
@@ -210,6 +201,7 @@ public class AdminContentMapper {
         List<AdminPlatformDTO> platformDTOs = new ArrayList<>(job.getPlatforms().values());
 
         return new AdminContentUpJobGetDetailResponse(
+                job.getBatchJobMetricId(),
                 job.getContentId(),
                 job.getTitle(),
                 job.getDescription(),
@@ -236,6 +228,7 @@ public class AdminContentMapper {
             AdminContentDeleteJob job) {
 
         return new AdminContentDelJobGetDetailResponse(
+                job.getBatchJobMetricId(),
                 job.getContentId(),
                 job.getErrorCode(),
                 job.getErrorMessage(),
@@ -244,7 +237,38 @@ public class AdminContentMapper {
         );
     }
 
-    // 배치 관련 끝---
+    public static BatchJobMetric initBatchJobMetric(BatchJobType batchJobType) {
+        return BatchJobMetric.of(
+                batchJobType,
+                BatchJobStatus.NOOP,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    public static BatchJobMetricDTO toBatchJobMetricDTO(BatchJobMetric metric) {
+        return new BatchJobMetricDTO(
+                metric.getTotalRead(),
+                metric.getTotalComplete(),
+                metric.getTotalInvalid(),
+                metric.getTotalFailed()
+        );
+    }
+
+    public static Content toContentEntity(AdminContentRegisterRequest adminContentRegisterRequest) {
+        return Content.of(
+                adminContentRegisterRequest.title(),
+                adminContentRegisterRequest.description(),
+                adminContentRegisterRequest.posterUrl(),
+                adminContentRegisterRequest.backdropUrl(),
+                adminContentRegisterRequest.trailerUrl(),
+                adminContentRegisterRequest.openDate(),
+                adminContentRegisterRequest.runningTime(),
+                adminContentRegisterRequest.episode(),
+                adminContentRegisterRequest.rating()
+        );
+    }
+
 
     public static List<AdminMemberGenreFeedbackDTO> toGenreFeedbackDtoList(
             List<FeedbackStatistics> stats) {

--- a/src/main/java/com/example/udtbe/domain/admin/dto/common/BatchJobMetricDTO.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/common/BatchJobMetricDTO.java
@@ -1,0 +1,10 @@
+package com.example.udtbe.domain.admin.dto.common;
+
+public record BatchJobMetricDTO(
+        long totalRead,
+        long totalCompleted,
+        long totalInvalid,
+        long totalFailed
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminScheduledContentResultGetsRequest.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/request/AdminScheduledContentResultGetsRequest.java
@@ -1,0 +1,14 @@
+package com.example.udtbe.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AdminScheduledContentResultGetsRequest(
+
+        String cursor,
+
+        @NotNull
+        int size
+
+) {
+
+}

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentDelJobGetDetailResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentDelJobGetDetailResponse.java
@@ -2,7 +2,9 @@ package com.example.udtbe.domain.admin.dto.response;
 
 public record AdminContentDelJobGetDetailResponse(
 
-        long contentId,
+        Long batchJobMetricId,
+
+        Long contentId,
 
         String errorCode,
 

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentDelJobGetDetailResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentDelJobGetDetailResponse.java
@@ -1,8 +1,12 @@
 package com.example.udtbe.domain.admin.dto.response;
 
+import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
+
 public record AdminContentDelJobGetDetailResponse(
 
         Long batchJobMetricId,
+
+        BatchStatus status,
 
         Long contentId,
 

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentRegJobGetDetailResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentRegJobGetDetailResponse.java
@@ -2,12 +2,15 @@ package com.example.udtbe.domain.admin.dto.response;
 
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
+import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminContentRegJobGetDetailResponse(
 
         Long batchJobMetricId,
+
+        BatchStatus status,
 
         String title,
 

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentRegJobGetDetailResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentRegJobGetDetailResponse.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public record AdminContentRegJobGetDetailResponse(
 
+        Long batchJobMetricId,
+
         String title,
 
         String description,

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentUpJobGetDetailResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentUpJobGetDetailResponse.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public record AdminContentUpJobGetDetailResponse(
 
+        Long batchJobMetricId,
+
         Long contentId,
 
         String title,

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentUpJobGetDetailResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminContentUpJobGetDetailResponse.java
@@ -2,12 +2,15 @@ package com.example.udtbe.domain.admin.dto.response;
 
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
+import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record AdminContentUpJobGetDetailResponse(
 
         Long batchJobMetricId,
+
+        BatchStatus status,
 
         Long contentId,
 

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminScheduledContentGetResultResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminScheduledContentGetResultResponse.java
@@ -4,14 +4,15 @@ import com.example.udtbe.domain.batch.entity.enums.BatchJobStatus;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import java.time.LocalDateTime;
 
-public record AdminScheduledContentResultResponse(
+public record AdminScheduledContentGetResultResponse(
 
         Long resultId,
         BatchJobType type,
         BatchJobStatus status,
         long totalRead,
-        long totalWrite,
-        long totalSkip,
+        long totalCompleted,
+        long totalInvalid,
+        long totalFailed,
         LocalDateTime startTime,
         LocalDateTime endTime
 ) {

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminScheduledContentMetricGetResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminScheduledContentMetricGetResponse.java
@@ -2,8 +2,9 @@ package com.example.udtbe.domain.admin.dto.response;
 
 public record AdminScheduledContentMetricGetResponse(
         long totalRead,
-        long totalWrite,
-        long totalSkip
+        long totalCompleted,
+        long totalInvalid,
+        long totalFailed
 ) {
 
 }

--- a/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminScheduledContentResultGetResponse.java
+++ b/src/main/java/com/example/udtbe/domain/admin/dto/response/AdminScheduledContentResultGetResponse.java
@@ -4,7 +4,7 @@ import com.example.udtbe.domain.batch.entity.enums.BatchJobStatus;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import java.time.LocalDateTime;
 
-public record AdminScheduledContentGetResultResponse(
+public record AdminScheduledContentResultGetResponse(
 
         Long resultId,
         BatchJobType type,

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminQuery.java
@@ -9,18 +9,17 @@ import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminContentCategoryMetricResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminDirectorsGetResponse;
+import com.example.udtbe.domain.admin.entity.Admin;
+import com.example.udtbe.domain.admin.repository.AdminRepository;
 import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
-import com.example.udtbe.domain.admin.entity.Admin;
-import com.example.udtbe.domain.admin.repository.AdminRepository;
 import com.example.udtbe.domain.batch.entity.BatchJobMetric;
-import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.exception.BatchErrorCode;
 import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
-import com.example.udtbe.domain.batch.repository.JobMetricRepository;
+import com.example.udtbe.domain.batch.repository.BatchJobMetricRepository;
 import com.example.udtbe.domain.content.entity.Cast;
 import com.example.udtbe.domain.content.entity.Category;
 import com.example.udtbe.domain.content.entity.Content;
@@ -59,7 +58,7 @@ public class AdminQuery {
     private final CastRepository castRepository;
     private final DirectorRepository directorRepository;
     private final CountryRepository countryRepository;
-    private final JobMetricRepository jobMetricRepository;
+    private final BatchJobMetricRepository batchJobMetricRepository;
     private final AdminContentRegisterJobRepository adminContentRegisterJobRepository;
     private final AdminContentUpdateJobRepository adminContentUpdateJobRepository;
     private final AdminContentDeleteJobRepository adminContentDeleteJobRepository;
@@ -208,8 +207,8 @@ public class AdminQuery {
         return directorRepository.getDirectors(adminDirectorsGetRequest);
     }
 
-    public BatchJobMetric findAdminContentJobMetric(BatchJobType batchJobType) {
-        return jobMetricRepository.findAdminContentJobMetricByType(batchJobType)
+    public BatchJobMetric findAdminContentJobMetric(Long contentJobMetricId) {
+        return batchJobMetricRepository.findById(contentJobMetricId)
                 .orElseThrow(()
                         -> new RestApiException(BatchErrorCode.ADMIN_CONTENT_JOB_METRIC)
                 );
@@ -236,6 +235,7 @@ public class AdminQuery {
                 new RestApiException(BatchErrorCode.ADMIN_CONTENT_DELETE_JOB_NOT_FOUND)
         );
     }
+
     public Admin getAdmin(String email) {
         return adminRepository.findByEmail(email)
                 .orElseThrow(() -> new RestApiException(ADMIN_NOT_FOUND));

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -5,6 +5,7 @@ import com.example.udtbe.domain.admin.dto.AdminMemberMapper;
 import com.example.udtbe.domain.admin.dto.common.AdminCategoryDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminMemberGenreFeedbackDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminPlatformDTO;
+import com.example.udtbe.domain.admin.dto.common.BatchJobMetricDTO;
 import com.example.udtbe.domain.admin.dto.request.AdminCastsGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminCastsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentGetsRequest;
@@ -37,11 +38,13 @@ import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
 import com.example.udtbe.domain.batch.entity.BatchJobMetric;
 import com.example.udtbe.domain.batch.entity.enums.BatchFilterType;
+import com.example.udtbe.domain.batch.entity.enums.BatchJobStatus;
+import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentJobRepositoryImpl;
 import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
-import com.example.udtbe.domain.batch.repository.JobMetricRepository;
+import com.example.udtbe.domain.batch.repository.BatchJobMetricRepository;
 import com.example.udtbe.domain.content.dto.CastMapper;
 import com.example.udtbe.domain.content.dto.DirectorMapper;
 import com.example.udtbe.domain.content.entity.Cast;
@@ -75,6 +78,8 @@ import com.example.udtbe.domain.content.service.FeedbackStatisticsQuery;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.service.MemberQuery;
 import com.example.udtbe.global.dto.CursorPageResponse;
+import com.example.udtbe.global.exception.RestApiException;
+import com.example.udtbe.global.exception.code.EnumErrorCode;
 import com.example.udtbe.global.log.annotation.LogReturn;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,7 +112,7 @@ public class AdminService {
     private final AdminContentMapper adminContentMapper;
     private final AdminContentJobRepositoryImpl adminContentJobRepositoryImpl;
     private final FeedbackStatisticsRepositoryImpl feedbackStatisticsRepositoryImpl;
-    private final JobMetricRepository jobMetricRepository;
+    private final BatchJobMetricRepository batchJobMetricRepository;
 
 
     @Transactional
@@ -414,42 +419,70 @@ public class AdminService {
     }
 
     @Transactional
-    public void updateMetric(BatchJobMetric metric) {
-        BatchJobMetric adminContentJobMetric = adminQuery.findAdminContentJobMetric(
-                metric.getType());
+    public void allUpdateMetric() {
+        List<BatchJobMetric> metrics = batchJobMetricRepository.findAll();
+        metrics.forEach(metric -> {
+            updateMetric(metric.getId());
+        });
+    }
 
-        adminContentJobMetric.update(metric.getStatus(), metric.getTotalRead(),
-                metric.getTotalWrite(), metric.getTotalSkip(), metric.getStartTime(),
-                metric.getEndTime());
+    private void updateMetric(Long metricJobId) {
+        BatchJobMetric metricJob = adminQuery.findAdminContentJobMetric(
+                metricJobId);
+
+        BatchJobMetricDTO dto;
+
+        if (metricJob.getType().equals(BatchJobType.REGISTER)) {
+            dto = adminContentJobRepositoryImpl.getContentRegisterJobMetrics(metricJobId);
+        } else if (metricJob.getType().equals(BatchJobType.UPDATE)) {
+            dto = adminContentJobRepositoryImpl.getContentUpdateJobMetrics(metricJobId);
+        } else if (metricJob.getType().equals(BatchJobType.DELETE)) {
+            dto = adminContentJobRepositoryImpl.getContentDeleteJobMetrics(metricJobId);
+        } else {
+            throw new RestApiException(EnumErrorCode.BATCH_JOB_TYPE_BAD_REQUEST);
+        }
+
+        BatchJobStatus status;
+
+        if (dto.totalRead() == 0) {
+            batchJobMetricRepository.deleteById(metricJobId);
+            return;
+        }
+
+        if (dto.totalRead() == dto.totalCompleted()) {
+            status = BatchJobStatus.COMPLETED;
+        } else if (dto.totalRead() == dto.totalFailed() || dto.totalRead() == dto.totalInvalid()) {
+            status = BatchJobStatus.FAILED;
+        } else {
+            status = BatchJobStatus.PARTIAL_COMPLETED;
+        }
+
+        metricJob.update(
+                status,
+                dto.totalRead(),
+                dto.totalCompleted(),
+                dto.totalInvalid(),
+                dto.totalFailed(),
+                metricJob.getStartTime(),
+                metricJob.getEndTime()
+        );
+    }
+
+    @Transactional
+    public BatchJobMetric initMetric(BatchJobType type) {
+        return AdminContentMapper.initBatchJobMetric(type);
     }
 
     @Transactional
     public List<AdminScheduledContentResultResponse> getsScheduledResults() {
-        List<BatchJobMetric> metrics = jobMetricRepository.findAllByOrderByIdAsc();
-
-        return metrics.stream().map(m ->
-                new AdminScheduledContentResultResponse(
-                        m.getId(),
-                        m.getType(),
-                        m.getStatus(),
-                        m.getTotalRead(),
-                        m.getTotalWrite(),
-                        m.getTotalSkip(),
-                        m.getStartTime(),
-                        m.getEndTime()
-                )
-        ).toList();
+        //todo
+        return null;
     }
 
     @Transactional
     public AdminScheduledContentMetricGetResponse getScheduledMetric() {
-        List<BatchJobMetric> metrics = jobMetricRepository.findAll();
-
-        long totalRead = metrics.stream().mapToLong(BatchJobMetric::getTotalRead).sum();
-        long totalWrite = metrics.stream().mapToLong(BatchJobMetric::getTotalWrite).sum();
-        long totalSkip = metrics.stream().mapToLong(BatchJobMetric::getTotalSkip).sum();
-
-        return new AdminScheduledContentMetricGetResponse(totalRead, totalWrite, totalSkip);
+        //todo
+        return null;
     }
 
     public AdminContentCategoryMetricResponse getContentCategoryMetric() {

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -14,6 +14,7 @@ import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsGetRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminMemberListGetRequest;
+import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentResultGetsRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminScheduledContentsRequest;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminCastsRegisterResponse;
@@ -30,9 +31,9 @@ import com.example.udtbe.domain.admin.dto.response.AdminDirectorsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminDirectorsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMembersGetResponse;
-import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentGetResultResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentMetricGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultGetResponse;
 import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
@@ -482,15 +483,15 @@ public class AdminService {
     }
 
     @Transactional
-    public CursorPageResponse<AdminScheduledContentGetResultResponse> getsScheduledResults() {
-        //todo
-        return null;
+    public CursorPageResponse<AdminScheduledContentResultGetResponse> getsScheduledResults(
+            AdminScheduledContentResultGetsRequest request) {
+        return adminContentJobRepositoryImpl.getScheduledContentResults(request.cursor(),
+                request.size());
     }
 
     @Transactional
     public AdminScheduledContentMetricGetResponse getScheduledMetric() {
-        //todo
-        return null;
+        return adminContentJobRepositoryImpl.getScheduledContentMetrics();
     }
 
     public AdminContentCategoryMetricResponse getContentCategoryMetric() {

--- a/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
+++ b/src/main/java/com/example/udtbe/domain/admin/service/AdminService.java
@@ -30,9 +30,9 @@ import com.example.udtbe.domain.admin.dto.response.AdminDirectorsGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminDirectorsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMembersGetResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentGetResultResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentMetricGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
-import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultResponse;
 import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
@@ -81,6 +81,7 @@ import com.example.udtbe.global.dto.CursorPageResponse;
 import com.example.udtbe.global.exception.RestApiException;
 import com.example.udtbe.global.exception.code.EnumErrorCode;
 import com.example.udtbe.global.log.annotation.LogReturn;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -449,6 +450,13 @@ public class AdminService {
             return;
         }
 
+        if (metricJob.getTotalRead() != dto.totalRead()
+                || metricJob.getTotalFailed() != dto.totalFailed()
+                || metricJob.getTotalInvalid() != dto.totalInvalid()
+                || metricJob.getTotalComplete() != metricJob.getTotalComplete()) {
+            metricJob.updateEndTime(LocalDateTime.now());
+        }
+
         if (dto.totalRead() == dto.totalCompleted()) {
             status = BatchJobStatus.COMPLETED;
         } else if (dto.totalRead() == dto.totalFailed() || dto.totalRead() == dto.totalInvalid()) {
@@ -474,7 +482,7 @@ public class AdminService {
     }
 
     @Transactional
-    public List<AdminScheduledContentResultResponse> getsScheduledResults() {
+    public CursorPageResponse<AdminScheduledContentGetResultResponse> getsScheduledResults() {
         //todo
         return null;
     }

--- a/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
+++ b/src/main/java/com/example/udtbe/domain/batch/config/BatchConfig.java
@@ -9,12 +9,15 @@ import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
+import com.example.udtbe.domain.batch.entity.BatchJobMetric;
+import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import com.example.udtbe.domain.batch.listener.BatchSkipListener;
 import com.example.udtbe.domain.batch.listener.StepStatsListener;
 import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentUpdateJobRepository;
+import com.example.udtbe.domain.batch.repository.BatchJobMetricRepository;
 import com.example.udtbe.domain.batch.util.BatchRetryProcessor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -51,12 +54,11 @@ public class BatchConfig {
     public static final String REGISTER_STEP = "contentRegisterStep";
     public static final String UPDATE_STEP = "contentUpdateStep";
     public static final String DELETE_STEP = "contentDeleteStep";
-    public static final String FEEDBACK_STEP = "feedbackStep";
     private static final int CHUNK_SIZE = 100;
-    private static final int RETRY_LIMIT = 3;
     private static final int SKIP_LIMIT = 200;
 
     private final JobRepository jobRepository;
+    private final BatchJobMetricRepository batchJobMetricRepository;
     private final PlatformTransactionManager transactionManager;
     private final AdminService adminService;
     private final AdminQuery adminQuery;
@@ -170,19 +172,40 @@ public class BatchConfig {
     @Bean
     @StepScope
     public ItemProcessor<AdminContentRegisterJob, AdminContentRegisterJob> contentRegisterProcessor() {
-        return item -> item;
+        BatchJobMetric metric = adminService.initMetric(BatchJobType.REGISTER);
+        batchJobMetricRepository.save(metric);
+        return item -> {
+            if (item.getBatchJobMetricId() == null) {
+                item.setBatchJobMetricId(metric.getId());
+            }
+            return item;
+        };
     }
 
     @Bean
     @StepScope
     public ItemProcessor<AdminContentUpdateJob, AdminContentUpdateJob> contentUpdateProcessor() {
-        return item -> item;
+        BatchJobMetric metric = adminService.initMetric(BatchJobType.UPDATE);
+        batchJobMetricRepository.save(metric);
+        return item -> {
+            if (item.getBatchJobMetricId() == null) {
+                item.setBatchJobMetricId(metric.getId());
+            }
+            return item;
+        };
     }
 
     @Bean
     @StepScope
     public ItemProcessor<AdminContentDeleteJob, AdminContentDeleteJob> contentDeleteProcessor() {
-        return item -> item;
+        BatchJobMetric metric = adminService.initMetric(BatchJobType.DELETE);
+        batchJobMetricRepository.save(metric);
+        return item -> {
+            if (item.getBatchJobMetricId() == null) {
+                item.setBatchJobMetricId(metric.getId());
+            }
+            return item;
+        };
     }
 
     @Bean

--- a/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentDeleteJob.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentDeleteJob.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "admin_content_delete_job")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AdminContentDeleteJob extends TimeBaseEntity {
 
@@ -47,6 +49,8 @@ public class AdminContentDeleteJob extends TimeBaseEntity {
     private int retryCount = 0;
 
     private int skipCount = 0;
+
+    private Long batchJobMetricId;
 
     @Builder(access = PRIVATE)
     private AdminContentDeleteJob(BatchStatus status, LocalDateTime scheduledAt, Long memberId,
@@ -91,6 +95,10 @@ public class AdminContentDeleteJob extends TimeBaseEntity {
 
     public void finish() {
         finishedAt = LocalDateTime.now();
+    }
+
+    public void setBatchJobMetricId(Long batchJobMetricId) {
+        this.batchJobMetricId = batchJobMetricId;
     }
 }
 

--- a/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentRegisterJob.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentRegisterJob.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.hibernate.annotations.Type;
 
 @Entity
 @Getter
+@Table(name = "admin_content_register_job")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AdminContentRegisterJob extends TimeBaseEntity {
 
@@ -93,6 +95,8 @@ public class AdminContentRegisterJob extends TimeBaseEntity {
     private int retryCount = 0;
 
     private int skipCount = 0;
+
+    private Long batchJobMetricId;
 
     @Builder(access = PRIVATE)
     private AdminContentRegisterJob(BatchStatus status, Long memberId,
@@ -171,5 +175,9 @@ public class AdminContentRegisterJob extends TimeBaseEntity {
 
     public void finish() {
         finishedAt = LocalDateTime.now();
+    }
+
+    public void setBatchJobMetricId(Long batchJobMetricId) {
+        this.batchJobMetricId = batchJobMetricId;
     }
 }

--- a/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentUpdateJob.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/AdminContentUpdateJob.java
@@ -18,6 +18,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import org.hibernate.annotations.Type;
 
 @Entity
 @Getter
+@Table(name = "admin_content_update_job")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AdminContentUpdateJob extends TimeBaseEntity {
 
@@ -95,6 +97,8 @@ public class AdminContentUpdateJob extends TimeBaseEntity {
     private int retryCount = 0;
 
     private int skipCount = 0;
+
+    private Long batchJobMetricId;
 
     @Builder(access = PRIVATE)
     private AdminContentUpdateJob(BatchStatus status, LocalDateTime scheduledAt,
@@ -178,6 +182,10 @@ public class AdminContentUpdateJob extends TimeBaseEntity {
 
     public void finish() {
         finishedAt = LocalDateTime.now();
+    }
+
+    public void setBatchJobMetricId(Long batchJobMetricId) {
+        this.batchJobMetricId = batchJobMetricId;
     }
 
 }

--- a/src/main/java/com/example/udtbe/domain/batch/entity/BatchJobMetric.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/BatchJobMetric.java
@@ -77,4 +77,8 @@ public class BatchJobMetric extends TimeBaseEntity {
         this.endTime = endTime;
     }
 
+    public void updateEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
 }

--- a/src/main/java/com/example/udtbe/domain/batch/entity/BatchJobMetric.java
+++ b/src/main/java/com/example/udtbe/domain/batch/entity/BatchJobMetric.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,15 +23,14 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "batch_job_metric")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BatchJobMetric extends TimeBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "admin_content_job_metric_id")
+    @Column(name = "batch_job_metric_id")
     private Long id;
-
-    private Long adminContentJobId;
 
     @Enumerated(EnumType.STRING)
     private BatchJobType type;
@@ -38,50 +38,41 @@ public class BatchJobMetric extends TimeBaseEntity {
     @Enumerated(EnumType.STRING)
     private BatchJobStatus status;
 
-    private long totalRead;
-    private long totalWrite;
-    private long totalSkip;
+    private long totalRead = 0;
+    private long totalComplete = 0;
+    private long totalInvalid = 0;
+    private long totalFailed = 0;
 
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 
-
     @Builder(access = PRIVATE)
-    private BatchJobMetric(Long adminContentJobId, BatchJobType type, BatchJobStatus status,
-            long totalRead, long totalWrite, long totalSkip, LocalDateTime startTime,
+    private BatchJobMetric(BatchJobType type, BatchJobStatus status, LocalDateTime startTime,
             LocalDateTime endTime) {
-        this.adminContentJobId = adminContentJobId;
         this.type = type;
         this.status = status;
-        this.totalRead = totalRead;
-        this.totalWrite = totalWrite;
-        this.totalSkip = totalSkip;
         this.startTime = startTime;
         this.endTime = endTime;
     }
 
-    public static BatchJobMetric of(Long adminContentJobId, BatchJobType type,
-            BatchJobStatus status, long totalRead, long totalWrite, long totalSkip,
+    public static BatchJobMetric of(BatchJobType type, BatchJobStatus status,
             LocalDateTime startTime, LocalDateTime endTime) {
 
         return BatchJobMetric.builder()
-                .adminContentJobId(adminContentJobId)
                 .type(type)
                 .status(status)
-                .totalRead(totalRead)
-                .totalWrite(totalWrite)
-                .totalSkip(totalSkip)
                 .startTime(startTime)
                 .endTime(endTime)
                 .build();
     }
 
-    public void update(BatchJobStatus status, long totalRead, long totalWrite, long totalSkip,
-            LocalDateTime startTime, LocalDateTime endTime) {
+    public void update(BatchJobStatus status, long totalRead, long totalComplete, long totalInvalid,
+            long totalFailed, LocalDateTime startTime, LocalDateTime endTime) {
         this.status = status;
-        this.totalRead += totalRead;
-        this.totalWrite += totalWrite;
-        this.totalSkip += totalSkip;
+        this.totalRead = totalRead;
+        this.totalComplete = totalComplete;
+        this.totalInvalid = totalInvalid;
+        this.totalFailed = totalFailed;
         this.startTime = startTime;
         this.endTime = endTime;
     }

--- a/src/main/java/com/example/udtbe/domain/batch/listener/StepStatsListener.java
+++ b/src/main/java/com/example/udtbe/domain/batch/listener/StepStatsListener.java
@@ -1,8 +1,6 @@
 package com.example.udtbe.domain.batch.listener;
 
-import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.domain.batch.config.BatchConfig;
-import com.example.udtbe.domain.batch.entity.BatchJobMetric;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobStatus;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.event.BatchJobCompleteEvent;
@@ -21,7 +19,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class StepStatsListener implements StepExecutionListener {
 
-    private final AdminService adminService;
     private final ApplicationEventPublisher eventPublisher;
 
     // 커스텀 통계 추적
@@ -41,7 +38,6 @@ public class StepStatsListener implements StepExecutionListener {
 
     @Override
     public ExitStatus afterStep(StepExecution stepExecution) {
-        BatchJobType batchJobType = determineBatchJobType(stepExecution.getStepName());
 
         long totalRead = stepExecution.getReadCount();
         long totalWrite = stepExecution.getWriteCount();
@@ -54,19 +50,6 @@ public class StepStatsListener implements StepExecutionListener {
 
         // 에러 정보 로깅
         logFailureExceptions(stepExecution);
-
-        BatchJobMetric metric = BatchJobMetric.of(
-                stepExecution.getJobExecutionId(),
-                batchJobType,
-                batchJobStatus,
-                totalRead,
-                totalWrite,
-                totalSkip,
-                stepExecution.getStartTime(),
-                stepExecution.getEndTime()
-        );
-
-        adminService.updateMetric(metric);
 
         if (BatchConfig.DELETE_STEP.equals(stepExecution.getStepName())) {
             publishBatchCompleteEvent(stepExecution, batchJobStatus, totalRead);

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentJobRepositoryCustom.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentJobRepositoryCustom.java
@@ -1,7 +1,9 @@
 package com.example.udtbe.domain.batch.repository;
 
 import com.example.udtbe.domain.admin.dto.common.BatchJobMetricDTO;
+import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentMetricGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
+import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultGetResponse;
 import com.example.udtbe.domain.batch.entity.enums.BatchFilterType;
 import com.example.udtbe.global.dto.CursorPageResponse;
 
@@ -16,4 +18,8 @@ public interface AdminContentJobRepositoryCustom {
 
     BatchJobMetricDTO getContentDeleteJobMetrics(Long metricId);
 
+    AdminScheduledContentMetricGetResponse getScheduledContentMetrics();
+
+    CursorPageResponse<AdminScheduledContentResultGetResponse> getScheduledContentResults(
+            String cursor, int size);
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentJobRepositoryCustom.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/AdminContentJobRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.example.udtbe.domain.batch.repository;
 
+import com.example.udtbe.domain.admin.dto.common.BatchJobMetricDTO;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
 import com.example.udtbe.domain.batch.entity.enums.BatchFilterType;
 import com.example.udtbe.global.dto.CursorPageResponse;
@@ -8,4 +9,11 @@ public interface AdminContentJobRepositoryCustom {
 
     CursorPageResponse<AdminScheduledContentResponse> getJobsByCursor(
             String cursor, int size, BatchFilterType type);
+
+    BatchJobMetricDTO getContentRegisterJobMetrics(Long metricId);
+
+    BatchJobMetricDTO getContentUpdateJobMetrics(Long metricId);
+
+    BatchJobMetricDTO getContentDeleteJobMetrics(Long metricId);
+
 }

--- a/src/main/java/com/example/udtbe/domain/batch/repository/BatchJobMetricRepository.java
+++ b/src/main/java/com/example/udtbe/domain/batch/repository/BatchJobMetricRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface JobMetricRepository extends
+public interface BatchJobMetricRepository extends
         JpaRepository<BatchJobMetric, Long> {
 
     @Query("SELECT j FROM BatchJobMetric j ORDER BY j.id ASC")

--- a/src/main/java/com/example/udtbe/domain/batch/scheduler/AdminScheduler.java
+++ b/src/main/java/com/example/udtbe/domain/batch/scheduler/AdminScheduler.java
@@ -1,7 +1,7 @@
 package com.example.udtbe.domain.batch.scheduler;
 
+import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.domain.batch.exception.BatchErrorCode;
-import com.example.udtbe.domain.batch.util.TimeUtil;
 import com.example.udtbe.domain.content.service.LuceneIndexService;
 import com.example.udtbe.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +27,9 @@ public class AdminScheduler {
     private final JobLauncher jobLauncher;
     private final Job contentBatchJob;
     private final LuceneIndexService luceneIndexService;
+    private final AdminService adminService;
 
-    @Scheduled(cron = TimeUtil.SCHEDULED_AT)
+    @Scheduled(cron = "0 0 4 * * *")
     @Retryable(retryFor = Exception.class, backoff = @Backoff(delay = 5000))
     public void runContentBatchJob() {
         try {
@@ -36,6 +37,8 @@ public class AdminScheduler {
                     .addLong("time", System.currentTimeMillis())
                     .toJobParameters();
             jobLauncher.run(contentBatchJob, jobParameters);
+            adminService.allUpdateMetric();
+            
         } catch (JobExecutionAlreadyRunningException e) {
             throw new RestApiException(BatchErrorCode.BATCH_ALREADY_RUNNING);
         } catch (JobRestartException e) {

--- a/src/main/java/com/example/udtbe/domain/batch/util/TimeUtil.java
+++ b/src/main/java/com/example/udtbe/domain/batch/util/TimeUtil.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 public class TimeUtil {
 
 
-    public static final String SCHEDULED_AT = "0 0 4 * * ?";
     public static final int SCHEDULED_HOUR = 4;
     public static final int SCHEDULED_MINUTE = 0;
     public static final int SCHEDULED_SECOND = 0;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -56,11 +56,3 @@ VALUES (1, 'NETFLIX', NOW(), NOW(), false),
        (6, 'WATCHA', NOW(), NOW(), false),
        (7, 'APPLE_TV', NOW(), NOW(), false);
 
--- 6) 배치 집계 메트릭 데이터 삽입
-INSERT INTO batch_job_metric (batch_job_metric_id, type, status, total_read, total_write,
-                              total_skip,
-                              start_time, end_time, created_at, updated_at)
-VALUES (1, 'REGISTER', 'NOOP', 0, 0, 0, null, null, NOW(), NOW()),
-       (2, 'UPDATE', 'NOOP', 0, 0, 0, null, null, NOW(), NOW()),
-       (3, 'DELETE', 'NOOP', 0, 0, 0, null, null, NOW(), NOW()),
-       (4, 'FEEDBACK', 'NOOP', 0, 0, 0, null, null, NOW(), NOW());

--- a/src/test/java/com/example/udtbe/admin/controller/AdminControllerTest.java
+++ b/src/test/java/com/example/udtbe/admin/controller/AdminControllerTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.example.udtbe.common.fixture.AdminContentDeleteJobFixture;
 import com.example.udtbe.common.fixture.AdminContentRegisterJobFixture;
-import com.example.udtbe.common.fixture.BatchJobMetricFixture;
 import com.example.udtbe.common.fixture.CastFixture;
 import com.example.udtbe.common.fixture.ContentCategoryFixture;
 import com.example.udtbe.common.fixture.ContentFixture;
@@ -25,11 +24,9 @@ import com.example.udtbe.domain.admin.dto.request.AdminCastsRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentRegisterRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminContentUpdateRequest;
 import com.example.udtbe.domain.admin.dto.request.AdminDirectorsRegisterRequest;
-import com.example.udtbe.domain.batch.entity.BatchJobMetric;
-import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.repository.AdminContentDeleteJobRepository;
 import com.example.udtbe.domain.batch.repository.AdminContentRegisterJobRepository;
-import com.example.udtbe.domain.batch.repository.JobMetricRepository;
+import com.example.udtbe.domain.batch.repository.BatchJobMetricRepository;
 import com.example.udtbe.domain.content.entity.Cast;
 import com.example.udtbe.domain.content.entity.Category;
 import com.example.udtbe.domain.content.entity.Content;
@@ -89,7 +86,7 @@ public class AdminControllerTest extends ApiSupport {
     @Autowired
     private DirectorRepository directorRepository;
     @Autowired
-    private JobMetricRepository jobMetricRepository;
+    private BatchJobMetricRepository batchJobMetricRepository;
     @Autowired
     private AdminContentRegisterJobRepository adminContentRegisterJobRepository;
     @Autowired
@@ -110,7 +107,7 @@ public class AdminControllerTest extends ApiSupport {
         directorRepository.deleteAllInBatch();
         contentMetadataRepository.deleteAllInBatch();
         contentRepository.deleteAllInBatch();
-        jobMetricRepository.deleteAllInBatch();
+        batchJobMetricRepository.deleteAllInBatch();
     }
 
     @Test
@@ -643,46 +640,6 @@ public class AdminControllerTest extends ApiSupport {
         ;
     }
 
-    @DisplayName("배치 작업 결과 목록을 조회할 수 있다.")
-    @Test
-    void getBatchResults() throws Exception {
-        // given
-        BatchJobMetric metric1 = BatchJobMetricFixture.completedJob(1L,
-                BatchJobType.REGISTER, 100);
-        BatchJobMetric metric2 = BatchJobMetricFixture.partialCompetedJob(2L,
-                BatchJobType.UPDATE, 100, 40);
-        jobMetricRepository.saveAll(List.of(metric1, metric2));
-
-        // when // then
-        mockMvc.perform(get("/api/admin/batch/results")
-                        .cookie(accessTokenOfAdmin)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2));
-    }
-
-    @DisplayName("배치 작업 메트릭을 조회할 수 있다.")
-    @Test
-    void getBatchMetric() throws Exception {
-        // given
-        BatchJobMetric metric1 = BatchJobMetricFixture.completedJob(1L,
-                BatchJobType.REGISTER, 100);
-        BatchJobMetric metric2 = BatchJobMetricFixture.partialCompetedJob(2L,
-                BatchJobType.UPDATE, 100, 40);
-        jobMetricRepository.saveAll(List.of(metric1, metric2));
-
-        // when // then
-        mockMvc.perform(get("/api/admin/batch/metrics")
-                        .cookie(accessTokenOfAdmin)
-                )
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalRead").value(
-                        metric1.getTotalRead() + (metric2.getTotalRead())))
-                .andExpect(jsonPath("$.totalWrite").value(
-                        metric1.getTotalWrite() + (metric2.getTotalWrite())))
-                .andExpect(jsonPath("$.totalSkip").value(
-                        metric1.getTotalSkip() + (metric2.getTotalSkip())));
-    }
 
     @Transactional
     @DisplayName("콘텐츠 카테고리 별 총 개수 지표를 가져온다.")

--- a/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/example/udtbe/admin/service/AdminServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.example.udtbe.common.fixture.BatchJobMetricFixture;
 import com.example.udtbe.common.fixture.MemberFixture;
 import com.example.udtbe.domain.admin.dto.common.AdminCastDTO;
 import com.example.udtbe.domain.admin.dto.common.AdminCastDetailsDTO;
@@ -35,20 +34,17 @@ import com.example.udtbe.domain.admin.dto.response.AdminContentGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminDirectorsRegisterResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMemberInfoGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminMembersGetResponse;
-import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentMetricGetResponse;
 import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResponse;
-import com.example.udtbe.domain.admin.dto.response.AdminScheduledContentResultResponse;
 import com.example.udtbe.domain.admin.service.AdminQuery;
 import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.domain.batch.entity.AdminContentDeleteJob;
 import com.example.udtbe.domain.batch.entity.AdminContentRegisterJob;
 import com.example.udtbe.domain.batch.entity.AdminContentUpdateJob;
-import com.example.udtbe.domain.batch.entity.BatchJobMetric;
 import com.example.udtbe.domain.batch.entity.enums.BatchFilterType;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
 import com.example.udtbe.domain.batch.entity.enums.BatchStatus;
 import com.example.udtbe.domain.batch.repository.AdminContentJobRepositoryImpl;
-import com.example.udtbe.domain.batch.repository.JobMetricRepository;
+import com.example.udtbe.domain.batch.repository.BatchJobMetricRepository;
 import com.example.udtbe.domain.content.entity.Cast;
 import com.example.udtbe.domain.content.entity.Category;
 import com.example.udtbe.domain.content.entity.Content;
@@ -121,7 +117,7 @@ public class AdminServiceTest {
     @Mock
     private FeedbackStatisticsRepository feedbackStatisticsRepository;
     @Mock
-    private JobMetricRepository jobMetricRepository;
+    private BatchJobMetricRepository batchJobMetricRepository;
 
     @InjectMocks
     private AdminService adminService;
@@ -711,68 +707,6 @@ public class AdminServiceTest {
                 .getJobsByCursor(request.cursor(), request.size(), type);
     }
 
-
-    @DisplayName("배치 작업의 메트릭을 업데이트할 수 있다.")
-    @Test
-    void updateMetric() {
-        // given
-        BatchJobMetric metric = BatchJobMetricFixture.completedJob(1L,
-                BatchJobType.DELETE, 100);
-        BatchJobMetric findMetric = mock(BatchJobMetric.class);
-
-        given(adminQuery.findAdminContentJobMetric(metric.getType())).willReturn(findMetric);
-
-        // when
-        adminService.updateMetric(metric);
-
-        // then
-        verify(findMetric).update(metric.getStatus(), metric.getTotalRead(),
-                metric.getTotalWrite(), metric.getTotalSkip(), metric.getStartTime(),
-                metric.getEndTime());
-    }
-
-    @DisplayName("배치 작업 결과 목록을 조회할 수 있다.")
-    @Test
-    void getsScheduledResults() {
-        // given
-        BatchJobMetric metric1 = BatchJobMetricFixture.completedJob(1L,
-                BatchJobType.REGISTER, 100);
-        BatchJobMetric metric2 = BatchJobMetricFixture.partialCompetedJob(2L,
-                BatchJobType.UPDATE, 100, 40);
-        List<BatchJobMetric> metrics = List.of(metric1, metric2);
-        given(jobMetricRepository.findAllByOrderByIdAsc()).willReturn(metrics);
-
-        // when
-        List<AdminScheduledContentResultResponse> responses = adminService.getsScheduledResults();
-
-        // then
-        assertThat(responses).hasSize(2);
-        assertThat(responses.get(0).resultId()).isEqualTo(metric1.getId());
-        assertThat(responses.get(1).resultId()).isEqualTo(metric2.getId());
-    }
-
-    @DisplayName("배치 작업 메트릭을 조회할 수 있다.")
-    @Test
-    void getScheduledMetric() {
-        // given
-        BatchJobMetric metric1 = BatchJobMetricFixture.completedJob(1L,
-                BatchJobType.DELETE, 100);
-
-        BatchJobMetric metric2 = BatchJobMetricFixture.partialCompetedJob(2L,
-                BatchJobType.UPDATE, 50, 10);
-
-        List<BatchJobMetric> metrics = List.of(metric1, metric2);
-        given(jobMetricRepository.findAll()).willReturn(metrics);
-
-        // when
-        AdminScheduledContentMetricGetResponse response = adminService.getScheduledMetric();
-
-        // then
-        assertThat(response.totalRead()).isEqualTo(metric1.getTotalRead() + metric2.getTotalRead());
-        assertThat(response.totalWrite()).isEqualTo(
-                metric1.getTotalWrite() + metric2.getTotalWrite());
-        assertThat(response.totalSkip()).isEqualTo(metric1.getTotalSkip() + metric2.getTotalSkip());
-    }
 
     @DisplayName("배치 등록 작업의 상세 정보를 조회할 수 있다.")
     @Test

--- a/src/test/java/com/example/udtbe/batch/repository/BatchJobMetricRepositoryTest.java
+++ b/src/test/java/com/example/udtbe/batch/repository/BatchJobMetricRepositoryTest.java
@@ -6,7 +6,7 @@ import com.example.udtbe.common.fixture.BatchJobMetricFixture;
 import com.example.udtbe.common.support.DataJpaSupport;
 import com.example.udtbe.domain.batch.entity.BatchJobMetric;
 import com.example.udtbe.domain.batch.entity.enums.BatchJobType;
-import com.example.udtbe.domain.batch.repository.JobMetricRepository;
+import com.example.udtbe.domain.batch.repository.BatchJobMetricRepository;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class BatchJobMetricRepositoryTest extends DataJpaSupport {
 
     @Autowired
-    private JobMetricRepository jobMetricRepository;
+    private BatchJobMetricRepository batchJobMetricRepository;
 
     @DisplayName("배치 작업 메트릭을 저장하고 조회할 수 있다.")
     @Test
@@ -26,10 +26,10 @@ class BatchJobMetricRepositoryTest extends DataJpaSupport {
         BatchJobMetric metric2 = BatchJobMetricFixture.partialCompetedJob(2L,
                 BatchJobType.UPDATE, 100, 40);
 
-        jobMetricRepository.saveAll(List.of(metric1, metric2));
+        batchJobMetricRepository.saveAll(List.of(metric1, metric2));
 
         // when
-        List<BatchJobMetric> metrics = jobMetricRepository.findAll();
+        List<BatchJobMetric> metrics = batchJobMetricRepository.findAll();
 
         // then
         assertThat(metrics).hasSize(2);

--- a/src/test/java/com/example/udtbe/batch/scheduler/AdminSchedulerTest.java
+++ b/src/test/java/com/example/udtbe/batch/scheduler/AdminSchedulerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
+import com.example.udtbe.domain.admin.service.AdminService;
 import com.example.udtbe.domain.batch.scheduler.AdminScheduler;
 import com.example.udtbe.domain.content.service.LuceneIndexService;
 import com.example.udtbe.global.exception.RestApiException;
@@ -38,6 +39,9 @@ class AdminSchedulerTest {
     private JobLauncher jobLauncher;
 
     @Mock
+    private AdminService adminService;
+
+    @Mock
     private Job contentBatchJob;
 
     @InjectMocks
@@ -49,7 +53,6 @@ class AdminSchedulerTest {
         // given
         given(jobLauncher.run(any(Job.class), any(JobParameters.class)))
                 .willReturn(new JobExecution(1L));
-
         // when
         adminScheduler.runContentBatchJob();
 

--- a/src/test/java/com/example/udtbe/common/fixture/BatchJobMetricFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/BatchJobMetricFixture.java
@@ -9,22 +9,36 @@ public class BatchJobMetricFixture {
 
     public static BatchJobMetric completedJob(Long id, BatchJobType batchJobType,
             long totalRead) {
-        return BatchJobMetric.of(id, batchJobType,
-                BatchJobStatus.COMPLETED, totalRead, totalRead, 0, LocalDateTime.now(),
-                LocalDateTime.now().plusHours(1));
+
+        BatchJobMetric batchJobMetric = BatchJobMetric.of(batchJobType, BatchJobStatus.NOOP,
+                LocalDateTime.now(), LocalDateTime.now());
+
+        batchJobMetric.update(BatchJobStatus.COMPLETED, totalRead, totalRead, 0, 0,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(1));
+
+        return batchJobMetric;
     }
 
     public static BatchJobMetric failedJob(Long id, BatchJobType batchJobType,
             long totalRead) {
-        return BatchJobMetric.of(id, batchJobType,
-                BatchJobStatus.COMPLETED, totalRead, 0, totalRead, LocalDateTime.now(),
-                LocalDateTime.now().plusHours(1));
+
+        BatchJobMetric batchJobMetric = BatchJobMetric.of(batchJobType, BatchJobStatus.NOOP,
+                LocalDateTime.now(), LocalDateTime.now());
+
+        batchJobMetric.update(BatchJobStatus.COMPLETED, totalRead, 0, 0, totalRead,
+                LocalDateTime.now(), LocalDateTime.now().plusHours(1));
+
+        return batchJobMetric;
     }
 
     public static BatchJobMetric partialCompetedJob(Long id, BatchJobType batchJobType,
             long totalRead, long totalFailed) {
-        return BatchJobMetric.of(id, batchJobType,
-                BatchJobStatus.PARTIAL_COMPLETED, totalRead, totalRead - totalFailed, totalFailed,
-                LocalDateTime.now(), LocalDateTime.now().plusHours(1));
+        BatchJobMetric batchJobMetric = BatchJobMetric.of(batchJobType, BatchJobStatus.NOOP,
+                LocalDateTime.now(), LocalDateTime.now());
+
+        batchJobMetric.update(BatchJobStatus.PARTIAL_COMPLETED, totalRead, totalRead - totalFailed,
+                0, totalFailed, LocalDateTime.now(), LocalDateTime.now().plusHours(1));
+
+        return batchJobMetric;
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->


1. 배치 집합 별로 집계 로직 구현 -> 재시도 시 배치 집합 별로 집계가 바뀐다. 
<img width="911" height="215" alt="image" src="https://github.com/user-attachments/assets/91d8875c-5a7c-4449-9c6b-e5ed2b30347f" />

2. 배치 실행 시 작업 하나 당 배치 집합 아이디가 부여 (단 대기 열에는 부여하지 않음, 무조건 작업이 시작될 때 만)

3. 배치 전체 작업 집계 API 개발, 및 배치 집합 별 집계 API 개발

4. 배치 상세보기 RESPONSE 약간 수정 (배치 집합 id, 배치 상태 반환하도록 변경)


## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분
