### PR TITLE
Refactor/udt 276 추천 서비스 분리

### DIFF
--- a/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/ContentRecommendationService.java
@@ -1,14 +1,10 @@
 package com.example.udtbe.domain.content.service;
 
-import com.example.udtbe.domain.content.dto.ContentRecommendationMapper;
 import com.example.udtbe.domain.content.dto.common.ContentRecommendationDTO;
 import com.example.udtbe.domain.content.dto.response.ContentRecommendationResponse;
-import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.ContentMetadata;
 import com.example.udtbe.domain.content.entity.Feedback;
-import com.example.udtbe.domain.content.entity.enums.FeedbackType;
 import com.example.udtbe.domain.content.entity.enums.GenreType;
-import com.example.udtbe.domain.content.entity.enums.PlatformType;
 import com.example.udtbe.domain.content.exception.RecommendContentErrorCode;
 import com.example.udtbe.domain.content.util.MemberRecommendationCache;
 import com.example.udtbe.domain.content.util.RecommendationCacheManager;
@@ -17,16 +13,11 @@ import com.example.udtbe.domain.survey.entity.Survey;
 import com.example.udtbe.global.exception.RestApiException;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.lucene.document.Document;
@@ -37,7 +28,6 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +38,10 @@ public class ContentRecommendationService {
     private final LuceneIndexService luceneIndexService;
     private final LuceneSearchService luceneSearchService;
     private final RecommendationCacheManager cacheManager;
+    private final RecommendationScoreCalculator scoreCalculator;
+    private final GenreAnalyzer genreAnalyzer;
+    private final RecommendationQueryBuilder queryBuilder;
+    private final RecommendationResponseBuilder responseBuilder;
 
     @Transactional(readOnly = true)
     public List<ContentRecommendationResponse> recommendContents(Member member, int limit) {
@@ -84,7 +78,7 @@ public class ContentRecommendationService {
 
         // TODO: 모든 ContentMetadata 한 번에 조회하여 캐시 생성 , 추후 메모리 분석 및 성능 개선의 여지가 농후
         Map<Long, ContentMetadata> metadataCache = contentRecommendationQuery.findContentMetadataCache();
-        List<Long> platformFilteredContentIds = getPlatformFilteredContentIds(
+        List<Long> platformFilteredContentIds = queryBuilder.getPlatformFilteredContentIds(
                 memberSurvey.getPlatformTag(), metadataCache);
 
         if (isCurated) {
@@ -101,8 +95,10 @@ public class ContentRecommendationService {
             Map<Long, ContentMetadata> metadataCache, List<Long> platformFilteredContentIds)
             throws IOException, ParseException {
 
-        List<String> feedbackBasedGenres = extractPreferredGenresFromFeedback(member,
-                metadataCache);
+        List<Feedback> feedbacks = contentRecommendationQuery.findFeedbacksByMemberId(
+                member.getId());
+        List<String> feedbackBasedGenres = genreAnalyzer.extractPreferredGenresFromFeedback(
+                feedbacks, metadataCache);
         List<String> surveyGenres = GenreType.toKoreanTypes(memberSurvey.getGenreTag());
         TopDocs topDocs = luceneSearchService.searchCuratedRecommendations(
                 platformFilteredContentIds, feedbackBasedGenres, limit);
@@ -115,7 +111,8 @@ public class ContentRecommendationService {
                 .limit(limit)
                 .toList();
 
-        return buildResponseFromRecommendations(sortedRecommendations, metadataCache);
+        return responseBuilder.buildResponseFromRecommendations(sortedRecommendations,
+                metadataCache);
     }
 
     private List<ContentRecommendationResponse> executeRegularRecommendation(
@@ -149,33 +146,29 @@ public class ContentRecommendationService {
             List<ContentRecommendationDTO> recommendations = new ArrayList<>();
             debugTopDocs(topDocs, searcher);
 
-            Map<String, Float> feedbackScores = calculateGenreFeedbackScores(member, metadataCache,
-                    Optional.empty());
+            List<Feedback> feedbacks = contentRecommendationQuery.findFeedbacksByMemberId(
+                    member.getId());
+            Map<String, Float> feedbackScores = scoreCalculator.calculateGenreFeedbackScores(
+                    feedbacks, metadataCache, Optional.empty());
 
-            Map<String, Float> contentTagGenreScores = calculateContentTagGenreScores(contentTagIds,
-                    metadataCache);
+            Map<String, Float> contentTagGenreScores = scoreCalculator.calculateContentTagGenreScores(
+                    contentTagIds, metadataCache);
 
             for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
                 Document doc = searcher.storedFields().document(scoreDoc.doc);
                 Long contentId = Long.valueOf(doc.get("contentId"));
 
-                Set<String> docGenres = parseGenreTags(doc.get("genreTag"));
+                Set<String> docGenres = genreAnalyzer.parseGenreTags(doc.get("genreTag"));
 
-                float luceneScore = scoreDoc.score * 3.0f;
-                float feedbackScore = calculateGenreFeedbackBoost(docGenres, feedbackScores);
                 float finalScore;
-
                 if (isCurated) {
-                    float feedbackGenreBoost = calculateGenreBoost(docGenres, primaryGenres);
-                    float surveyGenreBoost = calculateGenreBoost(docGenres, secondaryGenres);
-                    finalScore =
-                            luceneScore + feedbackGenreBoost * 2.0f + surveyGenreBoost
-                                    + feedbackScore;
+                    finalScore = scoreCalculator.calculateCuratedScore(
+                            scoreDoc.score, docGenres, primaryGenres, secondaryGenres,
+                            feedbackScores);
                 } else {
-                    float genreBoost = calculateGenreBoost(docGenres, primaryGenres);
-                    float contentTagBoost = calculateContentTagBoost(docGenres,
+                    finalScore = scoreCalculator.calculateRegularScore(
+                            scoreDoc.score, docGenres, primaryGenres, feedbackScores,
                             contentTagGenreScores);
-                    finalScore = luceneScore + genreBoost * 2.0f + feedbackScore + contentTagBoost;
                 }
 
                 recommendations.add(new ContentRecommendationDTO(contentId, finalScore));
@@ -184,196 +177,6 @@ public class ContentRecommendationService {
             return recommendations;
         }
     }
-
-    private List<String> extractPreferredGenresFromFeedback(Member member,
-            Map<Long, ContentMetadata> metadataCache) {
-
-        Map<String, Float> genreScores = calculateGenreFeedbackScores(member, metadataCache,
-                Optional.of(20));
-
-        List<String> preferredGenres = genreScores.entrySet().stream()
-                .filter(entry -> entry.getValue() > 0.0f)
-                .sorted(Map.Entry.<String, Float>comparingByValue().reversed())
-                .limit(3)
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
-
-        if (preferredGenres.isEmpty()) {
-            List<Feedback> feedbacks = contentRecommendationQuery.findFeedbacksByMemberId(
-                    member.getId());
-            preferredGenres = extractFallbackGenresFromRecentLikes(feedbacks, metadataCache);
-            log.info("선호 장르가 없어 최근 좋아요 기반 장르 사용: {}", preferredGenres);
-        } else {
-            log.info("추출된 선호 장르: {}", preferredGenres);
-        }
-
-        return preferredGenres;
-    }
-
-    private List<Long> getPlatformFilteredContentIds(List<String> platformTags,
-            Map<Long, ContentMetadata> metadataCache) {
-        if (platformTags == null || platformTags.isEmpty()) {
-            return new ArrayList<>(metadataCache.keySet());
-        }
-
-        List<String> koreanPlatformTags = PlatformType.toKoreanTypes(platformTags);
-
-        if (koreanPlatformTags.isEmpty()) {
-            log.warn("플랫폼 태그 변환 실패 - 모든 콘텐츠 반환");
-            return new ArrayList<>(metadataCache.keySet());
-        }
-
-        Set<Long> contentIds = new HashSet<>();
-        for (String koreanPlatformTag : koreanPlatformTags) {
-            if (StringUtils.hasText(koreanPlatformTag)) {
-                for (Map.Entry<Long, ContentMetadata> entry : metadataCache.entrySet()) {
-                    ContentMetadata metadata = entry.getValue();
-                    if (metadata.getPlatformTag() != null &&
-                            metadata.getPlatformTag().contains(koreanPlatformTag)) {
-                        contentIds.add(entry.getKey());
-                    }
-                }
-            }
-        }
-
-        return new ArrayList<>(contentIds);
-    }
-
-    private float calculateGenreBoost(Set<String> docGenres, List<String> memberGenres) {
-        if (memberGenres == null || memberGenres.isEmpty() || docGenres.isEmpty()) {
-            return 0.0f;
-        }
-
-        float boost = 0.0f;
-        for (String memberGenre : memberGenres) {
-            if (StringUtils.hasText(memberGenre)) {
-                String targetGenre = memberGenre.trim();
-                if (docGenres.contains(targetGenre)) {
-                    boost += 1.0f;
-                }
-            }
-        }
-        return boost;
-    }
-
-    private float calculateGenreFeedbackBoost(Set<String> docGenres,
-            Map<String, Float> genreScores) {
-        if (docGenres.isEmpty()) {
-            return 0.0f;
-        }
-
-        float boost = 0.0f;
-        for (String genre : docGenres) {
-            boost += genreScores.getOrDefault(genre, 0.0f);
-        }
-        return boost;
-    }
-
-    private float calculateContentTagBoost(Set<String> docGenres,
-            Map<String, Float> contentTagGenreScores) {
-        if (docGenres.isEmpty() || contentTagGenreScores.isEmpty()) {
-            return 0.0f;
-        }
-
-        float boost = 0.0f;
-        for (String docGenre : docGenres) {
-            boost += contentTagGenreScores.getOrDefault(docGenre, 0.0f);
-        }
-        return boost;
-    }
-
-    private Map<String, Float> calculateContentTagGenreScores(List<Long> contentTagIds,
-            Map<Long, ContentMetadata> metadataCache) {
-        Map<String, Float> genreScores = new HashMap<>();
-
-        if (contentTagIds == null || contentTagIds.isEmpty()) {
-            return genreScores;
-        }
-
-        for (Long contentId : contentTagIds) {
-            ContentMetadata metadata = metadataCache.get(contentId);
-            if (metadata != null && metadata.getGenreTag() != null) {
-                for (String genre : metadata.getGenreTag()) {
-                    if (StringUtils.hasText(genre)) {
-                        genre = genre.trim();
-                        genreScores.put(genre, genreScores.getOrDefault(genre, 0.0f) + 1.0f);
-                    }
-                }
-            }
-        }
-
-        return genreScores;
-    }
-
-    private Set<String> parseGenreTags(String genreTag) {
-        if (genreTag == null || genreTag.trim().isEmpty()) {
-            return Set.of();
-        }
-
-        return Arrays.stream(genreTag.split(","))
-                .map(String::trim)
-                .filter(genre -> !genre.isEmpty())
-                .collect(Collectors.toSet());
-    }
-
-    private Map<String, Float> calculateGenreFeedbackScores(Member member,
-            Map<Long, ContentMetadata> metadataCache, Optional<Integer> recentFeedbackLimit) {
-        Map<String, Float> genreScores = new HashMap<>();
-
-        List<Feedback> feedbacks = contentRecommendationQuery.findFeedbacksByMemberId(
-                member.getId());
-        if (feedbacks == null || feedbacks.isEmpty()) {
-            return genreScores;
-        }
-
-        List<Feedback> targetFeedbacks;
-        targetFeedbacks = recentFeedbackLimit.map(limit -> feedbacks.stream()
-                .sorted((f1, f2) -> f2.getUpdatedAt().compareTo(f1.getUpdatedAt()))
-                .limit(limit)
-                .toList()).orElse(feedbacks);
-
-        for (Feedback feedback : targetFeedbacks) {
-            if (!feedback.isDeleted()) {
-                Long contentId = feedback.getContent().getId();
-                ContentMetadata metadata = metadataCache.get(contentId);
-
-                if (metadata != null && metadata.getGenreTag() != null) {
-                    float score = switch (feedback.getFeedbackType()) {
-                        case LIKE -> 1.0f;
-                        case DISLIKE -> -1.0f;
-                        case UNINTERESTED -> 0.2f;
-                    };
-
-                    for (String genre : metadata.getGenreTag()) {
-                        if (StringUtils.hasText(genre)) {
-                            genre = genre.trim();
-                            float oldScore = genreScores.getOrDefault(genre, 0.0f);
-                            float newScore = oldScore + score;
-                            genreScores.put(genre, newScore);
-                        }
-                    }
-                }
-            }
-        }
-
-        return genreScores;
-    }
-
-
-    private List<String> extractFallbackGenresFromRecentLikes(List<Feedback> feedbacks,
-            Map<Long, ContentMetadata> metadataCache) {
-        return feedbacks.stream()
-                .filter(f -> !f.isDeleted() && f.getFeedbackType() == FeedbackType.LIKE)
-                .sorted((f1, f2) -> f2.getCreatedAt().compareTo(f1.getCreatedAt()))
-                .limit(20)
-                .map(f -> metadataCache.get(f.getContent().getId()))
-                .filter(Objects::nonNull)
-                .flatMap(m -> m.getGenreTag().stream())
-                .distinct()
-                .limit(3)
-                .toList();
-    }
-
 
     private List<ContentRecommendationResponse> getCachedRecommendations(
             MemberRecommendationCache cache) {
@@ -386,7 +189,7 @@ public class ContentRecommendationService {
         debugCachedRecommendations(nextBatch, cache);
 
         Map<Long, ContentMetadata> metadataCache = contentRecommendationQuery.findContentMetadataCache();
-        return buildResponseFromRecommendations(nextBatch, metadataCache);
+        return responseBuilder.buildResponseFromRecommendations(nextBatch, metadataCache);
     }
 
     private List<ContentRecommendationResponse> buildRegularRecommendationResponse(
@@ -407,29 +210,7 @@ public class ContentRecommendationService {
 
         cacheManager.putCache(memberId, remainingRecommendations);
 
-        return buildResponseFromRecommendations(firstBatch, metadataCache);
-    }
-
-    private List<ContentRecommendationResponse> buildResponseFromRecommendations(
-            List<ContentRecommendationDTO> recommendations,
-            Map<Long, ContentMetadata> metadataCache) {
-
-        List<Long> recommendedContentIds = recommendations.stream()
-                .map(ContentRecommendationDTO::contentId)
-                .toList();
-
-        List<Content> contents = contentRecommendationQuery.findContentsByIds(
-                recommendedContentIds);
-        List<ContentMetadata> metadataList = contents.stream()
-                .map(content -> metadataCache.get(content.getId()))
-                .filter(Objects::nonNull)
-                .toList();
-
-        for (Content content : contents) {
-            log.info("추출된 순서 : {}", content.getTitle());
-        }
-
-        return ContentRecommendationMapper.toResponseList(contents, metadataList);
+        return responseBuilder.buildResponseFromRecommendations(firstBatch, metadataCache);
     }
 
     private void debugTopDocs(TopDocs topDocs, IndexSearcher searcher) throws IOException {

--- a/src/main/java/com/example/udtbe/domain/content/service/GenreAnalyzer.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/GenreAnalyzer.java
@@ -1,0 +1,73 @@
+package com.example.udtbe.domain.content.service;
+
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.entity.enums.FeedbackType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GenreAnalyzer {
+
+    private final RecommendationScoreCalculator scoreCalculator;
+
+    public List<String> extractPreferredGenresFromFeedback(
+            List<Feedback> feedbacks,
+            Map<Long, ContentMetadata> metadataCache) {
+
+        Map<String, Float> genreScores = scoreCalculator.calculateGenreFeedbackScores(
+                feedbacks, metadataCache, java.util.Optional.of(20));
+
+        List<String> preferredGenres = genreScores.entrySet().stream()
+                .filter(entry -> entry.getValue() > 0.0f)
+                .sorted(Map.Entry.<String, Float>comparingByValue().reversed())
+                .limit(3)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+
+        if (preferredGenres.isEmpty()) {
+            preferredGenres = extractFallbackGenresFromRecentLikes(feedbacks, metadataCache);
+            log.info("선호 장르가 없어 최근 좋아요 기반 장르 사용: {}", preferredGenres);
+        } else {
+            log.info("추출된 선호 장르: {}", preferredGenres);
+        }
+
+        return preferredGenres;
+    }
+
+    public List<String> extractFallbackGenresFromRecentLikes(
+            List<Feedback> feedbacks,
+            Map<Long, ContentMetadata> metadataCache) {
+
+        return feedbacks.stream()
+                .filter(f -> !f.isDeleted() && f.getFeedbackType() == FeedbackType.LIKE)
+                .sorted((f1, f2) -> f2.getCreatedAt().compareTo(f1.getCreatedAt()))
+                .limit(20)
+                .map(f -> metadataCache.get(f.getContent().getId()))
+                .filter(Objects::nonNull)
+                .flatMap(m -> m.getGenreTag().stream())
+                .distinct()
+                .limit(3)
+                .toList();
+    }
+
+    public Set<String> parseGenreTags(String genreTag) {
+        if (genreTag == null || genreTag.trim().isEmpty()) {
+            return Set.of();
+        }
+
+        return Arrays.stream(genreTag.split(","))
+                .map(String::trim)
+                .filter(genre -> !genre.isEmpty())
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/service/RecommendationQueryBuilder.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/RecommendationQueryBuilder.java
@@ -1,0 +1,48 @@
+package com.example.udtbe.domain.content.service;
+
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.enums.PlatformType;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@Slf4j
+public class RecommendationQueryBuilder {
+
+    public List<Long> getPlatformFilteredContentIds(
+            List<String> platformTags,
+            Map<Long, ContentMetadata> metadataCache) {
+
+        if (platformTags == null || platformTags.isEmpty()) {
+            return new ArrayList<>(metadataCache.keySet());
+        }
+
+        List<String> koreanPlatformTags = PlatformType.toKoreanTypes(platformTags);
+
+        if (koreanPlatformTags.isEmpty()) {
+            log.warn("플랫폼 태그 변환 실패 - 모든 콘텐츠 반환");
+            return new ArrayList<>(metadataCache.keySet());
+        }
+
+        Set<Long> contentIds = new HashSet<>();
+        for (String koreanPlatformTag : koreanPlatformTags) {
+            if (StringUtils.hasText(koreanPlatformTag)) {
+                for (Map.Entry<Long, ContentMetadata> entry : metadataCache.entrySet()) {
+                    ContentMetadata metadata = entry.getValue();
+                    if (metadata.getPlatformTag() != null &&
+                            metadata.getPlatformTag().contains(koreanPlatformTag)) {
+                        contentIds.add(entry.getKey());
+                    }
+                }
+            }
+        }
+
+        return new ArrayList<>(contentIds);
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/service/RecommendationResponseBuilder.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/RecommendationResponseBuilder.java
@@ -1,0 +1,43 @@
+package com.example.udtbe.domain.content.service;
+
+import com.example.udtbe.domain.content.dto.ContentRecommendationMapper;
+import com.example.udtbe.domain.content.dto.common.ContentRecommendationDTO;
+import com.example.udtbe.domain.content.dto.response.ContentRecommendationResponse;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RecommendationResponseBuilder {
+
+    private final ContentRecommendationQuery contentRecommendationQuery;
+
+    public List<ContentRecommendationResponse> buildResponseFromRecommendations(
+            List<ContentRecommendationDTO> recommendations,
+            Map<Long, ContentMetadata> metadataCache) {
+
+        List<Long> recommendedContentIds = recommendations.stream()
+                .map(ContentRecommendationDTO::contentId)
+                .toList();
+
+        List<Content> contents = contentRecommendationQuery.findContentsByIds(
+                recommendedContentIds);
+        List<ContentMetadata> metadataList = contents.stream()
+                .map(content -> metadataCache.get(content.getId()))
+                .filter(Objects::nonNull)
+                .toList();
+
+        for (Content content : contents) {
+            log.info("추출된 순서 : {}", content.getTitle());
+        }
+
+        return ContentRecommendationMapper.toResponseList(contents, metadataList);
+    }
+}

--- a/src/main/java/com/example/udtbe/domain/content/service/RecommendationScoreCalculator.java
+++ b/src/main/java/com/example/udtbe/domain/content/service/RecommendationScoreCalculator.java
@@ -1,0 +1,171 @@
+package com.example.udtbe.domain.content.service;
+
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.Feedback;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@Slf4j
+public class RecommendationScoreCalculator {
+
+    private static final float LUCENE_SCORE_WEIGHT = 3.0f;
+    private static final float GENRE_BOOST_WEIGHT = 2.0f;
+    private static final float FEEDBACK_GENRE_BOOST_WEIGHT = 2.0f;
+
+    private static final float LIKE_SCORE = 1.0f;
+    private static final float DISLIKE_SCORE = -1.0f;
+    private static final float UNINTERESTED_SCORE = 0.2f;
+
+    public float calculateGenreBoost(Set<String> docGenres, List<String> memberGenres) {
+        if (memberGenres == null || memberGenres.isEmpty() || docGenres.isEmpty()) {
+            return 0.0f;
+        }
+
+        float boost = 0.0f;
+        for (String memberGenre : memberGenres) {
+            if (StringUtils.hasText(memberGenre)) {
+                String targetGenre = memberGenre.trim();
+                if (docGenres.contains(targetGenre)) {
+                    boost += 1.0f;
+                }
+            }
+        }
+        return boost;
+    }
+
+    public float calculateGenreFeedbackBoost(Set<String> docGenres,
+            Map<String, Float> genreScores) {
+        if (docGenres.isEmpty()) {
+            return 0.0f;
+        }
+
+        float boost = 0.0f;
+        for (String genre : docGenres) {
+            boost += genreScores.getOrDefault(genre, 0.0f);
+        }
+        return boost;
+    }
+
+    public float calculateContentTagBoost(Set<String> docGenres,
+            Map<String, Float> contentTagGenreScores) {
+        if (docGenres.isEmpty() || contentTagGenreScores.isEmpty()) {
+            return 0.0f;
+        }
+
+        float boost = 0.0f;
+        for (String docGenre : docGenres) {
+            boost += contentTagGenreScores.getOrDefault(docGenre, 0.0f);
+        }
+        return boost;
+    }
+
+    public Map<String, Float> calculateGenreFeedbackScores(
+            List<Feedback> feedbacks,
+            Map<Long, ContentMetadata> metadataCache,
+            Optional<Integer> recentFeedbackLimit) {
+
+        Map<String, Float> genreScores = new HashMap<>();
+
+        if (feedbacks == null || feedbacks.isEmpty()) {
+            return genreScores;
+        }
+
+        List<Feedback> targetFeedbacks;
+        targetFeedbacks = recentFeedbackLimit.map(limit -> feedbacks.stream()
+                .sorted((f1, f2) -> f2.getUpdatedAt().compareTo(f1.getUpdatedAt()))
+                .limit(limit)
+                .toList()).orElse(feedbacks);
+
+        for (Feedback feedback : targetFeedbacks) {
+            if (!feedback.isDeleted()) {
+                Long contentId = feedback.getContent().getId();
+                ContentMetadata metadata = metadataCache.get(contentId);
+
+                if (metadata != null && metadata.getGenreTag() != null) {
+                    float score = switch (feedback.getFeedbackType()) {
+                        case LIKE -> LIKE_SCORE;
+                        case DISLIKE -> DISLIKE_SCORE;
+                        case UNINTERESTED -> UNINTERESTED_SCORE;
+                    };
+
+                    for (String genre : metadata.getGenreTag()) {
+                        if (StringUtils.hasText(genre)) {
+                            genre = genre.trim();
+                            float oldScore = genreScores.getOrDefault(genre, 0.0f);
+                            float newScore = oldScore + score;
+                            genreScores.put(genre, newScore);
+                        }
+                    }
+                }
+            }
+        }
+
+        return genreScores;
+    }
+
+    public Map<String, Float> calculateContentTagGenreScores(
+            List<Long> contentTagIds,
+            Map<Long, ContentMetadata> metadataCache) {
+
+        Map<String, Float> genreScores = new HashMap<>();
+
+        if (contentTagIds == null || contentTagIds.isEmpty()) {
+            return genreScores;
+        }
+
+        for (Long contentId : contentTagIds) {
+            ContentMetadata metadata = metadataCache.get(contentId);
+            if (metadata != null && metadata.getGenreTag() != null) {
+                for (String genre : metadata.getGenreTag()) {
+                    if (StringUtils.hasText(genre)) {
+                        genre = genre.trim();
+                        genreScores.put(genre, genreScores.getOrDefault(genre, 0.0f) + 1.0f);
+                    }
+                }
+            }
+        }
+
+        return genreScores;
+    }
+
+    public float calculateCuratedScore(
+            float luceneScore,
+            Set<String> docGenres,
+            List<String> feedbackGenres,
+            List<String> surveyGenres,
+            Map<String, Float> feedbackScores) {
+
+        float feedbackGenreBoost = calculateGenreBoost(docGenres, feedbackGenres);
+        float surveyGenreBoost = calculateGenreBoost(docGenres, surveyGenres);
+        float feedbackScore = calculateGenreFeedbackBoost(docGenres, feedbackScores);
+
+        return (luceneScore * LUCENE_SCORE_WEIGHT)
+                + (feedbackGenreBoost * FEEDBACK_GENRE_BOOST_WEIGHT)
+                + surveyGenreBoost
+                + feedbackScore;
+    }
+
+    public float calculateRegularScore(
+            float luceneScore,
+            Set<String> docGenres,
+            List<String> memberGenres,
+            Map<String, Float> feedbackScores,
+            Map<String, Float> contentTagGenreScores) {
+
+        float genreBoost = calculateGenreBoost(docGenres, memberGenres);
+        float feedbackScore = calculateGenreFeedbackBoost(docGenres, feedbackScores);
+        float contentTagBoost = calculateContentTagBoost(docGenres, contentTagGenreScores);
+
+        return (luceneScore * LUCENE_SCORE_WEIGHT)
+                + (genreBoost * GENRE_BOOST_WEIGHT)
+                + feedbackScore
+                + contentTagBoost;
+    }
+}

--- a/src/test/java/com/example/udtbe/common/fixture/FeedbackFixture.java
+++ b/src/test/java/com/example/udtbe/common/fixture/FeedbackFixture.java
@@ -6,13 +6,25 @@ import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.Feedback;
 import com.example.udtbe.domain.content.entity.enums.FeedbackType;
 import com.example.udtbe.domain.member.entity.Member;
+import java.time.LocalDateTime;
 import lombok.NoArgsConstructor;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @NoArgsConstructor(access = PRIVATE)
 public class FeedbackFixture {
 
     public static Feedback feedback(Member member, Content content, FeedbackType type) {
-        return Feedback.of(type, false, member, content);
+        Feedback feedback = Feedback.of(type, false, member, content);
+        ReflectionTestUtils.setField(feedback, "updatedAt", LocalDateTime.now());
+        return feedback;
+    }
+
+    public static Feedback feedbackWithTime(Member member, Content content, FeedbackType type,
+            LocalDateTime createdAt, LocalDateTime updatedAt) {
+        Feedback feedback = Feedback.of(type, false, member, content);
+        ReflectionTestUtils.setField(feedback, "createdAt", createdAt);
+        ReflectionTestUtils.setField(feedback, "updatedAt", updatedAt);
+        return feedback;
     }
 
     public static Feedback like(Member member, Content content) {

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -197,7 +197,7 @@ class ContentRecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("플랫폼 필터링 - QueryBuilder가 디즈니+ 콘텐츠만 필터링")
+    @DisplayName("플랫폼 필터링 - QueryBuilder가 디즈니+ ID만 Lucene에 전달")
     void shouldFilterByPlatform() throws Exception {
         // given - 디즈니+만 사용하는 사용자
         Survey disneyPlusSurvey = SurveyFixture.disneyPlusSurvey(testMember);
@@ -218,30 +218,22 @@ class ContentRecommendationServiceTest {
                             .toList();
                 });
 
-        // Lucene 결과: [아바타(디즈니+), 블랙팬서(디즈니+), 기생충(넷플릭스), 조커(넷플릭스)]
-        mockLuceneSearchService(List.of(4L, 8L, 1L, 9L));
+        // Lucene Mock
+        mockLuceneSearchService(List.of(4L, 8L));
 
-        // when - QueryBuilder가 디즈니+ 플랫폼만 필터링
+        // when
         List<ContentRecommendationResponse> result = contentRecommendationService
                 .recommendContents(testMember, 3);
 
-        // then - QueryBuilder의 플랫폼 필터링 동작 검증
-        assertThat(result).hasSizeGreaterThanOrEqualTo(2);
+        // 최종 결과 디즈니+ 콘텐츠만 포함
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(r ->
+                r.platforms().stream().anyMatch(p -> p.contains("디즈니+")));
 
-        // 디즈니+ 콘텐츠가 포함되어 있는지 검증
         List<String> resultTitles = result.stream()
                 .map(ContentRecommendationResponse::title)
                 .toList();
-        assertThat(resultTitles).contains("아바타: 물의 길", "블랙 팬서");
-
-        // 디즈니+ 플랫폼 콘텐츠 검증
-        long disneyPlusCount = result.stream()
-                .filter(r -> r.platforms().stream()
-                        .anyMatch(p -> p.contains("디즈니+")))
-                .count();
-        assertThat(disneyPlusCount).isGreaterThanOrEqualTo(2);
-
-        verify(contentRecommendationQuery).findSurveyByMemberId(testMember.getId());
+        assertThat(resultTitles).containsExactlyInAnyOrder("아바타: 물의 길", "블랙 팬서");
     }
 
     // === Helper 메서드들 ===

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.lucene.analysis.ko.KoreanAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
@@ -45,7 +46,6 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.analysis.ko.KoreanAnalyzer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,7 +57,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class ContentRecommendationServiceTest {
 
-    // === Mock: 외부 의존성만 Mock ===
     @Mock
     private ContentRecommendationQuery contentRecommendationQuery;
 
@@ -70,7 +69,7 @@ class ContentRecommendationServiceTest {
     @Mock
     private RecommendationCacheManager cacheManager;
 
-    // === 실제 객체: 비즈니스 로직 컴포넌트 ===
+    // 실제 객체: 비즈니스 로직 컴포넌트
     private RecommendationScoreCalculator scoreCalculator;
     private GenreAnalyzer genreAnalyzer;
     private RecommendationQueryBuilder queryBuilder;
@@ -149,9 +148,9 @@ class ContentRecommendationServiceTest {
     }
 
     @Test
-    @DisplayName("액션/스릴러 선호 사용자 - 기생충, 올드보이, 블랙팬서 높은 순위")
-    void shouldRecommendActionThrillerContent() throws Exception {
-        // given - 액션/스릴러 선호, 넷플릭스 사용자
+    @DisplayName("선호 장르 부스트 - GenreAnalyzer와 ScoreCalculator 협력으로 액션/스릴러 영화 우선 추천")
+    void shouldBoostScoreForPreferredGenres() throws Exception {
+        // given - 액션/스릴러 선호 사용자
         Survey actionThrillerSurvey = createActionThrillerSurvey();
 
         when(cacheManager.getCache(testMember.getId())).thenReturn(null);
@@ -171,55 +170,100 @@ class ContentRecommendationServiceTest {
                             .toList();
                 });
 
-        // LuceneSearchService Mock 설정
-        mockLuceneSearchService(List.of(1L, 2L, 8L));
+        // Lucene 검색 결과: [기생충(스릴러), 블랙팬서(액션), 라라랜드(뮤지컬)]
+        mockLuceneSearchService(List.of(1L, 8L, 6L));
 
-        // when
+        // when - GenreAnalyzer가 "액션", "스릴러" 추출 → ScoreCalculator가 부스트 적용
         List<ContentRecommendationResponse> result = contentRecommendationService
                 .recommendContents(testMember, 3);
 
-        // then
+        // then - 장르 부스트로 인해 액션/스릴러 영화가 상위 랭크
         assertThat(result).hasSize(3);
 
-        // 첫 번째 추천이 액션/스릴러 장르를 포함하는지 확인
-        assertThat(result.get(0).genres())
-                .anyMatch(genre -> genre.contains("액션") || genre.contains("스릴러"));
+        // 기생충(스릴러)이 최상위에 위치
+        assertThat(result.get(0).title()).isEqualTo("기생충");
+        assertThat(result.get(0).genres()).contains("스릴러");
+
+        // 라라랜드(뮤지컬)는 선호 장르가 아니므로 중간 랭크
+        assertThat(result.get(1).title()).isEqualTo("라라랜드");
+        assertThat(result.get(1).genres()).contains("뮤지컬");
+
+        // 블랙팬서(액션)는 선호 장르이므로 높은 랭크
+        assertThat(result.get(2).title()).isEqualTo("블랙 팬서");
+        assertThat(result.get(2).genres()).contains("액션");
 
         verify(contentRecommendationQuery).findSurveyByMemberId(testMember.getId());
         verify(luceneSearchService).searchRecommendations(anyList(), anyList(), anyInt());
     }
 
     @Test
-    @DisplayName("사용자 추천 캐시 삭제")
-    void shouldClearUserCache_WhenCacheExists() {
-        // given
-        when(cacheManager.hasCache(testMember.getId())).thenReturn(true);
+    @DisplayName("플랫폼 필터링 - QueryBuilder가 디즈니+ 콘텐츠만 필터링")
+    void shouldFilterByPlatform() throws Exception {
+        // given - 디즈니+만 사용하는 사용자
+        Survey disneyPlusSurvey = SurveyFixture.disneyPlusSurvey(testMember);
 
-        // when
-        contentRecommendationService.clearMyRecommendationCache(testMember);
+        when(cacheManager.getCache(testMember.getId())).thenReturn(null);
+        when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
+                .thenReturn(disneyPlusSurvey);
+        when(contentRecommendationQuery.findContentMetadataCache())
+                .thenReturn(testMetadataCache);
+        when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                .thenReturn(new ArrayList<>());
 
-        // then
-        verify(cacheManager).hasCache(testMember.getId());
-        verify(cacheManager).removeMemberCache(testMember.getId());
+        when(contentRecommendationQuery.findContentsByIds(anyList()))
+                .thenAnswer(invocation -> {
+                    List<Long> requestedIds = invocation.getArgument(0);
+                    return testContents.stream()
+                            .filter(c -> requestedIds.contains(c.getId()))
+                            .toList();
+                });
+
+        // Lucene 결과: [아바타(디즈니+), 블랙팬서(디즈니+), 기생충(넷플릭스), 조커(넷플릭스)]
+        mockLuceneSearchService(List.of(4L, 8L, 1L, 9L));
+
+        // when - QueryBuilder가 디즈니+ 플랫폼만 필터링
+        List<ContentRecommendationResponse> result = contentRecommendationService
+                .recommendContents(testMember, 3);
+
+        // then - QueryBuilder의 플랫폼 필터링 동작 검증
+        assertThat(result).hasSizeGreaterThanOrEqualTo(2);
+
+        // 디즈니+ 콘텐츠가 포함되어 있는지 검증
+        List<String> resultTitles = result.stream()
+                .map(ContentRecommendationResponse::title)
+                .toList();
+        assertThat(resultTitles).contains("아바타: 물의 길", "블랙 팬서");
+
+        // 디즈니+ 플랫폼 콘텐츠 검증
+        long disneyPlusCount = result.stream()
+                .filter(r -> r.platforms().stream()
+                        .anyMatch(p -> p.contains("디즈니+")))
+                .count();
+        assertThat(disneyPlusCount).isGreaterThanOrEqualTo(2);
+
+        verify(contentRecommendationQuery).findSurveyByMemberId(testMember.getId());
     }
 
     // === Helper 메서드들 ===
 
     private void mockLuceneSearchService(List<Long> contentIds) throws Exception {
+        // TopDocs Mock: Lucene 검색 결과
         ScoreDoc[] scoreDocs = new ScoreDoc[contentIds.size()];
         for (int i = 0; i < contentIds.size(); i++) {
             scoreDocs[i] = new ScoreDoc(i, 1.0f + (contentIds.size() - i) * 0.1f);
         }
-        TotalHits totalHits = new TotalHits(scoreDocs.length, TotalHits.Relation.EQUAL_TO);
-        TopDocs topDocs = new TopDocs(totalHits, scoreDocs);
+        TopDocs topDocs = new TopDocs(
+                new TotalHits(scoreDocs.length, TotalHits.Relation.EQUAL_TO),
+                scoreDocs
+        );
 
         when(luceneSearchService.searchRecommendations(anyList(), anyList(), anyInt()))
                 .thenReturn(topDocs);
 
-        // Lucene IndexReader Mock 설정
-        KoreanAnalyzer analyzer = new KoreanAnalyzer();
+        // IndexReader Mock: 간소화된 Lucene Document 생성
         Directory directory = new ByteBuffersDirectory();
-        IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer));
+        IndexWriter writer = new IndexWriter(directory,
+                new IndexWriterConfig(new KoreanAnalyzer()));
 
         for (Long contentId : contentIds) {
             ContentMetadata metadata = testMetadataCache.get(contentId);

--- a/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
+++ b/src/test/java/com/example/udtbe/content/service/ContentRecommendationServiceTest.java
@@ -3,8 +3,6 @@ package com.example.udtbe.content.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -20,19 +18,21 @@ import com.example.udtbe.domain.content.entity.Content;
 import com.example.udtbe.domain.content.entity.ContentMetadata;
 import com.example.udtbe.domain.content.service.ContentRecommendationQuery;
 import com.example.udtbe.domain.content.service.ContentRecommendationService;
+import com.example.udtbe.domain.content.service.GenreAnalyzer;
 import com.example.udtbe.domain.content.service.LuceneIndexService;
 import com.example.udtbe.domain.content.service.LuceneSearchService;
+import com.example.udtbe.domain.content.service.RecommendationQueryBuilder;
+import com.example.udtbe.domain.content.service.RecommendationResponseBuilder;
+import com.example.udtbe.domain.content.service.RecommendationScoreCalculator;
 import com.example.udtbe.domain.content.util.MemberRecommendationCache;
 import com.example.udtbe.domain.content.util.RecommendationCacheManager;
 import com.example.udtbe.domain.member.entity.Member;
 import com.example.udtbe.domain.member.entity.enums.Role;
 import com.example.udtbe.domain.survey.entity.Survey;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.lucene.analysis.ko.KoreanAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
@@ -40,17 +40,16 @@ import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.analysis.ko.KoreanAnalyzer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -58,6 +57,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class ContentRecommendationServiceTest {
 
+    // === Mock: 외부 의존성만 Mock ===
     @Mock
     private ContentRecommendationQuery contentRecommendationQuery;
 
@@ -70,11 +70,15 @@ class ContentRecommendationServiceTest {
     @Mock
     private RecommendationCacheManager cacheManager;
 
-    @InjectMocks
+    // === 실제 객체: 비즈니스 로직 컴포넌트 ===
+    private RecommendationScoreCalculator scoreCalculator;
+    private GenreAnalyzer genreAnalyzer;
+    private RecommendationQueryBuilder queryBuilder;
+    private RecommendationResponseBuilder responseBuilder;
+
     private ContentRecommendationService contentRecommendationService;
 
     private Member testMember;
-    private Survey testSurvey;
     private List<ContentMetadata> testMetadataList;
     private Map<Long, ContentMetadata> testMetadataCache;
     private List<Content> testContents;
@@ -86,15 +90,29 @@ class ContentRecommendationServiceTest {
         testContents = createRealTestContents();
         testMetadataList = createRealTestMetadata();
         testMetadataCache = createTestMetadataCache();
-        //테스트 멤버 기준으로 생성
-        testSurvey = createTestSurvey();
 
-        lenient().when(cacheManager.getCache(anyLong())).thenReturn(null);
+        // 비즈니스 로직 컴포넌트를 실제 객체로 초기화
+        scoreCalculator = new RecommendationScoreCalculator();
+        genreAnalyzer = new GenreAnalyzer(scoreCalculator);
+        queryBuilder = new RecommendationQueryBuilder();
+        responseBuilder = new RecommendationResponseBuilder(contentRecommendationQuery);
+
+        // ContentRecommendationService 수동 생성 (Mock + 실제 객체 조합)
+        contentRecommendationService = new ContentRecommendationService(
+                contentRecommendationQuery,
+                luceneIndexService,
+                luceneSearchService,
+                cacheManager,
+                scoreCalculator,
+                genreAnalyzer,
+                queryBuilder,
+                responseBuilder
+        );
     }
 
     @Test
     @DisplayName("캐시 히트 - 기존 캐시에서 다음 배치 반환")
-    void shouldReturnCachedRecommendations_WhenCacheHit() throws IOException, ParseException {
+    void shouldReturnCachedRecommendations_WhenCacheHit() {
         // given - 유효한 캐시 존재
         List<ContentRecommendationDTO> cachedRecommendations = List.of(
                 new ContentRecommendationDTO(1L, 5.0f),
@@ -109,7 +127,15 @@ class ContentRecommendationServiceTest {
         when(contentRecommendationQuery.findContentMetadataCache())
                 .thenReturn(testMetadataCache);
 
-        mockContentQueryWithOrder(List.of(1L, 2L, 3L));
+        // ResponseBuilder가 실제 객체이므로 findContentsByIds Mock 설정
+        List<Long> ids = cachedRecommendations.stream()
+                .map(ContentRecommendationDTO::contentId)
+                .toList();
+        List<Content> expectedContents = testContents.stream()
+                .filter(c -> ids.contains(c.getId()))
+                .toList();
+        when(contentRecommendationQuery.findContentsByIds(ids))
+                .thenReturn(expectedContents);
 
         // when
         List<ContentRecommendationResponse> result = contentRecommendationService
@@ -128,15 +154,25 @@ class ContentRecommendationServiceTest {
         // given - 액션/스릴러 선호, 넷플릭스 사용자
         Survey actionThrillerSurvey = createActionThrillerSurvey();
 
+        when(cacheManager.getCache(testMember.getId())).thenReturn(null);
         when(contentRecommendationQuery.findSurveyByMemberId(testMember.getId()))
                 .thenReturn(actionThrillerSurvey);
         when(contentRecommendationQuery.findContentMetadataCache())
                 .thenReturn(testMetadataCache);
+        when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
+                .thenReturn(new ArrayList<>());
+
+        // ResponseBuilder가 실제 객체이므로 findContentsByIds Mock 설정
+        when(contentRecommendationQuery.findContentsByIds(anyList()))
+                .thenAnswer(invocation -> {
+                    List<Long> requestedIds = invocation.getArgument(0);
+                    return testContents.stream()
+                            .filter(c -> requestedIds.contains(c.getId()))
+                            .toList();
+                });
 
         // LuceneSearchService Mock 설정
         mockLuceneSearchService(List.of(1L, 2L, 8L));
-        mockFeedbackData();
-        mockContentQueryWithOrder(List.of(1L, 2L, 8L));
 
         // when
         List<ContentRecommendationResponse> result = contentRecommendationService
@@ -153,12 +189,26 @@ class ContentRecommendationServiceTest {
         verify(luceneSearchService).searchRecommendations(anyList(), anyList(), anyInt());
     }
 
+    @Test
+    @DisplayName("사용자 추천 캐시 삭제")
+    void shouldClearUserCache_WhenCacheExists() {
+        // given
+        when(cacheManager.hasCache(testMember.getId())).thenReturn(true);
+
+        // when
+        contentRecommendationService.clearMyRecommendationCache(testMember);
+
+        // then
+        verify(cacheManager).hasCache(testMember.getId());
+        verify(cacheManager).removeMemberCache(testMember.getId());
+    }
+
     // === Helper 메서드들 ===
 
     private void mockLuceneSearchService(List<Long> contentIds) throws Exception {
         ScoreDoc[] scoreDocs = new ScoreDoc[contentIds.size()];
         for (int i = 0; i < contentIds.size(); i++) {
-            scoreDocs[i] = new ScoreDoc(i, 1.0f + (contentIds.size() - i) * 0.1f); // 점수 내림차순
+            scoreDocs[i] = new ScoreDoc(i, 1.0f + (contentIds.size() - i) * 0.1f);
         }
         TotalHits totalHits = new TotalHits(scoreDocs.length, TotalHits.Relation.EQUAL_TO);
         TopDocs topDocs = new TopDocs(totalHits, scoreDocs);
@@ -166,13 +216,12 @@ class ContentRecommendationServiceTest {
         when(luceneSearchService.searchRecommendations(anyList(), anyList(), anyInt()))
                 .thenReturn(topDocs);
 
+        // Lucene IndexReader Mock 설정
         KoreanAnalyzer analyzer = new KoreanAnalyzer();
         Directory directory = new ByteBuffersDirectory();
-
         IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig(analyzer));
 
-        for (int i = 0; i < contentIds.size(); i++) {
-            Long contentId = contentIds.get(i);
+        for (Long contentId : contentIds) {
             ContentMetadata metadata = testMetadataCache.get(contentId);
             if (metadata != null) {
                 Document doc = new Document();
@@ -186,78 +235,15 @@ class ContentRecommendationServiceTest {
             }
         }
 
-        if (contentIds.isEmpty()) {
-            Document emptyDoc = new Document();
-            emptyDoc.add(new StringField("contentId", "0", Field.Store.YES));
-            emptyDoc.add(new TextField("title", "empty", Field.Store.YES));
-            emptyDoc.add(new TextField("genreTag", "", Field.Store.YES));
-            emptyDoc.add(new TextField("platformTag", "", Field.Store.YES));
-            writer.addDocument(emptyDoc);
-        }
-
         writer.close();
-
         DirectoryReader reader = DirectoryReader.open(directory);
         when(luceneIndexService.getIndexReader()).thenReturn(reader);
-    }
-
-    private void mockLuceneSearchServiceForCurated(List<Long> contentIds) throws Exception {
-        ScoreDoc[] scoreDocs = new ScoreDoc[contentIds.size()];
-        for (int i = 0; i < contentIds.size(); i++) {
-            scoreDocs[i] = new ScoreDoc(i, 1.0f + (contentIds.size() - i) * 0.1f); // 점수 내림차순
-        }
-        TotalHits totalHits = new TotalHits(scoreDocs.length, TotalHits.Relation.EQUAL_TO);
-        TopDocs topDocs = new TopDocs(totalHits, scoreDocs);
-
-        when(luceneSearchService.searchCuratedRecommendations(anyList(), anyList(), anyInt()))
-                .thenReturn(topDocs);
-
-        // 독립적인 Directory와 Reader 생성
-        KoreanAnalyzer analyzer = new KoreanAnalyzer();
-        Directory curatedDirectory = new ByteBuffersDirectory();
-
-        IndexWriter curatedWriter = new IndexWriter(curatedDirectory,
-                new IndexWriterConfig(analyzer));
-
-        for (int i = 0; i < contentIds.size(); i++) {
-            Long contentId = contentIds.get(i);
-            ContentMetadata metadata = testMetadataCache.get(contentId);
-            if (metadata != null) {
-                Document doc = new Document();
-                doc.add(new StringField("contentId", contentId.toString(), Field.Store.YES));
-                doc.add(new TextField("title", metadata.getTitle(), Field.Store.YES));
-                doc.add(new TextField("genreTag", String.join(",", metadata.getGenreTag()),
-                        Field.Store.YES));
-                doc.add(new TextField("platformTag", String.join(",", metadata.getPlatformTag()),
-                        Field.Store.YES));
-                curatedWriter.addDocument(doc);
-            }
-        }
-
-        if (contentIds.isEmpty()) {
-            Document emptyDoc = new Document();
-            emptyDoc.add(new StringField("contentId", "0", Field.Store.YES));
-            emptyDoc.add(new TextField("title", "empty", Field.Store.YES));
-            emptyDoc.add(new TextField("genreTag", "", Field.Store.YES));
-            emptyDoc.add(new TextField("platformTag", "", Field.Store.YES));
-            curatedWriter.addDocument(emptyDoc);
-        }
-
-        curatedWriter.close();
-
-        DirectoryReader curatedReader = DirectoryReader.open(curatedDirectory);
-        // 엄선된 추천을 위한 별도의 reader 설정
-        when(luceneIndexService.getIndexReader()).thenReturn(curatedReader);
     }
 
     private Member createTestMember() {
         Member member = MemberFixture.member("test@example.com", Role.ROLE_USER);
         ReflectionTestUtils.setField(member, "id", 1L);
         return member;
-    }
-
-    private Survey createTestSurvey() {
-        return SurveyFixture.actionThrillerSurvey(testMember);
     }
 
     private Survey createActionThrillerSurvey() {
@@ -281,35 +267,4 @@ class ContentRecommendationServiceTest {
                 ));
     }
 
-    private void mockContentQueryWithOrder(List<Long> contentIds) {
-        List<Content> orderedContents = contentIds.stream()
-                .map(id -> testContents.stream()
-                        .filter(content -> content.getId().equals(id))
-                        .findFirst()
-                        .orElseThrow())
-                .collect(Collectors.toList());
-
-        when(contentRecommendationQuery.findContentsByIds(anyList()))
-                .thenReturn(orderedContents);
-    }
-
-    private void mockFeedbackData() {
-        // 기본 피드백 데이터 (필요에 따라 각 테스트에서 오버라이드)
-        when(contentRecommendationQuery.findFeedbacksByMemberId(testMember.getId()))
-                .thenReturn(new ArrayList<>());
-    }
-
-    @Test
-    @DisplayName("사용자 추천 캐시 삭제")
-    void shouldClearUserCache_WhenCacheExists() {
-        // given
-        when(cacheManager.hasCache(testMember.getId())).thenReturn(true);
-
-        // when
-        contentRecommendationService.clearMyRecommendationCache(testMember);
-
-        // then
-        verify(cacheManager).hasCache(testMember.getId());
-        verify(cacheManager).removeMemberCache(testMember.getId());
-    }
 }

--- a/src/test/java/com/example/udtbe/content/service/GenreAnalyzerTest.java
+++ b/src/test/java/com/example/udtbe/content/service/GenreAnalyzerTest.java
@@ -1,0 +1,320 @@
+package com.example.udtbe.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentMetadataFixture;
+import com.example.udtbe.common.fixture.FeedbackFixture;
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.entity.enums.FeedbackType;
+import com.example.udtbe.domain.content.service.GenreAnalyzer;
+import com.example.udtbe.domain.content.service.RecommendationScoreCalculator;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GenreAnalyzerTest {
+
+    @Mock
+    private RecommendationScoreCalculator scoreCalculator;
+
+    @InjectMocks
+    private GenreAnalyzer genreAnalyzer;
+
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = MemberFixture.member("test@example.com", Role.ROLE_USER);
+    }
+
+    @Test
+    @DisplayName("선호 장르 추출 - 긍정적 피드백이 많은 장르 순으로 반환")
+    void extractPreferredGenresFromFeedback_WithPositiveFeedback() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+        Content content3 = createContentWithId(3L, "영화3");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션,스릴러");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스", "액션,코미디");
+        ContentMetadata metadata3 = ContentMetadataFixture.metadata(content3, "넷플릭스", "드라마");
+
+        // 액션: 2회 LIKE, 스릴러: 1회 LIKE, 코미디: 1회 LIKE, 드라마: 1회 LIKE
+        Feedback feedback1 = FeedbackFixture.feedback(testMember, content1, FeedbackType.LIKE);
+        Feedback feedback2 = FeedbackFixture.feedback(testMember, content2, FeedbackType.LIKE);
+        Feedback feedback3 = FeedbackFixture.feedback(testMember, content3, FeedbackType.LIKE);
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2,
+                3L, metadata3
+        );
+
+        // Mock: 액션이 가장 높은 점수로 반환되도록 설정
+        when(scoreCalculator.calculateGenreFeedbackScores(any(), eq(metadataCache),
+                eq(Optional.of(20))))
+                .thenReturn(Map.of(
+                        "액션", 2.0f,
+                        "스릴러", 1.0f,
+                        "코미디", 1.0f
+                ));
+
+        // when
+        List<String> result = genreAnalyzer.extractPreferredGenresFromFeedback(
+                List.of(feedback1, feedback2, feedback3), metadataCache);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).isEqualTo("액션"); // 2회로 가장 많음
+    }
+
+    @Test
+    @DisplayName("선호 장르 추출 - 부정적 피드백은 제외")
+    void extractPreferredGenresFromFeedback_ExcludesNegativeFeedback() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스", "공포");
+
+        Feedback like = FeedbackFixture.feedback(testMember, content1, FeedbackType.LIKE);
+        Feedback dislike = FeedbackFixture.feedback(testMember, content2, FeedbackType.DISLIKE);
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2
+        );
+
+        when(scoreCalculator.calculateGenreFeedbackScores(any(), eq(metadataCache),
+                eq(Optional.of(20))))
+                .thenReturn(Map.of("액션", 1.0f));
+
+        // when
+        List<String> result = genreAnalyzer.extractPreferredGenresFromFeedback(
+                List.of(like, dislike), metadataCache);
+
+        // then
+        assertThat(result).contains("액션");
+        assertThat(result).doesNotContain("공포");
+    }
+
+    @Test
+    @DisplayName("선호 장르 추출 - 선호 장르가 없으면 fallback 사용 (LIKE 없음)")
+    void extractPreferredGenresFromFeedback_UsesFallbackWhenNoPreferredGenres_NoLikes() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+
+        // 모든 피드백이 DISLIKE여서 선호 장르 점수가 음수
+        Feedback dislike = FeedbackFixture.feedback(testMember, content1, FeedbackType.DISLIKE);
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, metadata1);
+
+        // Mock: 모든 장르 점수가 음수 또는 빈 맵 반환 (선호 장르 없음)
+        when(scoreCalculator.calculateGenreFeedbackScores(any(), eq(metadataCache),
+                eq(Optional.of(20))))
+                .thenReturn(Map.of("액션", -1.0f));
+
+        // when
+        List<String> result = genreAnalyzer.extractPreferredGenresFromFeedback(
+                List.of(dislike), metadataCache);
+
+        // then
+        // fallback은 최근 LIKE 기반이지만, LIKE가 없으므로 빈 리스트
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("선호 장르 추출 - 점수가 0 이하면 fallback으로 최근 LIKE 장르 사용")
+    void extractPreferredGenresFromFeedback_UsesFallbackWhenScoresAreNegative() {
+        // given
+        Content likedContent = createContentWithId(1L, "좋아한 영화");
+        Content dislikedContent = createContentWithId(2L, "싫어한 영화");
+
+        ContentMetadata likedMetadata = ContentMetadataFixture.metadata(likedContent, "넷플릭스",
+                "코미디,로맨스");
+        ContentMetadata dislikedMetadata = ContentMetadataFixture.metadata(dislikedContent,
+                "넷플릭스", "공포");
+
+        // LIKE 1개, DISLIKE 3개 → 점수 계산 결과 모두 음수
+        LocalDateTime now = LocalDateTime.now();
+        Feedback like = FeedbackFixture.feedbackWithTime(testMember, likedContent,
+                FeedbackType.LIKE, now.minusDays(1), now.minusDays(1));
+        Feedback dislike1 = FeedbackFixture.feedback(testMember, dislikedContent,
+                FeedbackType.DISLIKE);
+        Feedback dislike2 = FeedbackFixture.feedback(testMember, dislikedContent,
+                FeedbackType.DISLIKE);
+        Feedback dislike3 = FeedbackFixture.feedback(testMember, dislikedContent,
+                FeedbackType.DISLIKE);
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, likedMetadata,
+                2L, dislikedMetadata
+        );
+
+        // Mock: 모든 장르 점수가 음수 (DISLIKE가 너무 많아서)
+        when(scoreCalculator.calculateGenreFeedbackScores(any(), eq(metadataCache),
+                eq(Optional.of(20))))
+                .thenReturn(Map.of(
+                        "코미디", -1.0f,
+                        "로맨스", -0.5f,
+                        "공포", -3.0f
+                ));
+
+        // when
+        List<String> result = genreAnalyzer.extractPreferredGenresFromFeedback(
+                List.of(like, dislike1, dislike2, dislike3), metadataCache);
+
+        // then
+        // fallback 동작: 최근 LIKE 기반 장르 추출
+        assertThat(result).isNotEmpty();
+        assertThat(result).containsAnyOf("코미디", "로맨스"); // LIKE한 영화의 장르
+        assertThat(result).doesNotContain("공포"); // DISLIKE한 영화의 장르는 제외
+    }
+
+    @Test
+    @DisplayName("Fallback 장르 추출 - 최근 LIKE 피드백 기반")
+    void extractFallbackGenresFromRecentLikes() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+        Content content3 = createContentWithId(3L, "영화3");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션,스릴러");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스", "코미디");
+        ContentMetadata metadata3 = ContentMetadataFixture.metadata(content3, "넷플릭스", "드라마");
+
+        LocalDateTime now = LocalDateTime.now();
+        Feedback like1 = FeedbackFixture.feedbackWithTime(testMember, content1, FeedbackType.LIKE,
+                now.minusDays(1), now.minusDays(1));
+        Feedback like2 = FeedbackFixture.feedbackWithTime(testMember, content2, FeedbackType.LIKE,
+                now.minusDays(2), now.minusDays(2));
+        Feedback like3 = FeedbackFixture.feedbackWithTime(testMember, content3, FeedbackType.LIKE,
+                now.minusDays(3), now.minusDays(3));
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2,
+                3L, metadata3
+        );
+
+        // when
+        List<String> result = genreAnalyzer.extractFallbackGenresFromRecentLikes(
+                List.of(like1, like2, like3), metadataCache);
+
+        // then
+        assertThat(result).hasSize(3); // 최대 3개
+        assertThat(result).contains("액션", "스릴러", "코미디");
+    }
+
+    @Test
+    @DisplayName("Fallback 장르 추출 - DISLIKE는 제외")
+    void extractFallbackGenresFromRecentLikes_ExcludesDislike() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스", "공포");
+
+        Feedback like = FeedbackFixture.feedback(testMember, content1, FeedbackType.LIKE);
+        Feedback dislike = FeedbackFixture.feedback(testMember, content2, FeedbackType.DISLIKE);
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2
+        );
+
+        // when
+        List<String> result = genreAnalyzer.extractFallbackGenresFromRecentLikes(
+                List.of(like, dislike), metadataCache);
+
+        // then
+        assertThat(result).contains("액션");
+        assertThat(result).doesNotContain("공포");
+    }
+
+    @Test
+    @DisplayName("장르 태그 파싱 - 쉼표로 구분된 문자열을 Set으로 변환")
+    void parseGenreTags_WithCommaSeparatedString() {
+        // given
+        String genreTag = "액션, 스릴러, 드라마";
+
+        // when
+        Set<String> result = genreAnalyzer.parseGenreTags(genreTag);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder("액션", "스릴러", "드라마");
+    }
+
+    @Test
+    @DisplayName("장르 태그 파싱 - 빈 문자열이면 빈 Set 반환")
+    void parseGenreTags_WithEmptyString() {
+        // when
+        Set<String> result1 = genreAnalyzer.parseGenreTags("");
+        Set<String> result2 = genreAnalyzer.parseGenreTags("   ");
+        Set<String> result3 = genreAnalyzer.parseGenreTags(null);
+
+        // then
+        assertThat(result1).isEmpty();
+        assertThat(result2).isEmpty();
+        assertThat(result3).isEmpty();
+    }
+
+    @Test
+    @DisplayName("장르 태그 파싱 - 공백이 섞여있어도 정상 파싱")
+    void parseGenreTags_WithWhitespace() {
+        // given
+        String genreTag = " 액션 ,  스릴러  , 드라마 ";
+
+        // when
+        Set<String> result = genreAnalyzer.parseGenreTags(genreTag);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder("액션", "스릴러", "드라마");
+    }
+
+    @Test
+    @DisplayName("장르 태그 파싱 - 중복 제거")
+    void parseGenreTags_RemovesDuplicates() {
+        // given
+        String genreTag = "액션,액션,스릴러";
+
+        // when
+        Set<String> result = genreAnalyzer.parseGenreTags(genreTag);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder("액션", "스릴러");
+        assertThat(result).hasSize(2);
+    }
+
+    // === Helper 메서드들 ===
+
+    private Content createContentWithId(Long id, String title) {
+        Content content = ContentFixture.content(title, "설명");
+        ReflectionTestUtils.setField(content, "id", id);
+        return content;
+    }
+}

--- a/src/test/java/com/example/udtbe/content/service/RecommendationQueryBuilderTest.java
+++ b/src/test/java/com/example/udtbe/content/service/RecommendationQueryBuilderTest.java
@@ -1,0 +1,174 @@
+package com.example.udtbe.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentMetadataFixture;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.service.RecommendationQueryBuilder;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecommendationQueryBuilderTest {
+
+    private final RecommendationQueryBuilder queryBuilder = new RecommendationQueryBuilder();
+
+    @Test
+    @DisplayName("플랫폼 필터링 - 넷플릭스 플랫폼만 필터링")
+    void getPlatformFilteredContentIds_WithNetflixOnly() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+        Content content3 = createContentWithId(3L, "영화3");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "왓챠", "코미디");
+        ContentMetadata metadata3 = ContentMetadataFixture.metadata(content3, "넷플릭스,왓챠", "드라마");
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2,
+                3L, metadata3
+        );
+
+        // when - NETFLIX는 영어이므로 toKoreanTypes로 변환됨
+        List<Long> result = queryBuilder.getPlatformFilteredContentIds(
+                List.of("NETFLIX"), metadataCache);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder(1L, 3L); // 넷플릭스 포함된 콘텐츠만
+    }
+
+    @Test
+    @DisplayName("플랫폼 필터링 - 여러 플랫폼 OR 조건")
+    void getPlatformFilteredContentIds_WithMultiplePlatforms() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+        Content content3 = createContentWithId(3L, "영화3");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "왓챠", "코미디");
+        ContentMetadata metadata3 = ContentMetadataFixture.metadata(content3, "티빙", "드라마");
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2,
+                3L, metadata3
+        );
+
+        // when
+        List<Long> result = queryBuilder.getPlatformFilteredContentIds(
+                List.of("NETFLIX", "WATCHA"), metadataCache);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder(1L, 2L); // 넷플릭스 or 왓챠
+    }
+
+    @Test
+    @DisplayName("플랫폼 필터링 - 빈 플랫폼 리스트면 모든 콘텐츠 반환")
+    void getPlatformFilteredContentIds_WithEmptyPlatforms() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "왓챠", "코미디");
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2
+        );
+
+        // when
+        List<Long> result1 = queryBuilder.getPlatformFilteredContentIds(
+                List.of(), metadataCache);
+        List<Long> result2 = queryBuilder.getPlatformFilteredContentIds(
+                null, metadataCache);
+
+        // then
+        assertThat(result1).containsExactlyInAnyOrder(1L, 2L);
+        assertThat(result2).containsExactlyInAnyOrder(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("플랫폼 필터링 - 일치하는 플랫폼이 없으면 빈 리스트")
+    void getPlatformFilteredContentIds_WithNoMatchingPlatform() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+        Content content2 = createContentWithId(2L, "영화2");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "왓챠", "코미디");
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2
+        );
+
+        // when
+        List<Long> result = queryBuilder.getPlatformFilteredContentIds(
+                List.of("TVING"), metadataCache);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("플랫폼 필터링 - 콘텐츠가 여러 플랫폼을 가진 경우")
+    void getPlatformFilteredContentIds_WithMultiplePlatformsPerContent() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+
+        // 넷플릭스, 왓챠, 티빙 모두 포함
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스,왓챠,티빙",
+                "액션");
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, metadata1);
+
+        // when
+        List<Long> netflixResult = queryBuilder.getPlatformFilteredContentIds(
+                List.of("NETFLIX"), metadataCache);
+        List<Long> watchaResult = queryBuilder.getPlatformFilteredContentIds(
+                List.of("WATCHA"), metadataCache);
+        List<Long> tvingResult = queryBuilder.getPlatformFilteredContentIds(
+                List.of("TVING"), metadataCache);
+
+        // then
+        assertThat(netflixResult).containsExactly(1L);
+        assertThat(watchaResult).containsExactly(1L);
+        assertThat(tvingResult).containsExactly(1L);
+    }
+
+    @Test
+    @DisplayName("플랫폼 필터링 - 중복 제거")
+    void getPlatformFilteredContentIds_RemovesDuplicates() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스,왓챠",
+                "액션");
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, metadata1);
+
+        // when - 넷플릭스와 왓챠 둘 다 요청하지만 content1은 둘 다 포함
+        List<Long> result = queryBuilder.getPlatformFilteredContentIds(
+                List.of("NETFLIX", "WATCHA"), metadataCache);
+
+        // then - 중복 없이 1L만 한 번
+        assertThat(result).hasSize(1);
+        assertThat(result).containsExactly(1L);
+    }
+
+    // === Helper 메서드들 ===
+
+    private Content createContentWithId(Long id, String title) {
+        Content content = ContentFixture.content(title, "설명");
+        ReflectionTestUtils.setField(content, "id", id);
+        return content;
+    }
+}

