### PR TITLE
fix/UDT-253: 백오피스 유저 목록 조회 키워드 검색 버그 수정

### DIFF
--- a/src/main/java/com/example/udtbe/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/example/udtbe/domain/member/repository/MemberRepositoryImpl.java
@@ -22,8 +22,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         BooleanBuilder builder = new BooleanBuilder();
 
         if (keyword != null && !keyword.isEmpty() && keyword.trim().length() > 0) {
-            builder.or(member.name.containsIgnoreCase(keyword))
-                    .and(member.email.containsIgnoreCase(keyword));
+            builder.and(member.name.containsIgnoreCase(keyword))
+                    .or(member.email.containsIgnoreCase(keyword));
         }
 
         if (StringUtils.hasText(cursor)) {


### PR DESCRIPTION
## 📝 요약(Summary)

백오피스에서 목록 조회 시 키워드 검색이 작동하지 않는 버그 수정

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 2분