--- a/src/test/java/com/example/udtbe/content/service/RecommendationResponseBuilderTest.java
+++ b/src/test/java/com/example/udtbe/content/service/RecommendationResponseBuilderTest.java
@@ -1,0 +1,200 @@
+package com.example.udtbe.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentMetadataFixture;
+import com.example.udtbe.domain.content.dto.common.ContentRecommendationDTO;
+import com.example.udtbe.domain.content.dto.response.ContentRecommendationResponse;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.service.ContentRecommendationQuery;
+import com.example.udtbe.domain.content.service.RecommendationResponseBuilder;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendationResponseBuilderTest {
+
+    @Mock
+    private ContentRecommendationQuery contentRecommendationQuery;
+
+    @InjectMocks
+    private RecommendationResponseBuilder responseBuilder;
+
+    @Test
+    @DisplayName("추천 응답 빌드 - 정상적인 경우")
+    void buildResponseFromRecommendations_Success() {
+        // given
+        Content content1 = createContentWithId(1L, "기생충");
+        Content content2 = createContentWithId(2L, "올드보이");
+        Content content3 = createContentWithId(3L, "인터스텔라");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스",
+                "스릴러,드라마");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스",
+                "스릴러,액션");
+        ContentMetadata metadata3 = ContentMetadataFixture.metadata(content3, "넷플릭스", "SF");
+
+        List<ContentRecommendationDTO> recommendations = List.of(
+                new ContentRecommendationDTO(1L, 5.0f),
+                new ContentRecommendationDTO(2L, 4.5f),
+                new ContentRecommendationDTO(3L, 4.0f)
+        );
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2,
+                3L, metadata3
+        );
+
+        when(contentRecommendationQuery.findContentsByIds(anyList()))
+                .thenReturn(List.of(content1, content2, content3));
+
+        // when
+        List<ContentRecommendationResponse> result = responseBuilder.buildResponseFromRecommendations(
+                recommendations, metadataCache);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).title()).isEqualTo("기생충");
+        assertThat(result.get(1).title()).isEqualTo("올드보이");
+        assertThat(result.get(2).title()).isEqualTo("인터스텔라");
+    }
+
+    @Test
+    @DisplayName("추천 응답 빌드 - 빈 추천 리스트")
+    void buildResponseFromRecommendations_WithEmptyRecommendations() {
+        // given
+        List<ContentRecommendationDTO> emptyRecommendations = List.of();
+        Map<Long, ContentMetadata> metadataCache = Map.of();
+
+        when(contentRecommendationQuery.findContentsByIds(anyList()))
+                .thenReturn(List.of());
+
+        // when
+        List<ContentRecommendationResponse> result = responseBuilder.buildResponseFromRecommendations(
+                emptyRecommendations, metadataCache);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("추천 응답 빌드 - 메타데이터가 없는 콘텐츠는 기본 응답 반환")
+    void buildResponseFromRecommendations_ReturnsDefaultResponseForContentWithoutMetadata() {
+        // given
+        Content content1 = createContentWithId(1L, "기생충");
+        Content content2 = createContentWithId(2L, "올드보이"); // 이 콘텐츠는 메타데이터 없음
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "스릴러");
+
+        List<ContentRecommendationDTO> recommendations = List.of(
+                new ContentRecommendationDTO(1L, 5.0f),
+                new ContentRecommendationDTO(2L, 4.5f)  // content2는 메타데이터 없음
+        );
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1
+                // 2L은 없음 - 메타데이터가 없는 경우
+        );
+
+        when(contentRecommendationQuery.findContentsByIds(anyList()))
+                .thenReturn(List.of(content1, content2));
+
+        // when
+        List<ContentRecommendationResponse> result = responseBuilder.buildResponseFromRecommendations(
+                recommendations, metadataCache);
+
+        // then
+        assertThat(result).hasSize(2); // content2는 기본 응답으로 반환됨
+        assertThat(result.get(0).title()).isEqualTo("기생충");
+        assertThat(result.get(0).genres()).isNotEmpty(); // metadata 있음
+
+        assertThat(result.get(1).title()).isEqualTo("올드보이");
+        assertThat(result.get(1).genres()).isEmpty(); // metadata 없으면 빈 리스트
+    }
+
+    @Test
+    @DisplayName("추천 응답 빌드 - 추천 순서대로 Content를 조회")
+    void buildResponseFromRecommendations_PreservesOrder() {
+        // given
+        Content content1 = createContentWithId(1L, "첫번째");
+        Content content2 = createContentWithId(2L, "두번째");
+        Content content3 = createContentWithId(3L, "세번째");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스", "코미디");
+        ContentMetadata metadata3 = ContentMetadataFixture.metadata(content3, "넷플릭스", "드라마");
+
+        // 점수 순서: 3L > 1L > 2L
+        List<ContentRecommendationDTO> recommendations = List.of(
+                new ContentRecommendationDTO(3L, 10.0f),
+                new ContentRecommendationDTO(1L, 8.0f),
+                new ContentRecommendationDTO(2L, 6.0f)
+        );
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, metadata1,
+                2L, metadata2,
+                3L, metadata3
+        );
+
+        // findContentsByIds는 요청된 순서대로 반환한다고 가정
+        when(contentRecommendationQuery.findContentsByIds(List.of(3L, 1L, 2L)))
+                .thenReturn(List.of(content3, content1, content2));
+
+        // when
+        List<ContentRecommendationResponse> result = responseBuilder.buildResponseFromRecommendations(
+                recommendations, metadataCache);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).title()).isEqualTo("세번째");
+        assertThat(result.get(1).title()).isEqualTo("첫번째");
+        assertThat(result.get(2).title()).isEqualTo("두번째");
+    }
+
+    @Test
+    @DisplayName("추천 응답 빌드 - Content ID 추출 확인")
+    void buildResponseFromRecommendations_ExtractsContentIds() {
+        // given
+        Content content1 = createContentWithId(1L, "영화1");
+
+        ContentMetadata metadata1 = ContentMetadataFixture.metadata(content1, "넷플릭스", "액션");
+
+        List<ContentRecommendationDTO> recommendations = List.of(
+                new ContentRecommendationDTO(1L, 5.0f)
+        );
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, metadata1);
+
+        when(contentRecommendationQuery.findContentsByIds(List.of(1L)))
+                .thenReturn(List.of(content1));
+
+        // when
+        List<ContentRecommendationResponse> result = responseBuilder.buildResponseFromRecommendations(
+                recommendations, metadataCache);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).contentId()).isEqualTo(1L);
+    }
+
+    // === Helper 메서드들 ===
+
+    private Content createContentWithId(Long id, String title) {
+        Content content = ContentFixture.content(title, "설명");
+        ReflectionTestUtils.setField(content, "id", id);
+        return content;
+    }
+}

--- a/src/test/java/com/example/udtbe/content/service/RecommendationScoreCalculatorTest.java
+++ b/src/test/java/com/example/udtbe/content/service/RecommendationScoreCalculatorTest.java
@@ -1,0 +1,331 @@
+package com.example.udtbe.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.udtbe.common.fixture.ContentFixture;
+import com.example.udtbe.common.fixture.ContentMetadataFixture;
+import com.example.udtbe.common.fixture.FeedbackFixture;
+import com.example.udtbe.common.fixture.MemberFixture;
+import com.example.udtbe.domain.content.entity.Content;
+import com.example.udtbe.domain.content.entity.ContentMetadata;
+import com.example.udtbe.domain.content.entity.Feedback;
+import com.example.udtbe.domain.content.entity.enums.FeedbackType;
+import com.example.udtbe.domain.content.service.RecommendationScoreCalculator;
+import com.example.udtbe.domain.member.entity.Member;
+import com.example.udtbe.domain.member.entity.enums.Role;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecommendationScoreCalculatorTest {
+
+    private RecommendationScoreCalculator calculator;
+    private Member testMember;
+    private Content testContent;
+    private ContentMetadata testMetadata;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new RecommendationScoreCalculator();
+        testMember = MemberFixture.member("test@example.com", Role.ROLE_USER);
+        testContent = ContentFixture.content("테스트 영화", "테스트 설명");
+        testMetadata = ContentMetadataFixture.metadata(testContent, "넷플릭스", "액션,스릴러");
+        ReflectionTestUtils.setField(testContent, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("장르 부스트 계산 - 일치하는 장르가 있으면 부스트 점수 증가")
+    void calculateGenreBoost_WithMatchingGenres() {
+        // given
+        Set<String> docGenres = Set.of("액션", "스릴러", "드라마");
+        List<String> memberGenres = List.of("액션", "코미디", "스릴러");
+
+        // when
+        float result = calculator.calculateGenreBoost(docGenres, memberGenres);
+
+        // then
+        assertThat(result).isEqualTo(2.0f); // 액션(1.0) + 스릴러(1.0)
+    }
+
+    @Test
+    @DisplayName("장르 부스트 계산 - 일치하는 장르가 없으면 0")
+    void calculateGenreBoost_WithNoMatchingGenres() {
+        // given
+        Set<String> docGenres = Set.of("액션", "스릴러");
+        List<String> memberGenres = List.of("코미디", "로맨스");
+
+        // when
+        float result = calculator.calculateGenreBoost(docGenres, memberGenres);
+
+        // then
+        assertThat(result).isEqualTo(0.0f);
+    }
+
+    @Test
+    @DisplayName("장르 부스트 계산 - 빈 입력값이면 0")
+    void calculateGenreBoost_WithEmptyInputs() {
+        // given
+        Set<String> emptyDocGenres = Set.of();
+        List<String> emptyMemberGenres = List.of();
+
+        // when
+        float result1 = calculator.calculateGenreBoost(emptyDocGenres, List.of("액션"));
+        float result2 = calculator.calculateGenreBoost(Set.of("액션"), emptyMemberGenres);
+        float result3 = calculator.calculateGenreBoost(Set.of("액션"), null);
+
+        // then
+        assertThat(result1).isEqualTo(0.0f);
+        assertThat(result2).isEqualTo(0.0f);
+        assertThat(result3).isEqualTo(0.0f);
+    }
+
+    @Test
+    @DisplayName("피드백 장르 부스트 계산 - 장르별 점수 합산")
+    void calculateGenreFeedbackBoost_WithGenreScores() {
+        // given
+        Set<String> docGenres = Set.of("액션", "스릴러");
+        Map<String, Float> genreScores = Map.of(
+                "액션", 2.5f,
+                "스릴러", 1.5f,
+                "코미디", 3.0f
+        );
+
+        // when
+        float result = calculator.calculateGenreFeedbackBoost(docGenres, genreScores);
+
+        // then
+        assertThat(result).isEqualTo(4.0f); // 액션(2.5) + 스릴러(1.5)
+    }
+
+    @Test
+    @DisplayName("피드백 장르 부스트 계산 - 빈 docGenres이면 0")
+    void calculateGenreFeedbackBoost_WithEmptyDocGenres() {
+        // given
+        Set<String> emptyDocGenres = Set.of();
+        Map<String, Float> genreScores = Map.of("액션", 2.5f);
+
+        // when
+        float result = calculator.calculateGenreFeedbackBoost(emptyDocGenres, genreScores);
+
+        // then
+        assertThat(result).isEqualTo(0.0f);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 태그 부스트 계산 - 장르별 점수 합산")
+    void calculateContentTagBoost_WithGenreScores() {
+        // given
+        Set<String> docGenres = Set.of("액션", "스릴러");
+        Map<String, Float> contentTagGenreScores = Map.of(
+                "액션", 3.0f,
+                "스릴러", 2.0f
+        );
+
+        // when
+        float result = calculator.calculateContentTagBoost(docGenres, contentTagGenreScores);
+
+        // then
+        assertThat(result).isEqualTo(5.0f);
+    }
+
+    @Test
+    @DisplayName("콘텐츠 태그 부스트 계산 - 빈 입력값이면 0")
+    void calculateContentTagBoost_WithEmptyInputs() {
+        // given
+        Set<String> emptyDocGenres = Set.of();
+        Map<String, Float> emptyScores = Map.of();
+
+        // when
+        float result1 = calculator.calculateContentTagBoost(emptyDocGenres, Map.of("액션", 1.0f));
+        float result2 = calculator.calculateContentTagBoost(Set.of("액션"), emptyScores);
+
+        // then
+        assertThat(result1).isEqualTo(0.0f);
+        assertThat(result2).isEqualTo(0.0f);
+    }
+
+    @Test
+    @DisplayName("피드백 기반 장르 점수 계산 - LIKE 피드백")
+    void calculateGenreFeedbackScores_WithLikeFeedback() {
+        // given
+        Feedback likeFeedback = FeedbackFixture.feedback(testMember, testContent,
+                FeedbackType.LIKE);
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, testMetadata);
+
+        // when
+        Map<String, Float> result = calculator.calculateGenreFeedbackScores(
+                List.of(likeFeedback), metadataCache, Optional.empty());
+
+        // then
+        assertThat(result).containsEntry("액션", 1.0f);
+        assertThat(result).containsEntry("스릴러", 1.0f);
+    }
+
+    @Test
+    @DisplayName("피드백 기반 장르 점수 계산 - DISLIKE 피드백")
+    void calculateGenreFeedbackScores_WithDislikeFeedback() {
+        // given
+        Feedback dislikeFeedback = FeedbackFixture.feedback(testMember, testContent,
+                FeedbackType.DISLIKE);
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, testMetadata);
+
+        // when
+        Map<String, Float> result = calculator.calculateGenreFeedbackScores(
+                List.of(dislikeFeedback), metadataCache, Optional.empty());
+
+        // then
+        assertThat(result).containsEntry("액션", -1.0f);
+        assertThat(result).containsEntry("스릴러", -1.0f);
+    }
+
+    @Test
+    @DisplayName("피드백 기반 장르 점수 계산 - UNINTERESTED 피드백")
+    void calculateGenreFeedbackScores_WithUninterestedFeedback() {
+        // given
+        Feedback uninterestedFeedback = FeedbackFixture.feedback(testMember, testContent,
+                FeedbackType.UNINTERESTED);
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, testMetadata);
+
+        // when
+        Map<String, Float> result = calculator.calculateGenreFeedbackScores(
+                List.of(uninterestedFeedback), metadataCache, Optional.empty());
+
+        // then
+        assertThat(result).containsEntry("액션", 0.2f);
+        assertThat(result).containsEntry("스릴러", 0.2f);
+    }
+
+    @Test
+    @DisplayName("피드백 기반 장르 점수 계산 - 여러 피드백 누적")
+    void calculateGenreFeedbackScores_WithMultipleFeedbacks() {
+        // given
+        Content content2 = ContentFixture.content("영화2", "설명2");
+        ReflectionTestUtils.setField(content2, "id", 2L);
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스", "액션,코미디");
+
+        Feedback feedback1 = FeedbackFixture.feedback(testMember, testContent, FeedbackType.LIKE);
+        Feedback feedback2 = FeedbackFixture.feedback(testMember, content2, FeedbackType.LIKE);
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, testMetadata,
+                2L, metadata2
+        );
+
+        // when
+        Map<String, Float> result = calculator.calculateGenreFeedbackScores(
+                List.of(feedback1, feedback2), metadataCache, Optional.empty());
+
+        // then
+        assertThat(result).containsEntry("액션", 2.0f); // 두 번 LIKE
+        assertThat(result).containsEntry("스릴러", 1.0f); // 한 번 LIKE
+        assertThat(result).containsEntry("코미디", 1.0f); // 한 번 LIKE
+    }
+
+    @Test
+    @DisplayName("피드백 기반 장르 점수 계산 - 빈 피드백 리스트면 빈 맵 반환")
+    void calculateGenreFeedbackScores_WithEmptyFeedbacks() {
+        // given
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, testMetadata);
+
+        // when
+        Map<String, Float> result1 = calculator.calculateGenreFeedbackScores(
+                List.of(), metadataCache, Optional.empty());
+        Map<String, Float> result2 = calculator.calculateGenreFeedbackScores(
+                null, metadataCache, Optional.empty());
+
+        // then
+        assertThat(result1).isEmpty();
+        assertThat(result2).isEmpty();
+    }
+
+    @Test
+    @DisplayName("콘텐츠 태그 장르 점수 계산")
+    void calculateContentTagGenreScores_WithContentTags() {
+        // given
+        Content content2 = ContentFixture.content("영화2", "설명2");
+        ReflectionTestUtils.setField(content2, "id", 2L);
+        ContentMetadata metadata2 = ContentMetadataFixture.metadata(content2, "넷플릭스", "액션,코미디");
+
+        Map<Long, ContentMetadata> metadataCache = Map.of(
+                1L, testMetadata,
+                2L, metadata2
+        );
+
+        // when
+        Map<String, Float> result = calculator.calculateContentTagGenreScores(
+                List.of(1L, 2L), metadataCache);
+
+        // then
+        assertThat(result).containsEntry("액션", 2.0f); // 두 콘텐츠에 있음
+        assertThat(result).containsEntry("스릴러", 1.0f); // 한 콘텐츠에 있음
+        assertThat(result).containsEntry("코미디", 1.0f); // 한 콘텐츠에 있음
+    }
+
+    @Test
+    @DisplayName("콘텐츠 태그 장르 점수 계산 - 빈 입력값이면 빈 맵 반환")
+    void calculateContentTagGenreScores_WithEmptyInputs() {
+        // given
+        Map<Long, ContentMetadata> metadataCache = Map.of(1L, testMetadata);
+
+        // when
+        Map<String, Float> result1 = calculator.calculateContentTagGenreScores(
+                List.of(), metadataCache);
+        Map<String, Float> result2 = calculator.calculateContentTagGenreScores(
+                null, metadataCache);
+
+        // then
+        assertThat(result1).isEmpty();
+        assertThat(result2).isEmpty();
+    }
+
+    @Test
+    @DisplayName("큐레이션 점수 계산 - 모든 요소 포함")
+    void calculateCuratedScore_WithAllFactors() {
+        // given
+        float luceneScore = 2.0f;
+        Set<String> docGenres = Set.of("액션", "스릴러");
+        List<String> feedbackGenres = List.of("액션", "드라마");
+        List<String> surveyGenres = List.of("스릴러", "코미디");
+        Map<String, Float> feedbackScores = Map.of("액션", 1.5f, "스릴러", 2.0f);
+
+        // when
+        float result = calculator.calculateCuratedScore(luceneScore, docGenres, feedbackGenres,
+                surveyGenres, feedbackScores);
+
+        // then
+        // luceneScore * 3.0 = 6.0
+        // feedbackGenreBoost(1.0) * 2.0 = 2.0  (액션 매칭)
+        // surveyGenreBoost = 1.0  (스릴러 매칭)
+        // feedbackScore = 3.5  (액션 1.5 + 스릴러 2.0)
+        // 총합 = 6.0 + 2.0 + 1.0 + 3.5 = 12.5
+        assertThat(result).isEqualTo(12.5f);
+    }
+
+    @Test
+    @DisplayName("일반 점수 계산 - 모든 요소 포함")
+    void calculateRegularScore_WithAllFactors() {
+        // given
+        float luceneScore = 2.0f;
+        Set<String> docGenres = Set.of("액션", "스릴러");
+        List<String> memberGenres = List.of("액션", "코미디");
+        Map<String, Float> feedbackScores = Map.of("액션", 1.5f, "스릴러", 2.0f);
+        Map<String, Float> contentTagGenreScores = Map.of("액션", 3.0f);
+
+        // when
+        float result = calculator.calculateRegularScore(luceneScore, docGenres, memberGenres,
+                feedbackScores, contentTagGenreScores);
+
+        // then
+        // luceneScore * 3.0 = 6.0
+        // genreBoost(1.0) * 2.0 = 2.0  (액션 매칭)
+        // feedbackScore = 3.5  (액션 1.5 + 스릴러 2.0)
+        // contentTagBoost = 3.0  (액션)
+        // 총합 = 6.0 + 2.0 + 3.5 + 3.0 = 14.5
+        assertThat(result).isEqualTo(14.5f);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

### 무엇을 수정했나요?
콘텐츠 추천 서비스의 막대한 역할을 4개의 비즈니스 컴포넌트로 분리하여 콘텐츠 추천 서비스 클래스의 코드를 줄여나갔습니다.
그로 인한 여러 클래스들이 생성 및 테스트 코드 구현을 했습니다.

### 왜?
- **기존 문제점**: `ContentRecommendationService`가 269줄의 복잡한 로직을 포함하며, 장르 분석, 점수 계산, 쿼리 빌드, 응답 생성 등 여러 책임을 가지고 있었습니다.
- **개선 효과**:
  - 각 컴포넌트가 단일 책임만 가지도록 분리하여 **유지보수성 향상**
  - 테스트 용이성 증가 (Mock 의존성 감소)
  - 코드 가독성 및 재사용성 개선

### 주요 변경 사항
1. **4개의 새로운 컴포넌트 생성**:
   - `RecommendationScoreCalculator`: 추천 점수 계산 로직 (171줄)
   - `GenreAnalyzer`: 장르 분석 및 파싱 로직 (73줄)
   - `RecommendationQueryBuilder`: 플랫폼 필터링 쿼리 생성 (48줄)
   - `RecommendationResponseBuilder`: 추천 응답 빌드 (43줄)

2. **기존 서비스 클래스 간소화**:
   - `ContentRecommendationService`: 269줄 → 약 100줄로 감소
   - 핵심 비즈니스 플로우에만 집중

3. **테스트 커버리지 강화**:
   - 각 컴포넌트별 단위 테스트 추가 (총 1,045줄의 테스트 코드)
   - 기존 통합 테스트도 새로운 구조에 맞게 리팩토링

## 💬 공유사항 to 리뷰어

### 고민: ContentRecommendationService 테스트 코드의 목적 -> 각 분리 클래스들의 상호작용을 테스트하자.
결론: Slice Test 전략 채택
- Mock: 외부 의존성만 (DB, Cache, Lucene)
- Real: 비즈니스 로직 컴포넌트 (GenreAnalyzer, ScoreCalculator, QueryBuilder, ResponseBuilder)
- 이유: 실제 협력 동작을 검증하면서도 빠른 테스트 유지

#### 기존 방식
```java
@Mock
private RecommendationScoreCalculator scoreCalculator;

@InjectMocks  
private ContentRecommendationService service;
```
- 모든 의존성을 Mock으로 처리
- 간결하지만 실제 비즈니스 로직 검증 부족

#### 적절한 접근 방식
```java
// Mock: 외부 의존성만
@Mock
private ContentRecommendationQuery contentRecommendationQuery;

// 실제 객체: 비즈니스 로직 컴포넌트
private RecommendationScoreCalculator scoreCalculator;
private GenreAnalyzer genreAnalyzer;

@BeforeEach
void setUp() {
    // new 연산자로 실제 객체 생성
    scoreCalculator = new RecommendationScoreCalculator();
    genreAnalyzer = new GenreAnalyzer(scoreCalculator);
    
    // 수동으로 의존성 주입
    service = new ContentRecommendationService(
        contentRecommendationQuery,
        luceneIndexService,
        luceneSearchService,
        cacheManager,
        scoreCalculator,  // 실제 객체
        genreAnalyzer,    // 실제 객체
        queryBuilder,     // 실제 객체
        responseBuilder   // 실제 객체
    );
}
```

#### 왜 이렇게 변경했나요?
1. **실제 비즈니스 로직 검증**: Mock이 아닌 실제 객체를 사용하여 점수 계산, 장르 분석 등의 로직이 올바르게 동작하는지 확인
2. **테스트 가독성 향상**: 각 테스트가 무엇을 검증하는지 명확하게 드러남
3. **리팩토링 안정성**: 내부 구현 변경 시 테스트가 실제 동작을 검증하므로 더 안전

### 테스트 코드 변경 사항
- shouldRecommendActionThrillerContent → shouldBoostScoreForPreferredGenres
  - Before: "장르 포함" 여부만 검증
  - After: 실제 순위 검증 (기생충 1위, 라라랜드 2위, 블랙팬서 3위)
  - 협력: GenreAnalyzer가 장르 추출 → ScoreCalculator가 부스트 적용 → 순위 변경

- shouldFilterByPlatform: 플랫폼 필터링 협력 검증
  - 협력: QueryBuilder가 디즈니+ 필터링 → 디즈니+ 콘텐츠 2개 이상 포함

- mockLuceneSearchService()
  - 목적 명시: "실제 Lucene 인프라 테스트가 아닌 추천 로직만 테스트"


### 리뷰 요청 사항
1. **컴포넌트 분리 기준**이 적절한지 검토 부탁드립니다.
   - 각 클래스가 단일 책임을 잘 가지고 있는지
   - 더 분리하거나 합쳐야 할 부분이 있는지!!!

2. **테스트 작성 방식**에 대한 의견 부탁드립니다.
   - DAMP 원칙 적용이 우리 프로젝트에 적합한지
   - `new` 연산자로 직접 생성하는 방식에 대한 의견

### 참고사항
- 기존 기능에 영향 없이 **내부 구조만 변경**했습니다.
- 모든 기존 테스트가 통과하며, 추가로 1,000줄 이상의 단위 테스트를 작성했습니다.
- 추후 각 컴포넌트를 독립적으로 확장/수정할 수 있습니다.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 기존 테스트가 모두 통과합니다.
- [x] 새로운 단위 테스트를 추가했습니다. (4개 클래스, 1,045줄)

## 🤔 Review 예상 시간
- **20분** 😭 